### PR TITLE
Failure handling: retry ladder and Escalation (issue #7)

### DIFF
--- a/src/act.test.ts
+++ b/src/act.test.ts
@@ -35,6 +35,7 @@ function recordingOpenPr(): { openPr: OpenPr; opened: number[] } {
 function outcome(ticket: number, overrides: Partial<WorkerOutcome> = {}): WorkerOutcome {
   return {
     ticket,
+    attempt: 1,
     branch: `border-collie/ticket-${ticket}`,
     base: "base-sha",
     transcript: `.border-collie/transcripts/ticket-${ticket}.jsonl`,
@@ -144,7 +145,7 @@ describe("act", () => {
   it("releases a failed attempt with its forensic record after Workers settle", async () => {
     const { exec, calls } = recordingExec();
     const dispatch: DispatchWorker = async () =>
-      outcome(7, { exitCode: null, failure: "stall", ok: false });
+      outcome(7, { attempt: 2, exitCode: null, failure: "stall", ok: false });
 
     await act([{ type: "spawn", ticket: 7, attempt: 2 }], dispatch, recordingOpenPr().openPr, exec, () => {});
 

--- a/src/act.test.ts
+++ b/src/act.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { act, type DispatchWorker, type OpenPr } from "./act.js";
 import type { Exec } from "./tracker.js";
-import { CLAIM_MARKER, RELEASE_MARKER } from "./types.js";
+import {
+  attemptMarker,
+  CLAIM_MARKER,
+  RELEASE_MARKER,
+  type AttemptFailure,
+} from "./types.js";
 import type { WorkerOutcome } from "./worker.js";
 
 function recordingExec(): { exec: Exec; calls: string[][] } {
@@ -33,8 +38,10 @@ function outcome(ticket: number, overrides: Partial<WorkerOutcome> = {}): Worker
     branch: `border-collie/ticket-${ticket}`,
     base: "base-sha",
     transcript: `.border-collie/transcripts/ticket-${ticket}.jsonl`,
+    model: "sonnet",
     exitCode: 0,
     newCommits: 2,
+    failure: undefined,
     ok: true,
     ...overrides,
   };
@@ -91,15 +98,15 @@ describe("act", () => {
       await gate;
       return ticket === 2
         ? outcome(2, { newCommits: 3 })
-        : outcome(4, { exitCode: 1, newCommits: 0, ok: false });
+        : outcome(4, { exitCode: 1, newCommits: 0, failure: "nonzero-exit", ok: false });
     };
 
     await act(
       [
         { type: "claim", ticket: 2 },
-        { type: "spawn", ticket: 2 },
+        { type: "spawn", ticket: 2, attempt: 1 },
         { type: "claim", ticket: 4 },
-        { type: "spawn", ticket: 4 },
+        { type: "spawn", ticket: 4, attempt: 1 },
       ],
       dispatch,
       openPr,
@@ -111,13 +118,93 @@ describe("act", () => {
     expect(opened).toEqual([2]); // only the success becomes a PR
     expect(lines).toEqual([
       "claimed #2",
-      "spawned Worker for #2",
+      "spawned Worker for #2 (attempt 1)",
       "claimed #4",
-      "spawned Worker for #4",
+      "spawned Worker for #4 (attempt 1)",
       "Worker for #2 succeeded: 3 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
       "opened draft PR for #2: https://github.com/o/r/pull/20",
-      "Worker for #4 failed attempt: exit 1, 0 new commits on border-collie/ticket-4 (transcript: .border-collie/transcripts/ticket-4.jsonl)",
+      "Worker for #4 failed attempt 1 (nonzero-exit): exit 1, 0 new commits on border-collie/ticket-4 (transcript: .border-collie/transcripts/ticket-4.jsonl)",
+      "released #4 with the attempt record (failed attempt 1)",
     ]);
+  });
+
+  it("dispatches with the planned attempt number (the retry ladder rung)", async () => {
+    const { exec } = recordingExec();
+    const attempts: [number, number][] = [];
+    const dispatch: DispatchWorker = async (ticket, attempt) => {
+      attempts.push([ticket, attempt]);
+      return outcome(ticket);
+    };
+
+    await act([{ type: "spawn", ticket: 7, attempt: 2 }], dispatch, recordingOpenPr().openPr, exec, () => {});
+
+    expect(attempts).toEqual([[7, 2]]);
+  });
+
+  it("releases a failed attempt with its forensic record after Workers settle", async () => {
+    const { exec, calls } = recordingExec();
+    const dispatch: DispatchWorker = async () =>
+      outcome(7, { exitCode: null, failure: "stall", ok: false });
+
+    await act([{ type: "spawn", ticket: 7, attempt: 2 }], dispatch, recordingOpenPr().openPr, exec, () => {});
+
+    const record: AttemptFailure = {
+      attempt: 2,
+      reason: "stall",
+      model: "sonnet",
+      branch: "border-collie/ticket-7",
+      transcript: ".border-collie/transcripts/ticket-7.jsonl",
+    };
+    expect(calls).toEqual([
+      ["gh", "issue", "edit", "7", "--remove-assignee", "@me"],
+      ["gh", "issue", "comment", "7", "--body", expect.stringContaining(attemptMarker(record))],
+    ]);
+  });
+
+  it("performs no tracker writes for a successful attempt", async () => {
+    const { exec, calls } = recordingExec();
+    const dispatch: DispatchWorker = async () => outcome(7);
+
+    await act([{ type: "spawn", ticket: 7, attempt: 1 }], dispatch, recordingOpenPr().openPr, exec, () => {});
+
+    expect(calls).toEqual([]);
+  });
+
+  it("escalates: forensic comment, then the ready-for-agent → ready-for-human label swap", async () => {
+    const { exec, calls } = recordingExec();
+    const lines: string[] = [];
+    const failures: AttemptFailure[] = [
+      {
+        attempt: 1,
+        reason: "timeout",
+        model: "sonnet",
+        branch: "border-collie/ticket-5",
+        transcript: ".border-collie/transcripts/ticket-5.jsonl",
+      },
+    ];
+
+    await act(
+      [{ type: "escalate", ticket: 5, failures }],
+      noDispatch,
+      recordingOpenPr().openPr,
+      exec,
+      (line) => lines.push(line),
+    );
+
+    expect(calls).toEqual([
+      ["gh", "issue", "comment", "5", "--body", expect.stringContaining("Escalated")],
+      [
+        "gh",
+        "issue",
+        "edit",
+        "5",
+        "--remove-label",
+        "ready-for-agent",
+        "--add-label",
+        "ready-for-human",
+      ],
+    ]);
+    expect(lines).toEqual(["escalated #5 to ready-for-human (attempts exhausted)"]);
   });
 
   it("still reports finished Workers when a sibling dispatch throws, then rethrows", async () => {
@@ -132,8 +219,8 @@ describe("act", () => {
     await expect(
       act(
         [
-          { type: "spawn", ticket: 2 },
-          { type: "spawn", ticket: 4 },
+          { type: "spawn", ticket: 2, attempt: 1 },
+          { type: "spawn", ticket: 4, attempt: 1 },
         ],
         dispatch,
         openPr,
@@ -156,7 +243,7 @@ describe("act", () => {
     };
 
     await expect(
-      act([{ type: "spawn", ticket: 2 }], dispatch, openPr, exec, (line) => lines.push(line)),
+      act([{ type: "spawn", ticket: 2, attempt: 1 }], dispatch, openPr, exec, (line) => lines.push(line)),
     ).rejects.toThrow("gh pr create exploded");
 
     expect(lines).toContain(

--- a/src/act.ts
+++ b/src/act.ts
@@ -18,21 +18,20 @@ export type DispatchWorker = (ticket: number, attempt: number) => Promise<Worker
 /** Open the draft PR for a successful Attempt; resolves with the PR URL. */
 export type OpenPr = (outcome: WorkerOutcome) => Promise<string>;
 
-/** What one spawn action came to: the Attempt, its rung, and its PR when one was opened. */
+/** What one spawn action came to: the Attempt, and its PR when one was opened. */
 interface SpawnResult {
   outcome: WorkerOutcome;
-  attempt: number;
   prUrl?: string;
   /** PR opening failed after a successful Attempt; reported, then rethrown. */
   prFailure?: unknown;
 }
 
-function describeOutcome({ outcome, attempt }: SpawnResult): string {
+function describeOutcome(outcome: WorkerOutcome): string {
   const commits = `${outcome.newCommits} new commit${outcome.newCommits === 1 ? "" : "s"}`;
   const where = `on ${outcome.branch} (transcript: ${outcome.transcript})`;
   return outcome.ok
     ? `Worker for #${outcome.ticket} succeeded: ${commits} ${where}`
-    : `Worker for #${outcome.ticket} failed attempt ${attempt} (${outcome.failure}): exit ${outcome.exitCode}, ${commits} ${where}`;
+    : `Worker for #${outcome.ticket} failed attempt ${outcome.attempt} (${outcome.failure}): exit ${outcome.exitCode}, ${commits} ${where}`;
 }
 
 /**
@@ -71,35 +70,33 @@ export async function act(
         await escalateTicket(action.ticket, action.failures, exec);
         log(`escalated #${action.ticket} to ready-for-human (attempts exhausted)`);
         break;
-      case "spawn": {
-        const attempt = action.attempt;
+      case "spawn":
         workers.push(
-          dispatch(action.ticket, attempt).then(async (outcome): Promise<SpawnResult> => {
-            if (!outcome.ok) return { outcome, attempt };
+          dispatch(action.ticket, action.attempt).then(async (outcome): Promise<SpawnResult> => {
+            if (!outcome.ok) return { outcome };
             try {
-              return { outcome, attempt, prUrl: await openPr(outcome) };
+              return { outcome, prUrl: await openPr(outcome) };
             } catch (error) {
-              return { outcome, attempt, prFailure: error };
+              return { outcome, prFailure: error };
             }
           }),
         );
-        log(`spawned Worker for #${action.ticket} (attempt ${attempt})`);
+        log(`spawned Worker for #${action.ticket} (attempt ${action.attempt})`);
         break;
-      }
     }
   }
 
   const settled = await Promise.allSettled(workers);
   for (const result of settled) {
     if (result.status !== "fulfilled") continue;
-    const { outcome, attempt, prUrl } = result.value;
-    log(describeOutcome(result.value));
+    const { outcome, prUrl } = result.value;
+    log(describeOutcome(outcome));
     if (prUrl !== undefined) log(`opened draft PR for #${outcome.ticket}: ${prUrl}`);
     if (outcome.failure) {
       await releaseFailedTicket(
         outcome.ticket,
         {
-          attempt,
+          attempt: outcome.attempt,
           reason: outcome.failure,
           model: outcome.model,
           branch: outcome.branch,
@@ -107,7 +104,9 @@ export async function act(
         },
         exec,
       );
-      log(`released #${outcome.ticket} with the attempt record (failed attempt ${attempt})`);
+      log(
+        `released #${outcome.ticket} with the attempt record (failed attempt ${outcome.attempt})`,
+      );
     }
   }
   const rejected = settled.find((result) => result.status === "rejected");

--- a/src/act.ts
+++ b/src/act.ts
@@ -1,27 +1,38 @@
-import { claimTicket, realExec, releaseTicket, type Exec } from "./tracker.js";
+import {
+  claimTicket,
+  escalateTicket,
+  realExec,
+  releaseFailedTicket,
+  releaseTicket,
+  type Exec,
+} from "./tracker.js";
 import type { Action } from "./types.js";
 import type { WorkerOutcome } from "./worker.js";
 
-/** Dispatch one Worker against one claimed ticket; the model is bound by the caller. */
-export type DispatchWorker = (ticket: number) => Promise<WorkerOutcome>;
+/**
+ * Dispatch one Worker against one claimed ticket; the caller binds the
+ * attempt number to a model (the retry ladder).
+ */
+export type DispatchWorker = (ticket: number, attempt: number) => Promise<WorkerOutcome>;
 
 /** Open the draft PR for a successful Attempt; resolves with the PR URL. */
 export type OpenPr = (outcome: WorkerOutcome) => Promise<string>;
 
-/** What one spawn action came to: the Attempt, and its PR when one was opened. */
+/** What one spawn action came to: the Attempt, its rung, and its PR when one was opened. */
 interface SpawnResult {
   outcome: WorkerOutcome;
+  attempt: number;
   prUrl?: string;
   /** PR opening failed after a successful Attempt; reported, then rethrown. */
   prFailure?: unknown;
 }
 
-function describeOutcome(outcome: WorkerOutcome): string {
+function describeOutcome({ outcome, attempt }: SpawnResult): string {
   const commits = `${outcome.newCommits} new commit${outcome.newCommits === 1 ? "" : "s"}`;
   const where = `on ${outcome.branch} (transcript: ${outcome.transcript})`;
   return outcome.ok
     ? `Worker for #${outcome.ticket} succeeded: ${commits} ${where}`
-    : `Worker for #${outcome.ticket} failed attempt: exit ${outcome.exitCode}, ${commits} ${where}`;
+    : `Worker for #${outcome.ticket} failed attempt ${attempt} (${outcome.failure}): exit ${outcome.exitCode}, ${commits} ${where}`;
 }
 
 /**
@@ -29,12 +40,14 @@ function describeOutcome(outcome: WorkerOutcome): string {
  * at a time, narrating each as it lands. Spawns are the exception: each
  * Worker starts as its action is reached but runs concurrently, its branch
  * becoming a draft PR the moment it succeeds, and the Tick waits for all of
- * them before reporting outcomes. A tracker failure mid-way throws — the
- * stateless recovery story is re-running the Tick, which recomputes the
- * world and re-plans whatever is still due. An infrastructure failure on the
- * Worker or PR side likewise throws (classification and the circuit breaker
- * land with later tickets), but only after every finished Worker's outcome
- * is reported.
+ * them before reporting outcomes. A failed attempt is then released with its
+ * forensic record — the write that makes attempt history live on the
+ * tracker, where the next Tick's retry ladder and a later Escalation read it
+ * back. A tracker failure mid-way throws — the stateless recovery story is
+ * re-running the Tick, which recomputes the world and re-plans whatever is
+ * still due. An infrastructure failure on the Worker or PR side likewise
+ * throws (classification and the circuit breaker land with later tickets),
+ * but only after every finished Worker's outcome is reported.
  */
 export async function act(
   actions: Action[],
@@ -54,28 +67,48 @@ export async function act(
         await releaseTicket(action.ticket, action.assignees, exec);
         log(`released #${action.ticket} (orphaned claim)`);
         break;
-      case "spawn":
+      case "escalate":
+        await escalateTicket(action.ticket, action.failures, exec);
+        log(`escalated #${action.ticket} to ready-for-human (attempts exhausted)`);
+        break;
+      case "spawn": {
+        const attempt = action.attempt;
         workers.push(
-          dispatch(action.ticket).then(async (outcome): Promise<SpawnResult> => {
-            if (!outcome.ok) return { outcome };
+          dispatch(action.ticket, attempt).then(async (outcome): Promise<SpawnResult> => {
+            if (!outcome.ok) return { outcome, attempt };
             try {
-              return { outcome, prUrl: await openPr(outcome) };
+              return { outcome, attempt, prUrl: await openPr(outcome) };
             } catch (error) {
-              return { outcome, prFailure: error };
+              return { outcome, attempt, prFailure: error };
             }
           }),
         );
-        log(`spawned Worker for #${action.ticket}`);
+        log(`spawned Worker for #${action.ticket} (attempt ${attempt})`);
         break;
+      }
     }
   }
 
   const settled = await Promise.allSettled(workers);
   for (const result of settled) {
     if (result.status !== "fulfilled") continue;
-    const { outcome, prUrl } = result.value;
-    log(describeOutcome(outcome));
+    const { outcome, attempt, prUrl } = result.value;
+    log(describeOutcome(result.value));
     if (prUrl !== undefined) log(`opened draft PR for #${outcome.ticket}: ${prUrl}`);
+    if (outcome.failure) {
+      await releaseFailedTicket(
+        outcome.ticket,
+        {
+          attempt,
+          reason: outcome.failure,
+          model: outcome.model,
+          branch: outcome.branch,
+          transcript: outcome.transcript,
+        },
+        exec,
+      );
+      log(`released #${outcome.ticket} with the attempt record (failed attempt ${attempt})`);
+    }
   }
   const rejected = settled.find((result) => result.status === "rejected");
   if (rejected) throw rejected.reason;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
 import { parseArgs } from "node:util";
 import { act } from "./act.js";
-import { ConfigError, loadConfigFile, resolveConfig, type Flags } from "./config.js";
+import {
+  ConfigError,
+  loadConfigFile,
+  modelForAttempt,
+  resolveConfig,
+  type Flags,
+} from "./config.js";
 import { plan } from "./plan.js";
 import { openPrForOutcome } from "./pr.js";
 import { renderPlan } from "./render.js";
@@ -88,7 +94,8 @@ async function main(argv: string[]): Promise<number> {
       actions,
       (ticket, attempt) =>
         dispatchWorker(ticket, {
-          model: attempt >= 2 ? config.retryModel : config.model,
+          model: modelForAttempt(config, attempt),
+          attempt,
           timeoutMs: config.timeoutMinutes * 60_000,
           stallMs: config.stallMinutes * 60_000,
         }),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,16 +18,23 @@ report each Worker's outcome. A successful Worker's branch is pushed and
 opened as a draft PR that closes its ticket on merge, its body taken from
 the Worker's final message (mechanical fallback: ticket + commit subjects).
 
+Every way a Worker can die is noticed — non-zero exit, no commits, wall-clock
+timeout, stall — and released with a forensic attempt record. A once-failed
+ticket is retried fresh on the stronger retry model; a twice-failed ticket is
+Escalated to ready-for-human with the evidence.
+
 Options:
   --dry-run            print the dispatch plan without writing anything
   --parent <n>         scope: sub-issues of parent issue #n (overrides config file)
   --all                scope: every agent-ready issue in the repo (explicit opt-in)
   --max-workers <n>    cap on planned claims (default 3, overrides config file)
   --model <name>       model Workers run on (default sonnet, overrides config file)
+  --retry-model <name> model second attempts run on (default opus, overrides config file)
   -h, --help           show this help
 
 Config: border-collie.json at the target repo root,
-e.g. {"parent": 1, "max_workers": 3, "worker_model": "sonnet"}`;
+e.g. {"parent": 1, "max_workers": 3, "worker_model": "sonnet",
+"retry_model": "opus", "worker_timeout_minutes": 45, "worker_stall_minutes": 10}`;
 
 function parseIntFlag(value: string | undefined, name: string): number | undefined {
   if (value === undefined) return undefined;
@@ -47,6 +54,7 @@ async function main(argv: string[]): Promise<number> {
       all: { type: "boolean", default: false },
       "max-workers": { type: "string" },
       model: { type: "string" },
+      "retry-model": { type: "string" },
       help: { type: "boolean", short: "h", default: false },
     },
   });
@@ -66,6 +74,7 @@ async function main(argv: string[]): Promise<number> {
   if (maxWorkers !== undefined) flags.maxWorkers = maxWorkers;
   if (values.all) flags.all = true;
   if (values.model !== undefined) flags.model = values.model;
+  if (values["retry-model"] !== undefined) flags.retryModel = values["retry-model"];
 
   const config = resolveConfig(loadConfigFile(process.cwd()), flags);
 
@@ -77,7 +86,12 @@ async function main(argv: string[]): Promise<number> {
     const titles = new Map(world.tickets.map((t) => [t.number, t.title]));
     await act(
       actions,
-      (ticket) => dispatchWorker(ticket, { model: config.model }),
+      (ticket, attempt) =>
+        dispatchWorker(ticket, {
+          model: attempt >= 2 ? config.retryModel : config.model,
+          timeoutMs: config.timeoutMinutes * 60_000,
+          stallMs: config.stallMinutes * 60_000,
+        }),
       (outcome) => openPrForOutcome(outcome, titles.get(outcome.ticket) ?? `Ticket #${outcome.ticket}`),
     );
   }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -9,6 +9,9 @@ describe("resolveConfig", () => {
       scope: { kind: "parent", parent: 1 },
       maxWorkers: 5,
       model: "sonnet",
+      retryModel: "opus",
+      timeoutMinutes: 45,
+      stallMinutes: 10,
     });
   });
 
@@ -28,6 +31,9 @@ describe("resolveConfig", () => {
       scope: { kind: "parent", parent: 4 },
       maxWorkers: 2,
       model: "opus",
+      retryModel: "opus",
+      timeoutMinutes: 45,
+      stallMinutes: 10,
     });
   });
 
@@ -38,13 +44,16 @@ describe("resolveConfig", () => {
       scope: { kind: "parent", parent: 9 },
       maxWorkers: 3,
       model: "sonnet",
+      retryModel: "opus",
+      timeoutMinutes: 45,
+      stallMinutes: 10,
     });
   });
 
   it("requires an explicit all flag for repo-wide scope", () => {
     const resolved = resolveConfig({ max_workers: 2 }, { all: true });
 
-    expect(resolved).toEqual({ scope: { kind: "all" }, maxWorkers: 2, model: "sonnet" });
+    expect(resolved).toMatchObject({ scope: { kind: "all" }, maxWorkers: 2, model: "sonnet" });
   });
 
   it("takes the worker model from the config file", () => {
@@ -56,6 +65,32 @@ describe("resolveConfig", () => {
   it("rejects a worker model that is not a non-empty string", () => {
     expect(() => resolveConfig({ parent: 1, worker_model: "" }, {})).toThrow(ConfigError);
     expect(() => resolveConfig({ parent: 1, worker_model: 4 }, {})).toThrow(ConfigError);
+  });
+
+  it("takes the retry model from the config file, with a flag override", () => {
+    expect(resolveConfig({ parent: 1, retry_model: "sonnet" }, {}).retryModel).toBe("sonnet");
+    expect(
+      resolveConfig({ parent: 1, retry_model: "sonnet" }, { retryModel: "haiku" }).retryModel,
+    ).toBe("haiku");
+  });
+
+  it("rejects a retry model that is not a non-empty string", () => {
+    expect(() => resolveConfig({ parent: 1, retry_model: "" }, {})).toThrow(ConfigError);
+  });
+
+  it("takes the Worker timeout and stall windows from the config file", () => {
+    const resolved = resolveConfig(
+      { parent: 1, worker_timeout_minutes: 90, worker_stall_minutes: 5 },
+      {},
+    );
+
+    expect(resolved.timeoutMinutes).toBe(90);
+    expect(resolved.stallMinutes).toBe(5);
+  });
+
+  it("rejects non-positive timeout and stall windows", () => {
+    expect(() => resolveConfig({ parent: 1, worker_timeout_minutes: 0 }, {})).toThrow(ConfigError);
+    expect(() => resolveConfig({ parent: 1, worker_stall_minutes: -1 }, {})).toThrow(ConfigError);
   });
 
   it("rejects a run with neither a parent nor the all flag", () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ConfigError, resolveConfig } from "./config.js";
+import { ConfigError, modelForAttempt, resolveConfig } from "./config.js";
 
 describe("resolveConfig", () => {
   it("takes the scope parent and max_workers from the config file", () => {
@@ -108,6 +108,13 @@ describe("resolveConfig", () => {
     const resolved = resolveConfig({ parent: 1 }, { all: true });
 
     expect(resolved.scope).toEqual({ kind: "all" });
+  });
+
+  it("binds attempt one to the base model and later attempts to the retry model", () => {
+    const config = resolveConfig({ parent: 1 }, {});
+
+    expect(modelForAttempt(config, 1)).toBe("sonnet");
+    expect(modelForAttempt(config, 2)).toBe("opus");
   });
 
   it("rejects a non-positive max_workers", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -99,6 +99,11 @@ export function resolveConfig(fileConfig: unknown, flags: Flags): ResolvedConfig
   return { scope: { kind: "parent", parent: asPositiveInt(parent, "parent") }, ...shared };
 }
 
+/** The retry ladder's model binding: attempt two runs the stronger retry model. */
+export function modelForAttempt(config: ResolvedConfig, attempt: number): string {
+  return attempt >= 2 ? config.retryModel : config.model;
+}
+
 /** Read the config file from the target repo root; absent file is fine. */
 export function loadConfigFile(repoDir: string): unknown {
   let raw: string;

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,9 @@ export const CONFIG_FILE = "border-collie.json";
 
 const DEFAULT_MAX_WORKERS = 3;
 const DEFAULT_WORKER_MODEL = "sonnet";
+const DEFAULT_RETRY_MODEL = "opus";
+const DEFAULT_TIMEOUT_MINUTES = 45;
+const DEFAULT_STALL_MINUTES = 10;
 
 export class ConfigError extends Error {}
 
@@ -15,6 +18,7 @@ export interface Flags {
   maxWorkers?: number;
   all?: boolean;
   model?: string;
+  retryModel?: string;
 }
 
 export type Scope = { kind: "parent"; parent: number } | { kind: "all" };
@@ -24,6 +28,12 @@ export interface ResolvedConfig {
   maxWorkers: number;
   /** Model Workers run on (`claude --model`). */
   model: string;
+  /** Stronger model a second attempt runs on (the retry ladder). */
+  retryModel: string;
+  /** Wall-clock ceiling per Worker. */
+  timeoutMinutes: number;
+  /** Max quiet time between Worker output events. */
+  stallMinutes: number;
 }
 
 function asPositiveInt(value: unknown, name: string): number {
@@ -59,12 +69,25 @@ export function resolveConfig(fileConfig: unknown, flags: Flags): ResolvedConfig
     flags.model ?? file["worker_model"] ?? DEFAULT_WORKER_MODEL,
     "worker_model",
   );
+  const retryModel = asNonEmptyString(
+    flags.retryModel ?? file["retry_model"] ?? DEFAULT_RETRY_MODEL,
+    "retry_model",
+  );
+  const timeoutMinutes = asPositiveInt(
+    file["worker_timeout_minutes"] ?? DEFAULT_TIMEOUT_MINUTES,
+    "worker_timeout_minutes",
+  );
+  const stallMinutes = asPositiveInt(
+    file["worker_stall_minutes"] ?? DEFAULT_STALL_MINUTES,
+    "worker_stall_minutes",
+  );
+  const shared = { maxWorkers, model, retryModel, timeoutMinutes, stallMinutes };
 
   if (flags.all) {
     if (flags.parent !== undefined) {
       throw new ConfigError("--all and --parent are mutually exclusive");
     }
-    return { scope: { kind: "all" }, maxWorkers, model };
+    return { scope: { kind: "all" }, ...shared };
   }
 
   const parent = flags.parent ?? file["parent"];
@@ -73,7 +96,7 @@ export function resolveConfig(fileConfig: unknown, flags: Flags): ResolvedConfig
       `no scope: set "parent" in ${CONFIG_FILE} or pass --parent <n> (repo-wide scope requires the explicit --all flag)`,
     );
   }
-  return { scope: { kind: "parent", parent: asPositiveInt(parent, "parent") }, maxWorkers, model };
+  return { scope: { kind: "parent", parent: asPositiveInt(parent, "parent") }, ...shared };
 }
 
 /** Read the config file from the target repo root; absent file is fine. */

--- a/src/plan.test.ts
+++ b/src/plan.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { plan } from "./plan.js";
-import type { Ticket, WorldSnapshot } from "./types.js";
+import type { AttemptFailure, Ticket, WorldSnapshot } from "./types.js";
 
 function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
   return {
@@ -10,7 +10,19 @@ function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
     labels: ["ready-for-agent"],
     openBlockers: 0,
     hasAgentClaim: false,
+    agentClaimCount: 0,
+    attemptFailures: [],
     ...overrides,
+  };
+}
+
+function failure(attempt: number): AttemptFailure {
+  return {
+    attempt,
+    reason: "timeout",
+    model: attempt === 1 ? "sonnet" : "opus",
+    branch: "border-collie/ticket-7",
+    transcript: ".border-collie/transcripts/ticket-7.jsonl",
   };
 }
 
@@ -24,7 +36,7 @@ describe("plan", () => {
 
     expect(actions).toEqual([
       { type: "claim", ticket: 7 },
-      { type: "spawn", ticket: 7 },
+      { type: "spawn", ticket: 7, attempt: 1 },
     ]);
   });
 
@@ -124,7 +136,7 @@ describe("plan", () => {
     expect(actions).toEqual([
       { type: "release", ticket: 4, assignees: ["operator"] },
       { type: "claim", ticket: 9 },
-      { type: "spawn", ticket: 9 },
+      { type: "spawn", ticket: 9, attempt: 1 },
     ]);
   });
 
@@ -142,11 +154,11 @@ describe("plan", () => {
 
     expect(actions).toEqual([
       { type: "claim", ticket: 2 },
-      { type: "spawn", ticket: 2 },
+      { type: "spawn", ticket: 2, attempt: 1 },
       { type: "claim", ticket: 4 },
-      { type: "spawn", ticket: 4 },
+      { type: "spawn", ticket: 4, attempt: 1 },
       { type: "claim", ticket: 6 },
-      { type: "spawn", ticket: 6 },
+      { type: "spawn", ticket: 6, attempt: 1 },
     ]);
   });
 
@@ -162,9 +174,91 @@ describe("plan", () => {
 
     expect(actions).toEqual([
       { type: "claim", ticket: 3 },
-      { type: "spawn", ticket: 3 },
+      { type: "spawn", ticket: 3, attempt: 1 },
       { type: "claim", ticket: 8 },
-      { type: "spawn", ticket: 8 },
+      { type: "spawn", ticket: 8, attempt: 1 },
+    ]);
+  });
+});
+
+describe("plan: retry ladder and Escalation", () => {
+  it("re-claims a once-failed ticket as attempt 2 (the retry ladder)", () => {
+    const actions = plan(
+      world([ticket({ number: 7, agentClaimCount: 1, attemptFailures: [failure(1)] })]),
+      { maxWorkers: 3 },
+    );
+
+    expect(actions).toEqual([
+      { type: "claim", ticket: 7 },
+      { type: "spawn", ticket: 7, attempt: 2 },
+    ]);
+  });
+
+  it("escalates instead of dispatching once attempts are exhausted, citing the failure records", () => {
+    const failures = [failure(1), failure(2)];
+    const actions = plan(
+      world([ticket({ number: 7, agentClaimCount: 2, attemptFailures: failures })]),
+      { maxWorkers: 3 },
+    );
+
+    expect(actions).toEqual([{ type: "escalate", ticket: 7, failures }]);
+  });
+
+  it("escalates a ticket with more claims than failure records (orphan-released attempts)", () => {
+    const actions = plan(
+      world([ticket({ number: 7, agentClaimCount: 3, attemptFailures: [failure(2)] })]),
+      { maxWorkers: 3 },
+    );
+
+    expect(actions).toEqual([{ type: "escalate", ticket: 7, failures: [failure(2)] }]);
+  });
+
+  it("never escalates an already-escalated ticket (label swap removed ready-for-agent)", () => {
+    const actions = plan(
+      world([
+        ticket({ number: 7, labels: ["ready-for-human"], agentClaimCount: 2 }),
+      ]),
+      { maxWorkers: 3 },
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it("does not escalate a ticket whose agent PR is still open — the work may land", () => {
+    const actions = plan(
+      world([ticket({ number: 7, agentClaimCount: 2 })], [7]),
+      { maxWorkers: 3 },
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it("does not escalate an assigned ticket this tick: the orphan release goes first", () => {
+    const actions = plan(
+      world([
+        ticket({ number: 7, assignees: ["operator"], hasAgentClaim: true, agentClaimCount: 2 }),
+      ]),
+      { maxWorkers: 3 },
+    );
+
+    expect(actions).toEqual([{ type: "release", ticket: 7, assignees: ["operator"] }]);
+  });
+
+  it("orders escalations after releases and before dispatches, without consuming Worker slots", () => {
+    const actions = plan(
+      world([
+        ticket({ number: 3 }),
+        ticket({ number: 5, agentClaimCount: 2, attemptFailures: [failure(1), failure(2)] }),
+        ticket({ number: 6, assignees: ["operator"], hasAgentClaim: true }),
+      ]),
+      { maxWorkers: 1 },
+    );
+
+    expect(actions).toEqual([
+      { type: "release", ticket: 6, assignees: ["operator"] },
+      { type: "escalate", ticket: 5, failures: [failure(1), failure(2)] },
+      { type: "claim", ticket: 3 },
+      { type: "spawn", ticket: 3, attempt: 1 },
     ]);
   });
 });

--- a/src/plan.ts
+++ b/src/plan.ts
@@ -1,4 +1,5 @@
 import {
+  MAX_ATTEMPTS,
   READY_FOR_AGENT,
   type Action,
   type PlanConfig,
@@ -43,10 +44,29 @@ function isOrphanedClaim(ticket: Ticket, world: WorldSnapshot): boolean {
 }
 
 /**
+ * Attempts exhausted: an otherwise-dispatchable ticket whose claim history
+ * already counts MAX_ATTEMPTS claims (each Attempt is preceded by exactly one
+ * claim — the stateless attempt counter). Escalated instead of dispatched;
+ * the label swap then removes it from the dispatchable set for good, so its
+ * dependents stay blocked. An open agent PR vetoes: the work may still land.
+ */
+function isEscalationDue(ticket: Ticket, world: WorldSnapshot): boolean {
+  return (
+    ticket.state === "open" &&
+    ticket.assignees.length === 0 &&
+    ticket.labels.includes(READY_FOR_AGENT) &&
+    ticket.agentClaimCount >= MAX_ATTEMPTS &&
+    !world.openAgentPrTickets.includes(ticket.number)
+  );
+}
+
+/**
  * The plan phase: a pure function from a world snapshot to the Actions now
  * due. Deterministic — releases first (recovery before new work), then
- * lowest ticket numbers claim first, each claim paired with the spawn of
- * its Worker.
+ * escalations (they free nothing and consume no Worker slots), then lowest
+ * ticket numbers claim first, each claim paired with the spawn of its Worker.
+ * The spawn's attempt number climbs the retry ladder: the caller binds
+ * attempt ≥ 2 to the stronger retry model.
  */
 export function plan(world: WorldSnapshot, config: PlanConfig): Action[] {
   const releases: Action[] = world.tickets
@@ -54,12 +74,22 @@ export function plan(world: WorldSnapshot, config: PlanConfig): Action[] {
     .sort((a, b) => a.number - b.number)
     .map((ticket) => ({ type: "release", ticket: ticket.number, assignees: ticket.assignees }));
 
+  const escalations: Action[] = world.tickets
+    .filter((ticket) => isEscalationDue(ticket, world))
+    .sort((a, b) => a.number - b.number)
+    .map((ticket) => ({
+      type: "escalate",
+      ticket: ticket.number,
+      failures: ticket.attemptFailures,
+    }));
+
   const dispatches: Action[] = dispatchableSet(world)
+    .filter((ticket) => ticket.agentClaimCount < MAX_ATTEMPTS)
     .slice(0, Math.max(0, config.maxWorkers))
     .flatMap((ticket) => [
       { type: "claim", ticket: ticket.number },
-      { type: "spawn", ticket: ticket.number },
+      { type: "spawn", ticket: ticket.number, attempt: ticket.agentClaimCount + 1 },
     ]);
 
-  return [...releases, ...dispatches];
+  return [...releases, ...escalations, ...dispatches];
 }

--- a/src/pr.test.ts
+++ b/src/pr.test.ts
@@ -107,6 +107,7 @@ describe("ensureCloseKeyword", () => {
 
 const OUTCOME: WorkerOutcome = {
   ticket: 5,
+  attempt: 1,
   branch: "border-collie/ticket-5",
   base: "base-sha",
   transcript: ".border-collie/transcripts/ticket-5.jsonl",

--- a/src/pr.test.ts
+++ b/src/pr.test.ts
@@ -110,8 +110,10 @@ const OUTCOME: WorkerOutcome = {
   branch: "border-collie/ticket-5",
   base: "base-sha",
   transcript: ".border-collie/transcripts/ticket-5.jsonl",
+  model: "sonnet",
   exitCode: 0,
   newCommits: 2,
+  failure: undefined,
   ok: true,
 };
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,38 +1,40 @@
 import { describe, expect, it } from "vitest";
 import { renderPlan } from "./render.js";
 import { plan } from "./plan.js";
-import type { WorldSnapshot } from "./types.js";
+import type { ResolvedConfig } from "./config.js";
+import type { Ticket, WorldSnapshot } from "./types.js";
+
+function ticket(overrides: Partial<Ticket> & { number: number; title: string }): Ticket {
+  return {
+    state: "open",
+    assignees: [],
+    labels: ["ready-for-agent"],
+    openBlockers: 0,
+    hasAgentClaim: false,
+    agentClaimCount: 0,
+    attemptFailures: [],
+    ...overrides,
+  };
+}
+
+function config(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
+  return {
+    scope: { kind: "parent", parent: 1 },
+    maxWorkers: 3,
+    model: "sonnet",
+    retryModel: "opus",
+    timeoutMinutes: 45,
+    stallMinutes: 10,
+    ...overrides,
+  };
+}
 
 describe("renderPlan", () => {
   const world: WorldSnapshot = {
     tickets: [
-      {
-        number: 2,
-        title: "Walking skeleton",
-        state: "open",
-        assignees: [],
-        labels: ["ready-for-agent"],
-        openBlockers: 0,
-        hasAgentClaim: false,
-      },
-      {
-        number: 3,
-        title: "Claiming",
-        state: "open",
-        assignees: [],
-        labels: ["ready-for-agent"],
-        openBlockers: 1,
-        hasAgentClaim: false,
-      },
-      {
-        number: 4,
-        title: "Done already",
-        state: "closed",
-        assignees: [],
-        labels: ["ready-for-agent"],
-        openBlockers: 0,
-        hasAgentClaim: false,
-      },
+      ticket({ number: 2, title: "Walking skeleton" }),
+      ticket({ number: 3, title: "Claiming", openBlockers: 1 }),
+      ticket({ number: 4, title: "Done already", state: "closed" }),
     ],
     openAgentPrTickets: [],
   };
@@ -40,19 +42,13 @@ describe("renderPlan", () => {
   it("shows the scope, the dispatchable set, and the planned claims and spawns", () => {
     const actions = plan(world, { maxWorkers: 3 });
 
-    const config = {
-      scope: { kind: "parent", parent: 1 } as const,
-      maxWorkers: 3,
-      model: "sonnet",
-    };
-
-    expect(renderPlan(config, world, actions, { dryRun: true })).toBe(
+    expect(renderPlan(config(), world, actions, { dryRun: true })).toBe(
       [
         "Scope: sub-issues of #1 — 3 tickets (2 open)",
         "Dispatchable: #2",
         "Plan (max_workers=3):",
         "  claim #2 — Walking skeleton",
-        "  spawn Worker for #2 — Walking skeleton (model sonnet)",
+        "  spawn Worker for #2 — Walking skeleton (model sonnet, attempt 1)",
         "Dry run: no writes performed.",
       ].join("\n"),
     );
@@ -62,9 +58,7 @@ describe("renderPlan", () => {
     const empty: WorldSnapshot = { tickets: [], openAgentPrTickets: [] };
 
     expect(
-      renderPlan({ scope: { kind: "all" }, maxWorkers: 3, model: "sonnet" }, empty, [], {
-        dryRun: true,
-      }),
+      renderPlan(config({ scope: { kind: "all" } }), empty, [], { dryRun: true }),
     ).toBe(
       [
         "Scope: repo-wide (--all) — 0 tickets (0 open)",
@@ -78,33 +72,46 @@ describe("renderPlan", () => {
   it("shows planned releases and drops the dry-run footer when acting", () => {
     const orphaned: WorldSnapshot = {
       tickets: [
-        {
+        ticket({
           number: 5,
           title: "Stranded by a crash",
-          state: "open",
           assignees: ["operator"],
-          labels: ["ready-for-agent"],
-          openBlockers: 0,
           hasAgentClaim: true,
-        },
+        }),
       ],
       openAgentPrTickets: [],
     };
     const actions = plan(orphaned, { maxWorkers: 3 });
 
-    expect(
-      renderPlan(
-        { scope: { kind: "parent", parent: 1 }, maxWorkers: 3, model: "sonnet" },
-        orphaned,
-        actions,
-        { dryRun: false },
-      ),
-    ).toBe(
+    expect(renderPlan(config(), orphaned, actions, { dryRun: false })).toBe(
       [
         "Scope: sub-issues of #1 — 1 tickets (1 open)",
         "Dispatchable: none",
         "Plan (max_workers=3):",
         "  release #5 — Stranded by a crash (orphaned agent claim)",
+      ].join("\n"),
+    );
+  });
+
+  it("shows the retry model on second attempts and planned escalations", () => {
+    const laddered: WorldSnapshot = {
+      tickets: [
+        ticket({ number: 6, title: "Failed once", agentClaimCount: 1 }),
+        ticket({ number: 7, title: "Failed twice", agentClaimCount: 2 }),
+      ],
+      openAgentPrTickets: [],
+    };
+    const actions = plan(laddered, { maxWorkers: 3 });
+
+    expect(renderPlan(config(), laddered, actions, { dryRun: true })).toBe(
+      [
+        "Scope: sub-issues of #1 — 2 tickets (2 open)",
+        "Dispatchable: #6, #7",
+        "Plan (max_workers=3):",
+        "  escalate #7 — Failed twice (attempts exhausted → ready-for-human)",
+        "  claim #6 — Failed once",
+        "  spawn Worker for #6 — Failed once (model opus, attempt 2)",
+        "Dry run: no writes performed.",
       ].join("\n"),
     );
   });

--- a/src/render.ts
+++ b/src/render.ts
@@ -4,7 +4,7 @@ import type { Action, WorldSnapshot } from "./types.js";
 
 /** Render the dispatch plan as human-readable lines. Pure. */
 export function renderPlan(
-  { scope, maxWorkers, model }: ResolvedConfig,
+  { scope, maxWorkers, model, retryModel }: ResolvedConfig,
   world: WorldSnapshot,
   actions: Action[],
   { dryRun }: { dryRun: boolean },
@@ -39,7 +39,16 @@ export function renderPlan(
           lines.push(`  release #${action.ticket} — ${title} (orphaned agent claim)`);
           break;
         case "spawn":
-          lines.push(`  spawn Worker for #${action.ticket} — ${title} (model ${model})`);
+          lines.push(
+            `  spawn Worker for #${action.ticket} — ${title} (model ${
+              action.attempt >= 2 ? retryModel : model
+            }, attempt ${action.attempt})`,
+          );
+          break;
+        case "escalate":
+          lines.push(
+            `  escalate #${action.ticket} — ${title} (attempts exhausted → ready-for-human)`,
+          );
           break;
       }
     }

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,14 +1,15 @@
-import type { ResolvedConfig } from "./config.js";
+import { modelForAttempt, type ResolvedConfig } from "./config.js";
 import { dispatchableSet } from "./plan.js";
 import type { Action, WorldSnapshot } from "./types.js";
 
 /** Render the dispatch plan as human-readable lines. Pure. */
 export function renderPlan(
-  { scope, maxWorkers, model, retryModel }: ResolvedConfig,
+  config: ResolvedConfig,
   world: WorldSnapshot,
   actions: Action[],
   { dryRun }: { dryRun: boolean },
 ): string {
+  const { scope, maxWorkers } = config;
   const lines: string[] = [];
   const open = world.tickets.filter((t) => t.state === "open").length;
   const scopeLabel =
@@ -40,9 +41,10 @@ export function renderPlan(
           break;
         case "spawn":
           lines.push(
-            `  spawn Worker for #${action.ticket} — ${title} (model ${
-              action.attempt >= 2 ? retryModel : model
-            }, attempt ${action.attempt})`,
+            `  spawn Worker for #${action.ticket} — ${title} (model ${modelForAttempt(
+              config,
+              action.attempt,
+            )}, attempt ${action.attempt})`,
           );
           break;
         case "escalate":

--- a/src/tracker.test.ts
+++ b/src/tracker.test.ts
@@ -1,6 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { claimTicket, createDraftPr, readScope, releaseTicket, type Exec } from "./tracker.js";
-import { CLAIM_MARKER, RELEASE_MARKER } from "./types.js";
+import {
+  claimTicket,
+  createDraftPr,
+  escalateTicket,
+  readScope,
+  releaseFailedTicket,
+  releaseTicket,
+  type Exec,
+} from "./tracker.js";
+import {
+  attemptMarker,
+  CLAIM_MARKER,
+  RELEASE_MARKER,
+  type AttemptFailure,
+} from "./types.js";
+
+const FAILURE: AttemptFailure = {
+  attempt: 1,
+  reason: "stall",
+  model: "sonnet",
+  branch: "border-collie/ticket-5",
+  transcript: ".border-collie/transcripts/ticket-5.jsonl",
+};
 
 const issue = (overrides: Record<string, unknown>) => ({
   number: 2,
@@ -37,23 +58,19 @@ const OPEN_PULLS = "repos/{owner}/{repo}/pulls?state=open&per_page=100";
 
 describe("readScope", () => {
   it("reads a parent's sub-issues via gh api with pagination", async () => {
-    const { exec, calls } = fakeExec({ [SUB_ISSUES]: [[issue({})]] });
+    const { exec, calls } = fakeExec({ [SUB_ISSUES]: [[issue({})]], [comments(2)]: [[]] });
 
     await readScope({ kind: "parent", parent: 1 }, exec);
 
-    expect(calls).toEqual([
-      ["gh", "api", SUB_ISSUES, "--paginate", "--slurp"],
-    ]);
+    expect(calls[0]).toEqual(["gh", "api", SUB_ISSUES, "--paginate", "--slurp"]);
   });
 
   it("reads repo-wide agent-ready issues when scope is all", async () => {
-    const { exec, calls } = fakeExec({ [ALL_ISSUES]: [[issue({})]] });
+    const { exec, calls } = fakeExec({ [ALL_ISSUES]: [[issue({})]], [comments(2)]: [[]] });
 
     await readScope({ kind: "all" }, exec);
 
-    expect(calls).toEqual([
-      ["gh", "api", ALL_ISSUES, "--paginate", "--slurp"],
-    ]);
+    expect(calls[0]).toEqual(["gh", "api", ALL_ISSUES, "--paginate", "--slurp"]);
   });
 
   it("maps issues to Tickets and flattens pages", async () => {
@@ -69,6 +86,7 @@ describe("readScope", () => {
         ],
         [issue({ number: 4, title: "Second page" })],
       ],
+      [comments(4)]: [[]],
     });
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
@@ -82,6 +100,8 @@ describe("readScope", () => {
         labels: ["ready-for-agent"],
         openBlockers: 2,
         hasAgentClaim: false,
+        agentClaimCount: 0,
+        attemptFailures: [],
       },
       {
         number: 4,
@@ -91,6 +111,8 @@ describe("readScope", () => {
         labels: ["ready-for-agent"],
         openBlockers: 0,
         hasAgentClaim: false,
+        agentClaimCount: 0,
+        attemptFailures: [],
       },
     ]);
   });
@@ -100,6 +122,7 @@ describe("readScope", () => {
       [ALL_ISSUES]: [
         [issue({ number: 5 }), issue({ number: 6, pull_request: { url: "x" } })],
       ],
+      [comments(5)]: [[]],
     });
 
     const world = await readScope({ kind: "all" }, exec);
@@ -110,6 +133,7 @@ describe("readScope", () => {
   it("treats a missing dependency summary as zero open blockers", async () => {
     const { exec } = fakeExec({
       [SUB_ISSUES]: [[issue({ number: 7, issue_dependencies_summary: undefined })]],
+      [comments(7)]: [[]],
     });
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
@@ -117,7 +141,7 @@ describe("readScope", () => {
     expect(world.tickets[0]?.openBlockers).toBe(0);
   });
 
-  it("reads comments only for assigned open tickets and detects the claim marker", async () => {
+  it("reads comments for assigned tickets and unassigned dispatch candidates, detecting the claim marker", async () => {
     const { exec, calls } = fakeExec({
       [SUB_ISSUES]: [
         [
@@ -128,6 +152,7 @@ describe("readScope", () => {
       [comments(5)]: [
         [{ body: "human chatter" }, { body: `${CLAIM_MARKER}\n🐕 claimed` }],
       ],
+      [comments(6)]: [[]],
       [OPEN_PULLS]: [[]],
     });
 
@@ -138,7 +163,68 @@ describe("readScope", () => {
       [6, false],
     ]);
     expect(calls.map((c) => c[2])).toContain(comments(5));
-    expect(calls.map((c) => c[2])).not.toContain(comments(6));
+    expect(calls.map((c) => c[2])).toContain(comments(6));
+  });
+
+  it("skips comment reads for closed, blocked, and non-agent unassigned tickets", async () => {
+    const { exec, calls } = fakeExec({
+      [SUB_ISSUES]: [
+        [
+          issue({ number: 3, state: "closed" }),
+          issue({ number: 4, issue_dependencies_summary: { blocked_by: 1 } }),
+          issue({ number: 8, labels: [] }),
+        ],
+      ],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(calls.map((c) => c[2])).toEqual([SUB_ISSUES]);
+    expect(world.tickets.map((t) => t.agentClaimCount)).toEqual([0, 0, 0]);
+  });
+
+  it("derives the Attempt counter and failure records from the comment history", async () => {
+    const { exec } = fakeExec({
+      [SUB_ISSUES]: [[issue({ number: 5 })]],
+      [comments(5)]: [
+        [
+          { body: `${CLAIM_MARKER}\n🐕 claimed` },
+          { body: `${RELEASE_MARKER}\n${attemptMarker(FAILURE)}\n🐕 Attempt 1 failed` },
+          { body: `${CLAIM_MARKER}\n🐕 claimed again` },
+          {
+            body: `${RELEASE_MARKER}\n${attemptMarker({ ...FAILURE, attempt: 2, model: "opus" })}\n🐕 Attempt 2 failed`,
+          },
+        ],
+      ],
+      [OPEN_PULLS]: [[]],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.tickets[0]).toMatchObject({
+      hasAgentClaim: false,
+      agentClaimCount: 2,
+      attemptFailures: [FAILURE, { ...FAILURE, attempt: 2, model: "opus" }],
+    });
+  });
+
+  it("reads open PRs when attempts are exhausted even with no live agent claim (the escalation veto)", async () => {
+    const { exec } = fakeExec({
+      [SUB_ISSUES]: [[issue({ number: 5 })]],
+      [comments(5)]: [
+        [
+          { body: `${CLAIM_MARKER}\nclaimed` },
+          { body: `${RELEASE_MARKER}\nreleased` },
+          { body: `${CLAIM_MARKER}\nclaimed` },
+          { body: `${RELEASE_MARKER}\nreleased` },
+        ],
+      ],
+      [OPEN_PULLS]: [[{ head: { ref: "border-collie/ticket-5" } }]],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.openAgentPrTickets).toEqual([5]);
   });
 
   it("treats a release marker after the claim as no agent claim, and skips the PR read", async () => {
@@ -239,5 +325,68 @@ describe("createDraftPr", () => {
         "A body.\n\nCloses #5",
       ],
     ]);
+  });
+});
+
+describe("releaseFailedTicket", () => {
+  it("unassigns @me first, then posts a release comment carrying the attempt record", async () => {
+    const { exec, calls } = recordingExec();
+
+    await releaseFailedTicket(5, FAILURE, exec);
+
+    expect(calls).toEqual([
+      ["gh", "issue", "edit", "5", "--remove-assignee", "@me"],
+      ["gh", "issue", "comment", "5", "--body", expect.stringContaining(RELEASE_MARKER)],
+    ]);
+    const body = calls[1]?.[5] ?? "";
+    expect(body).toContain(attemptMarker(FAILURE));
+    expect(body).toContain("no output events");
+    expect(body).toContain(FAILURE.transcript);
+  });
+});
+
+describe("escalateTicket", () => {
+  it("posts the forensic comment first, then swaps ready-for-agent for ready-for-human", async () => {
+    const { exec, calls } = recordingExec();
+    const second: AttemptFailure = {
+      ...FAILURE,
+      attempt: 2,
+      reason: "timeout",
+      model: "opus",
+      transcript: ".border-collie/transcripts/ticket-5-2.jsonl",
+    };
+
+    await escalateTicket(5, [FAILURE, second], exec);
+
+    expect(calls).toEqual([
+      ["gh", "issue", "comment", "5", "--body", expect.stringContaining("Escalated")],
+      [
+        "gh",
+        "issue",
+        "edit",
+        "5",
+        "--remove-label",
+        "ready-for-agent",
+        "--add-label",
+        "ready-for-human",
+      ],
+    ]);
+    const body = calls[0]?.[5] ?? "";
+    expect(body).toContain("Attempt 1 (sonnet)");
+    expect(body).toContain("no output events");
+    expect(body).toContain("Attempt 2 (opus)");
+    expect(body).toContain("wall-clock timeout");
+    expect(body).toContain(FAILURE.transcript);
+    expect(body).toContain(second.transcript);
+    expect(body).toContain(FAILURE.branch);
+  });
+
+  it("still escalates with no attempt records, noting the missing forensics", async () => {
+    const { exec, calls } = recordingExec();
+
+    await escalateTicket(5, [], exec);
+
+    const body = calls[0]?.[5] ?? "";
+    expect(body).toContain("no attempt records");
   });
 });

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -1,10 +1,16 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import {
+  attemptMarker,
   CLAIM_MARKER,
+  FAILURE_DESCRIPTIONS,
+  MAX_ATTEMPTS,
+  parseAttemptMarker,
   READY_FOR_AGENT,
+  READY_FOR_HUMAN,
   RELEASE_MARKER,
   ticketFromAgentBranch,
+  type AttemptFailure,
   type Ticket,
   type WorldSnapshot,
 } from "./types.js";
@@ -47,6 +53,8 @@ function toTicket(issue: GithubIssue): Ticket {
     labels: (issue.labels ?? []).map((l) => l.name),
     openBlockers: issue.issue_dependencies_summary?.blocked_by ?? 0,
     hasAgentClaim: false,
+    agentClaimCount: 0,
+    attemptFailures: [],
   };
 }
 
@@ -56,22 +64,37 @@ async function readPages<T>(endpoint: string, exec: Exec): Promise<T[]> {
   return pages.flat();
 }
 
+interface ClaimHistory {
+  hasAgentClaim: boolean;
+  agentClaimCount: number;
+  attemptFailures: AttemptFailure[];
+}
+
 /**
- * The latest border-collie marker comment decides claim ownership: a claim
- * marker after any release marker means the assignment is agent-held. Both
- * are append-only, so history stays auditable.
+ * One pass over a ticket's comments, oldest first. The latest border-collie
+ * marker comment decides claim ownership: a claim marker after any release
+ * marker means the assignment is agent-held. The claim markers ever posted
+ * count Attempts (each Attempt is preceded by exactly one claim), and release
+ * comments carry the failed attempts' forensic records. All append-only, so
+ * history stays auditable and attempt state needs no local store.
  */
-async function ticketHasAgentClaim(ticket: number, exec: Exec): Promise<boolean> {
+async function readClaimHistory(ticket: number, exec: Exec): Promise<ClaimHistory> {
   const comments = await readPages<{ body?: string }>(
     `repos/{owner}/{repo}/issues/${ticket}/comments?per_page=100`,
     exec,
   );
-  let claimed = false;
+  const history: ClaimHistory = { hasAgentClaim: false, agentClaimCount: 0, attemptFailures: [] };
   for (const comment of comments) {
-    if (comment.body?.includes(CLAIM_MARKER)) claimed = true;
-    else if (comment.body?.includes(RELEASE_MARKER)) claimed = false;
+    if (comment.body?.includes(CLAIM_MARKER)) {
+      history.hasAgentClaim = true;
+      history.agentClaimCount += 1;
+    } else if (comment.body?.includes(RELEASE_MARKER)) {
+      history.hasAgentClaim = false;
+      const failure = parseAttemptMarker(comment.body);
+      if (failure) history.attemptFailures.push(failure);
+    }
   }
-  return claimed;
+  return history;
 }
 
 /** Ticket numbers of open PRs whose head branch carries the agent prefix. */
@@ -102,15 +125,26 @@ export async function readScope(scope: Scope, exec: Exec = realExec): Promise<Wo
     .filter((issue) => issue.pull_request === undefined)
     .map(toTicket);
 
+  // Claim history is read where it can matter: assigned tickets (claim
+  // ownership) and unassigned dispatch candidates (the Attempt counter that
+  // picks the retry rung or triggers Escalation).
   for (const ticket of tickets) {
-    if (ticket.state === "open" && ticket.assignees.length > 0) {
-      ticket.hasAgentClaim = await ticketHasAgentClaim(ticket.number, exec);
+    const isDispatchCandidate =
+      ticket.labels.includes(READY_FOR_AGENT) && ticket.openBlockers === 0;
+    if (ticket.state === "open" && (ticket.assignees.length > 0 || isDispatchCandidate)) {
+      const history = await readClaimHistory(ticket.number, exec);
+      ticket.hasAgentClaim = history.hasAgentClaim;
+      ticket.agentClaimCount = history.agentClaimCount;
+      ticket.attemptFailures = history.attemptFailures;
     }
   }
 
-  // Open agent PRs matter only to orphan detection, which needs an agent
-  // claim to exist — skip the read otherwise.
-  const openAgentPrTickets = tickets.some((t) => t.hasAgentClaim)
+  // Open agent PRs matter only to orphan detection (which needs an agent
+  // claim to exist) and to the escalation veto (which needs exhausted
+  // attempts) — skip the read otherwise.
+  const openAgentPrTickets = tickets.some(
+    (t) => t.hasAgentClaim || t.agentClaimCount >= MAX_ATTEMPTS,
+  )
     ? await listOpenAgentPrTickets(exec)
     : [];
 
@@ -168,4 +202,62 @@ export async function createDraftPr(
     request.body,
   ]);
   return stdout.trim();
+}
+
+/**
+ * Act phase: release a ticket whose Attempt just failed, embedding the
+ * attempt's forensic record in the release comment — the tracker is the only
+ * state store, so this comment IS the attempt history that the next Tick's
+ * retry ladder and a later Escalation read back. Same crash-safe ordering as
+ * releaseTicket: unassign first.
+ */
+export async function releaseFailedTicket(
+  ticket: number,
+  failure: AttemptFailure,
+  exec: Exec = realExec,
+): Promise<void> {
+  const body = [
+    RELEASE_MARKER,
+    attemptMarker(failure),
+    `🐕 Attempt ${failure.attempt} failed: ${FAILURE_DESCRIPTIONS[failure.reason]} (model ${failure.model}).`,
+    `Worktree torn down; branch \`${failure.branch}\` abandoned; transcript at \`${failure.transcript}\`.`,
+  ].join("\n");
+  await exec("gh", ["issue", "edit", String(ticket), "--remove-assignee", "@me"]);
+  await exec("gh", ["issue", "comment", String(ticket), "--body", body]);
+}
+
+/**
+ * Act phase: Escalate a ticket whose Attempts are exhausted — the forensic
+ * comment first, then the label swap that removes it from the dispatchable
+ * set for good. A crash in between re-escalates next Tick (worst case a
+ * duplicate comment); the swap first would strand the forensics unwritten
+ * with no trigger left to write them.
+ */
+export async function escalateTicket(
+  ticket: number,
+  failures: AttemptFailure[],
+  exec: Exec = realExec,
+): Promise<void> {
+  const evidence =
+    failures.length === 0
+      ? ["(no attempt records found — the claims were likely released as orphans after crashes)"]
+      : failures.map(
+          (f) =>
+            `- Attempt ${f.attempt} (${f.model}): ${FAILURE_DESCRIPTIONS[f.reason]} — transcript \`${f.transcript}\`, abandoned branch \`${f.branch}\``,
+        );
+  const body = [
+    `🐕 Escalated by border-collie: ${MAX_ATTEMPTS} Attempts exhausted, handing this ticket to a human.`,
+    "",
+    ...evidence,
+  ].join("\n");
+  await exec("gh", ["issue", "comment", String(ticket), "--body", body]);
+  await exec("gh", [
+    "issue",
+    "edit",
+    String(ticket),
+    "--remove-label",
+    READY_FOR_AGENT,
+    "--add-label",
+    READY_FOR_HUMAN,
+  ]);
 }

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -167,19 +167,23 @@ export async function claimTicket(ticket: number, exec: Exec = realExec): Promis
 }
 
 /**
- * Act phase: release an orphaned claim back to unassigned. Unassign first —
- * a crash in between leaves the ticket unassigned with a stale claim marker,
- * which the next Tick claims afresh (self-healing). The release marker then
- * neutralizes the claim marker so a later human assignment is never misread
- * as agent-held.
+ * The shared release shape: unassign first — a crash in between leaves the
+ * ticket unassigned with a stale claim marker, which the next Tick claims
+ * afresh (self-healing). The release marker then neutralizes the claim
+ * marker so a later human assignment is never misread as agent-held.
  */
+async function release(ticket: number, assignees: string, body: string, exec: Exec): Promise<void> {
+  await exec("gh", ["issue", "edit", String(ticket), "--remove-assignee", assignees]);
+  await exec("gh", ["issue", "comment", String(ticket), "--body", body]);
+}
+
+/** Act phase: release an orphaned claim back to unassigned. */
 export async function releaseTicket(
   ticket: number,
   assignees: string[],
   exec: Exec = realExec,
 ): Promise<void> {
-  await exec("gh", ["issue", "edit", String(ticket), "--remove-assignee", assignees.join(",")]);
-  await exec("gh", ["issue", "comment", String(ticket), "--body", RELEASE_COMMENT]);
+  await release(ticket, assignees.join(","), RELEASE_COMMENT, exec);
 }
 
 /**
@@ -208,8 +212,7 @@ export async function createDraftPr(
  * Act phase: release a ticket whose Attempt just failed, embedding the
  * attempt's forensic record in the release comment — the tracker is the only
  * state store, so this comment IS the attempt history that the next Tick's
- * retry ladder and a later Escalation read back. Same crash-safe ordering as
- * releaseTicket: unassign first.
+ * retry ladder and a later Escalation read back.
  */
 export async function releaseFailedTicket(
   ticket: number,
@@ -222,8 +225,7 @@ export async function releaseFailedTicket(
     `🐕 Attempt ${failure.attempt} failed: ${FAILURE_DESCRIPTIONS[failure.reason]} (model ${failure.model}).`,
     `Worktree torn down; branch \`${failure.branch}\` abandoned; transcript at \`${failure.transcript}\`.`,
   ].join("\n");
-  await exec("gh", ["issue", "edit", String(ticket), "--remove-assignee", "@me"]);
-  await exec("gh", ["issue", "comment", String(ticket), "--body", body]);
+  await release(ticket, "@me", body, exec);
 }
 
 /**
@@ -231,7 +233,9 @@ export async function releaseFailedTicket(
  * comment first, then the label swap that removes it from the dispatchable
  * set for good. A crash in between re-escalates next Tick (worst case a
  * duplicate comment); the swap first would strand the forensics unwritten
- * with no trigger left to write them.
+ * with no trigger left to write them. The glossary's "unassign" is already
+ * done: only unassigned tickets escalate (every failure or orphan release
+ * unassigns first), so no assignee write belongs here.
  */
 export async function escalateTicket(
   ticket: number,

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  attemptMarker,
+  parseAttemptMarker,
+  ticketFromAgentBranch,
+  type AttemptFailure,
+} from "./types.js";
+
+const FAILURE: AttemptFailure = {
+  attempt: 1,
+  reason: "timeout",
+  model: "sonnet",
+  branch: "border-collie/ticket-7",
+  transcript: ".border-collie/transcripts/ticket-7.jsonl",
+};
+
+describe("attemptMarker", () => {
+  it("round-trips an attempt failure through a hidden HTML marker", () => {
+    const body = `${attemptMarker(FAILURE)}\n🐕 Attempt 1 failed.`;
+
+    expect(parseAttemptMarker(body)).toEqual(FAILURE);
+  });
+
+  it("parses nothing from a body without the marker", () => {
+    expect(parseAttemptMarker("🐕 released an orphaned claim")).toBeUndefined();
+  });
+
+  it("parses nothing from a mangled marker payload", () => {
+    expect(parseAttemptMarker("<!-- border-collie:attempt not-json -->")).toBeUndefined();
+  });
+});
+
+describe("ticketFromAgentBranch", () => {
+  it("extracts the ticket number, tolerating a slug suffix", () => {
+    expect(ticketFromAgentBranch("border-collie/ticket-8")).toBe(8);
+    expect(ticketFromAgentBranch("border-collie/ticket-8-slug")).toBe(8);
+    expect(ticketFromAgentBranch("feature/other")).toBeUndefined();
+  });
+});

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -28,6 +28,16 @@ describe("attemptMarker", () => {
   it("parses nothing from a mangled marker payload", () => {
     expect(parseAttemptMarker("<!-- border-collie:attempt not-json -->")).toBeUndefined();
   });
+
+  it("parses nothing from valid JSON that is not an attempt record", () => {
+    expect(parseAttemptMarker('<!-- border-collie:attempt {"attempt":1} -->')).toBeUndefined();
+    expect(parseAttemptMarker("<!-- border-collie:attempt null -->")).toBeUndefined();
+    expect(
+      parseAttemptMarker(
+        `<!-- border-collie:attempt ${JSON.stringify({ ...FAILURE, reason: "made-up" })} -->`,
+      ),
+    ).toBeUndefined();
+  });
 });
 
 describe("ticketFromAgentBranch", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,7 +54,11 @@ export function attemptMarker(failure: AttemptFailure): string {
   return `${ATTEMPT_MARKER_OPEN}${JSON.stringify(failure)}${ATTEMPT_MARKER_CLOSE}`;
 }
 
-/** The attempt record in a comment body, or undefined when absent/mangled. */
+/**
+ * The attempt record in a comment body, or undefined when absent or mangled.
+ * Shape-checked: comment bodies are world input, edited or truncated by
+ * anyone with tracker access.
+ */
 export function parseAttemptMarker(body: string): AttemptFailure | undefined {
   const start = body.indexOf(ATTEMPT_MARKER_OPEN);
   if (start === -1) return undefined;
@@ -62,7 +66,15 @@ export function parseAttemptMarker(body: string): AttemptFailure | undefined {
   const end = rest.indexOf(ATTEMPT_MARKER_CLOSE);
   if (end === -1) return undefined;
   try {
-    return JSON.parse(rest.slice(0, end)) as AttemptFailure;
+    const parsed = JSON.parse(rest.slice(0, end)) as Partial<AttemptFailure>;
+    const wellFormed =
+      typeof parsed.attempt === "number" &&
+      typeof parsed.reason === "string" &&
+      parsed.reason in FAILURE_DESCRIPTIONS &&
+      typeof parsed.model === "string" &&
+      typeof parsed.branch === "string" &&
+      typeof parsed.transcript === "string";
+    return wellFormed ? (parsed as AttemptFailure) : undefined;
   } catch {
     return undefined;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,10 @@
  */
 
 export const READY_FOR_AGENT = "ready-for-agent";
+export const READY_FOR_HUMAN = "ready-for-human";
+
+/** A Ticket gets at most this many Attempts before Escalation (CONTEXT.md). */
+export const MAX_ATTEMPTS = 2;
 
 /**
  * Hidden HTML markers that make a claim structurally border-collie's
@@ -12,6 +16,57 @@ export const READY_FOR_AGENT = "ready-for-agent";
  */
 export const CLAIM_MARKER = "<!-- border-collie:claim -->";
 export const RELEASE_MARKER = "<!-- border-collie:release -->";
+
+/**
+ * The four ticket-failure triggers (CONTEXT.md "Ticket failure"): every way
+ * a Worker can die that counts against the ticket's Attempts.
+ */
+export type FailureReason = "nonzero-exit" | "no-commits" | "timeout" | "stall";
+
+export const FAILURE_DESCRIPTIONS: Record<FailureReason, string> = {
+  "nonzero-exit": "the Worker process exited non-zero",
+  "no-commits": "the Worker exited cleanly but committed nothing",
+  timeout: "the Worker hit the wall-clock timeout",
+  stall: "the Worker produced no output events for the stall window",
+};
+
+/**
+ * One failed Attempt's forensics, embedded in its release comment so attempt
+ * history lives on the tracker (the only state store) and Escalation can cite
+ * evidence without any local record.
+ */
+export interface AttemptFailure {
+  attempt: number;
+  reason: FailureReason;
+  /** Model the attempt ran on. */
+  model: string;
+  /** Abandoned agent branch the attempt committed to (worktree torn down). */
+  branch: string;
+  /** Transcript file path at the target repo root, for post-mortems. */
+  transcript: string;
+}
+
+const ATTEMPT_MARKER_OPEN = "<!-- border-collie:attempt ";
+const ATTEMPT_MARKER_CLOSE = " -->";
+
+/** Hidden HTML marker carrying one attempt's forensics as JSON. */
+export function attemptMarker(failure: AttemptFailure): string {
+  return `${ATTEMPT_MARKER_OPEN}${JSON.stringify(failure)}${ATTEMPT_MARKER_CLOSE}`;
+}
+
+/** The attempt record in a comment body, or undefined when absent/mangled. */
+export function parseAttemptMarker(body: string): AttemptFailure | undefined {
+  const start = body.indexOf(ATTEMPT_MARKER_OPEN);
+  if (start === -1) return undefined;
+  const rest = body.slice(start + ATTEMPT_MARKER_OPEN.length);
+  const end = rest.indexOf(ATTEMPT_MARKER_CLOSE);
+  if (end === -1) return undefined;
+  try {
+    return JSON.parse(rest.slice(0, end)) as AttemptFailure;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Branch naming that makes a PR structurally an agent PR. Workers land with
@@ -48,6 +103,13 @@ export interface Ticket {
    * "Claim").
    */
   hasAgentClaim: boolean;
+  /**
+   * Count of claim marker comments ever posted — the stateless Attempt
+   * counter: each Attempt is preceded by exactly one claim.
+   */
+  agentClaimCount: number;
+  /** Attempt records parsed from release comments, in comment order. */
+  attemptFailures: AttemptFailure[];
 }
 
 /** Everything the planner knows about the world, recomputed each Tick. */
@@ -63,11 +125,13 @@ export interface PlanConfig {
 
 /**
  * One intended write, produced by the pure plan phase.
- * A discriminated union that later tickets extend (spawn worker, open PR,
- * escalate, ...). `release` carries the observed assignee logins so the act
- * phase needs no second look at the world.
+ * A discriminated union that later tickets extend (open PR, ...). `release`
+ * carries the observed assignee logins and `escalate` the observed attempt
+ * records so the act phase needs no second look at the world. `spawn` carries
+ * the attempt number; the caller binds it to a model (the retry ladder).
  */
 export type Action =
   | { type: "claim"; ticket: number }
   | { type: "release"; ticket: number; assignees: string[] }
-  | { type: "spawn"; ticket: number };
+  | { type: "spawn"; ticket: number; attempt: number }
+  | { type: "escalate"; ticket: number; failures: AttemptFailure[] };

--- a/src/worker.test.ts
+++ b/src/worker.test.ts
@@ -16,10 +16,10 @@ import {
 } from "./worker.js";
 
 const WORKTREE = ".border-collie/worktrees/ticket-4";
-const BRANCH = "border-collie/ticket-4";
-const TRANSCRIPT = ".border-collie/transcripts/ticket-4.jsonl";
+const BRANCH = "border-collie/ticket-4-attempt-1";
+const TRANSCRIPT = ".border-collie/transcripts/ticket-4-attempt-1.jsonl";
 
-const CONFIG: WorkerConfig = { model: "sonnet", timeoutMs: 60_000, stallMs: 30_000 };
+const CONFIG: WorkerConfig = { model: "sonnet", attempt: 1, timeoutMs: 60_000, stallMs: 30_000 };
 
 /**
  * Fake the git side of the subprocess seam: reads are answered from fixtures,
@@ -98,7 +98,7 @@ describe("dispatchWorker", () => {
         ],
         cwd: WORKTREE,
         transcriptPath: TRANSCRIPT,
-        stderrPath: ".border-collie/transcripts/ticket-4.stderr.log",
+        stderrPath: ".border-collie/transcripts/ticket-4-attempt-1.stderr.log",
         timeoutMs: 60_000,
         stallMs: 30_000,
       },
@@ -133,10 +133,10 @@ describe("dispatchWorker", () => {
         "add",
         `.border-collie/worktrees/ticket-${ticket}`,
         "-B",
-        `border-collie/ticket-${ticket}`,
+        `border-collie/ticket-${ticket}-attempt-1`,
         "origin/HEAD",
       ],
-      ["git", "rev-parse", `border-collie/ticket-${ticket}`],
+      ["git", "rev-parse", `border-collie/ticket-${ticket}-attempt-1`],
     ];
     expect(calls.slice(0, 10)).toEqual([...setupBlock(1), ...setupBlock(2)]);
     expect(outcomes.map((o) => o.ok)).toEqual([true, true]);
@@ -150,6 +150,7 @@ describe("dispatchWorker", () => {
 
     expect(outcome).toEqual({
       ticket: 4,
+      attempt: 1,
       branch: BRANCH,
       base: "base-sha",
       transcript: TRANSCRIPT,
@@ -222,6 +223,16 @@ describe("dispatchWorker", () => {
     await dispatchWorker(7, { ...CONFIG, model: "opus" }, exec, spawn);
 
     expect(requests[0]?.args).toContain("opus");
+  });
+
+  it("namespaces branch and transcript per attempt, so a retry never clobbers prior evidence", async () => {
+    const { exec } = fakeExec({ newCommits: "0" });
+    const { spawn } = fakeSpawn(1);
+
+    const outcome = await dispatchWorker(7, { ...CONFIG, attempt: 2 }, exec, spawn);
+
+    expect(outcome.branch).toBe("border-collie/ticket-7-attempt-2");
+    expect(outcome.transcript).toBe(".border-collie/transcripts/ticket-7-attempt-2.jsonl");
   });
 });
 

--- a/src/worker.test.ts
+++ b/src/worker.test.ts
@@ -1,17 +1,25 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import type { Exec } from "./tracker.js";
 import {
   branchCommitSubjects,
   dispatchWorker,
   pushAgentBranch,
+  realSpawnWorkerProcess,
   workerPrompt,
   type SpawnWorkerProcess,
+  type WorkerConfig,
+  type WorkerProcessExit,
   type WorkerProcessRequest,
 } from "./worker.js";
 
 const WORKTREE = ".border-collie/worktrees/ticket-4";
 const BRANCH = "border-collie/ticket-4";
 const TRANSCRIPT = ".border-collie/transcripts/ticket-4.jsonl";
+
+const CONFIG: WorkerConfig = { model: "sonnet", timeoutMs: 60_000, stallMs: 30_000 };
 
 /**
  * Fake the git side of the subprocess seam: reads are answered from fixtures,
@@ -35,7 +43,10 @@ function fakeExec(opts: { newCommits?: string; removeThrows?: boolean } = {}): {
   return { exec, calls };
 }
 
-function fakeSpawn(result: number | null | Error): {
+function fakeSpawn(
+  result: number | null | Error,
+  endedBy: WorkerProcessExit["endedBy"] = "exit",
+): {
   spawn: SpawnWorkerProcess;
   requests: WorkerProcessRequest[];
 } {
@@ -43,7 +54,7 @@ function fakeSpawn(result: number | null | Error): {
   const spawn: SpawnWorkerProcess = async (request) => {
     requests.push(request);
     if (result instanceof Error) throw result;
-    return result;
+    return { exitCode: result, endedBy };
   };
   return { spawn, requests };
 }
@@ -61,7 +72,7 @@ describe("dispatchWorker", () => {
     const { exec, calls } = fakeExec({ newCommits: "3" });
     const { spawn, requests } = fakeSpawn(0);
 
-    await dispatchWorker(4, { model: "sonnet" }, exec, spawn);
+    await dispatchWorker(4, CONFIG, exec, spawn);
 
     expect(calls).toEqual([
       ["git", "worktree", "remove", "--force", WORKTREE],
@@ -88,6 +99,8 @@ describe("dispatchWorker", () => {
         cwd: WORKTREE,
         transcriptPath: TRANSCRIPT,
         stderrPath: ".border-collie/transcripts/ticket-4.stderr.log",
+        timeoutMs: 60_000,
+        stallMs: 30_000,
       },
     ]);
   });
@@ -106,8 +119,8 @@ describe("dispatchWorker", () => {
     const { spawn } = fakeSpawn(0);
 
     const outcomes = await Promise.all([
-      dispatchWorker(1, { model: "sonnet" }, exec, spawn),
-      dispatchWorker(2, { model: "sonnet" }, exec, spawn),
+      dispatchWorker(1, CONFIG, exec, spawn),
+      dispatchWorker(2, CONFIG, exec, spawn),
     ]);
 
     const setupBlock = (ticket: number) => [
@@ -133,15 +146,17 @@ describe("dispatchWorker", () => {
     const { exec } = fakeExec({ newCommits: "3" });
     const { spawn } = fakeSpawn(0);
 
-    const outcome = await dispatchWorker(4, { model: "sonnet" }, exec, spawn);
+    const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
 
     expect(outcome).toEqual({
       ticket: 4,
       branch: BRANCH,
       base: "base-sha",
       transcript: TRANSCRIPT,
+      model: "sonnet",
       exitCode: 0,
       newCommits: 3,
+      failure: undefined,
       ok: true,
     });
   });
@@ -150,25 +165,43 @@ describe("dispatchWorker", () => {
     const { exec } = fakeExec({ newCommits: "0" });
     const { spawn } = fakeSpawn(0);
 
-    const outcome = await dispatchWorker(4, { model: "sonnet" }, exec, spawn);
+    const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
 
-    expect(outcome).toMatchObject({ ok: false, exitCode: 0, newCommits: 0 });
+    expect(outcome).toMatchObject({ ok: false, exitCode: 0, newCommits: 0, failure: "no-commits" });
   });
 
   it("fails the attempt on a non-zero exit even when commits exist", async () => {
     const { exec } = fakeExec({ newCommits: "2" });
     const { spawn } = fakeSpawn(1);
 
-    const outcome = await dispatchWorker(4, { model: "sonnet" }, exec, spawn);
+    const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
 
-    expect(outcome).toMatchObject({ ok: false, exitCode: 1, newCommits: 2 });
+    expect(outcome).toMatchObject({ ok: false, exitCode: 1, newCommits: 2, failure: "nonzero-exit" });
+  });
+
+  it("fails the attempt as a timeout when the process was killed at the wall clock, even with commits", async () => {
+    const { exec } = fakeExec({ newCommits: "2" });
+    const { spawn } = fakeSpawn(null, "timeout");
+
+    const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
+
+    expect(outcome).toMatchObject({ ok: false, newCommits: 2, failure: "timeout" });
+  });
+
+  it("fails the attempt as a stall when the process went quiet past the stall window", async () => {
+    const { exec } = fakeExec({ newCommits: "0" });
+    const { spawn } = fakeSpawn(null, "stall");
+
+    const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
+
+    expect(outcome).toMatchObject({ ok: false, failure: "stall" });
   });
 
   it("tolerates worktree-remove failures: no stale worktree before, best-effort cleanup after", async () => {
     const { exec } = fakeExec({ newCommits: "1", removeThrows: true });
     const { spawn } = fakeSpawn(0);
 
-    const outcome = await dispatchWorker(4, { model: "sonnet" }, exec, spawn);
+    const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
 
     expect(outcome.ok).toBe(true);
   });
@@ -177,7 +210,7 @@ describe("dispatchWorker", () => {
     const { exec, calls } = fakeExec();
     const { spawn } = fakeSpawn(new Error("spawn claude ENOENT"));
 
-    await expect(dispatchWorker(4, { model: "sonnet" }, exec, spawn)).rejects.toThrow("ENOENT");
+    await expect(dispatchWorker(4, CONFIG, exec, spawn)).rejects.toThrow("ENOENT");
 
     expect(calls.at(-1)).toEqual(["git", "worktree", "remove", "--force", WORKTREE]);
   });
@@ -186,7 +219,7 @@ describe("dispatchWorker", () => {
     const { exec } = fakeExec({ newCommits: "1" });
     const { spawn, requests } = fakeSpawn(0);
 
-    await dispatchWorker(7, { model: "opus" }, exec, spawn);
+    await dispatchWorker(7, { ...CONFIG, model: "opus" }, exec, spawn);
 
     expect(requests[0]?.args).toContain("opus");
   });
@@ -214,5 +247,51 @@ describe("branchCommitSubjects", () => {
 
     expect(calls).toEqual([["git", "log", "--format=%s", "--reverse", `base-sha..${BRANCH}`]]);
     expect(subjects).toEqual(["First commit", "Second commit"]);
+  });
+});
+
+/** Drive real node child processes through the seam with tiny windows. */
+describe("realSpawnWorkerProcess", () => {
+  function request(script: string, windows: { timeoutMs: number; stallMs: number }): WorkerProcessRequest {
+    const dir = mkdtempSync(join(tmpdir(), "border-collie-test-"));
+    return {
+      cmd: "node",
+      args: ["-e", script],
+      cwd: dir,
+      transcriptPath: join(dir, "transcript.jsonl"),
+      stderrPath: join(dir, "stderr.log"),
+      ...windows,
+    };
+  }
+
+  it("lets a clean exit through, streaming stdout to the transcript", async () => {
+    const req = request(`console.log("event")`, { timeoutMs: 5_000, stallMs: 5_000 });
+
+    const exit = await realSpawnWorkerProcess(req);
+
+    expect(exit).toEqual({ exitCode: 0, endedBy: "exit" });
+    expect(readFileSync(req.transcriptPath, "utf8")).toContain("event");
+  });
+
+  it("kills a process that outlives the wall-clock timeout even while it keeps emitting output", async () => {
+    const req = request(`setInterval(() => console.log("tick"), 20)`, {
+      timeoutMs: 300,
+      stallMs: 5_000,
+    });
+
+    const exit = await realSpawnWorkerProcess(req);
+
+    expect(exit.endedBy).toBe("timeout");
+  });
+
+  it("kills a process that goes quiet past the stall window", async () => {
+    const req = request(`console.log("hi"); setTimeout(() => {}, 60_000)`, {
+      timeoutMs: 5_000,
+      stallMs: 300,
+    });
+
+    const exit = await realSpawnWorkerProcess(req);
+
+    expect(exit.endedBy).toBe("stall");
   });
 });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -17,6 +17,12 @@ export const RUN_DIR = ".border-collie";
 export interface WorkerConfig {
   /** Model the Worker runs on (`claude --model`). */
   model: string;
+  /**
+   * Which Attempt this dispatch is (1-based). Namespaces the branch and
+   * transcript so a retry never clobbers the prior attempt's evidence — an
+   * Escalation must be able to cite every attempt's forensics.
+   */
+  attempt: number;
   /** Wall-clock ceiling for the whole Worker process. */
   timeoutMs: number;
   /** Max quiet time between output events before the Worker counts as stalled. */
@@ -26,6 +32,8 @@ export interface WorkerConfig {
 /** One finished Attempt, as observed by the Orchestrator. */
 export interface WorkerOutcome {
   ticket: number;
+  /** Attempt number the dispatch ran as, echoed from the config. */
+  attempt: number;
   /** Agent-prefixed branch the Worker committed to; retained after cleanup. */
   branch: string;
   /** Commit the branch was cut from; `base..branch` is the Attempt's work. */
@@ -176,10 +184,12 @@ export async function branchCommitSubjects(
  * each dispatch), never the local checkout: a ticket is Dispatchable only
  * once its blockers' PRs have merged, and that gating holds only if the
  * Worker's base contains those merges — the local checkout goes stale the
- * moment a sibling merges mid-run. `-B` and the up-front removal reset leftovers from a
- * crashed run or failed attempt — a local branch that never became a PR is
- * not recorded progress, so a fresh attempt supersedes it and the recovery
- * story stays "re-run the Tick".
+ * moment a sibling merges mid-run. Branch and transcript are namespaced per
+ * attempt so a retry leaves the failed attempt's evidence intact for
+ * Escalation. `-B` and the up-front removal reset leftovers of the SAME
+ * attempt from a crashed run — a local branch that never became a PR is not
+ * recorded progress (ADR 0001: GitHub is the only state store), so
+ * re-running the Tick supersedes it.
  */
 export async function dispatchWorker(
   ticket: number,
@@ -187,10 +197,14 @@ export async function dispatchWorker(
   exec: Exec = realExec,
   spawnProcess: SpawnWorkerProcess = realSpawnWorkerProcess,
 ): Promise<WorkerOutcome> {
-  const branch = `${AGENT_BRANCH_PREFIX}${ticket}`;
+  const branch = `${AGENT_BRANCH_PREFIX}${ticket}-attempt-${config.attempt}`;
   const worktree = join(RUN_DIR, "worktrees", `ticket-${ticket}`);
-  const transcript = join(RUN_DIR, "transcripts", `ticket-${ticket}.jsonl`);
-  const stderrLog = join(RUN_DIR, "transcripts", `ticket-${ticket}.stderr.log`);
+  const transcript = join(RUN_DIR, "transcripts", `ticket-${ticket}-attempt-${config.attempt}.jsonl`);
+  const stderrLog = join(
+    RUN_DIR,
+    "transcripts",
+    `ticket-${ticket}-attempt-${config.attempt}.stderr.log`,
+  );
 
   const base = await withGitLock(async () => {
     await removeWorktree(worktree, exec);
@@ -237,6 +251,7 @@ export async function dispatchWorker(
             : undefined;
     return {
       ticket,
+      attempt: config.attempt,
       branch,
       base,
       transcript,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { createWriteStream, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { realExec, type Exec } from "./tracker.js";
-import { AGENT_BRANCH_PREFIX } from "./types.js";
+import { AGENT_BRANCH_PREFIX, type FailureReason } from "./types.js";
 
 /**
  * The WorkerHost seam: everything a dispatched Worker needs around it —
@@ -17,6 +17,10 @@ export const RUN_DIR = ".border-collie";
 export interface WorkerConfig {
   /** Model the Worker runs on (`claude --model`). */
   model: string;
+  /** Wall-clock ceiling for the whole Worker process. */
+  timeoutMs: number;
+  /** Max quiet time between output events before the Worker counts as stalled. */
+  stallMs: number;
 }
 
 /** One finished Attempt, as observed by the Orchestrator. */
@@ -28,14 +32,17 @@ export interface WorkerOutcome {
   base: string;
   /** Transcript file path, for post-mortems. */
   transcript: string;
+  /** Model the attempt ran on, echoed into the attempt record on failure. */
+  model: string;
   exitCode: number | null;
   /** Commits on the branch beyond the base it was cut from. */
   newCommits: number;
   /**
-   * The success predicate: the process exited cleanly AND new commits exist.
-   * Anything else is a failed attempt (classified fully by the
-   * failure-handling ticket).
+   * Which ticket-failure trigger fired, or undefined on success. Exactly the
+   * four triggers: nonzero-exit, no-commits, timeout, stall.
    */
+  failure: FailureReason | undefined;
+  /** The success predicate: no failure trigger fired. */
   ok: boolean;
 }
 
@@ -48,10 +55,20 @@ export interface WorkerProcessRequest {
   transcriptPath: string;
   /** File the process's stderr streams into, kept apart so the transcript stays parseable. */
   stderrPath: string;
+  /** Wall-clock ceiling; the process is killed when it elapses. */
+  timeoutMs: number;
+  /** Stall window; the process is killed when stdout goes quiet this long. */
+  stallMs: number;
 }
 
-/** Process seam: run the Worker to completion, resolving with its exit code. */
-export type SpawnWorkerProcess = (request: WorkerProcessRequest) => Promise<number | null>;
+/** How the Worker process ended: on its own, or killed by which watchdog. */
+export interface WorkerProcessExit {
+  exitCode: number | null;
+  endedBy: "exit" | "timeout" | "stall";
+}
+
+/** Process seam: run the Worker to completion under both watchdogs. */
+export type SpawnWorkerProcess = (request: WorkerProcessRequest) => Promise<WorkerProcessExit>;
 
 export const realSpawnWorkerProcess: SpawnWorkerProcess = (request) =>
   new Promise((resolve, reject) => {
@@ -64,7 +81,27 @@ export const realSpawnWorkerProcess: SpawnWorkerProcess = (request) =>
     });
     child.stdout.pipe(transcript);
     child.stderr.pipe(stderr);
+
+    // SIGKILL, not SIGTERM: a stalled Worker may not be servicing signals.
+    let endedBy: WorkerProcessExit["endedBy"] = "exit";
+    const wallTimer = setTimeout(() => {
+      endedBy = "timeout";
+      child.kill("SIGKILL");
+    }, request.timeoutMs);
+    let stallTimer: NodeJS.Timeout | undefined;
+    const rearmStallWatchdog = () => {
+      clearTimeout(stallTimer);
+      stallTimer = setTimeout(() => {
+        endedBy = "stall";
+        child.kill("SIGKILL");
+      }, request.stallMs);
+    };
+    rearmStallWatchdog();
+    child.stdout.on("data", rearmStallWatchdog);
+
     const end = () => {
+      clearTimeout(wallTimer);
+      clearTimeout(stallTimer);
       transcript.end();
       stderr.end();
     };
@@ -74,7 +111,7 @@ export const realSpawnWorkerProcess: SpawnWorkerProcess = (request) =>
     });
     child.on("close", (code) => {
       end();
-      resolve(code);
+      resolve({ exitCode: code, endedBy });
     });
   });
 
@@ -167,7 +204,7 @@ export async function dispatchWorker(
     // Headless Workers cannot answer permission prompts; skipping them is
     // what confines the blast radius to the worktree plus the operator's
     // own tracker.
-    const exitCode = await spawnProcess({
+    const { exitCode, endedBy } = await spawnProcess({
       cmd: "claude",
       args: [
         "-p",
@@ -182,18 +219,32 @@ export async function dispatchWorker(
       cwd: worktree,
       transcriptPath: transcript,
       stderrPath: stderrLog,
+      timeoutMs: config.timeoutMs,
+      stallMs: config.stallMs,
     });
     const newCommits = Number(
       (await withGitLock(() => exec("git", ["rev-list", "--count", `${base}..${branch}`]))).trim(),
     );
+    // A killed Worker fails even with commits on the branch: it never got to
+    // finish, so the work is unverified and the PR description is missing.
+    const failure: FailureReason | undefined =
+      endedBy !== "exit"
+        ? endedBy
+        : exitCode !== 0
+          ? "nonzero-exit"
+          : newCommits === 0
+            ? "no-commits"
+            : undefined;
     return {
       ticket,
       branch,
       base,
       transcript,
+      model: config.model,
       exitCode,
       newCommits,
-      ok: exitCode === 0 && newCommits > 0,
+      failure,
+      ok: failure === undefined,
     };
   } finally {
     await withGitLock(() => removeWorktree(worktree, exec));


### PR DESCRIPTION
Closes #7.

## What this does

Every way a Worker can die is noticed, retried once with more capability, and finally escalated to a human with evidence — with attempt state derived entirely from the tracker (ADR 0001: GitHub is the only state store).

- **Four ticket-failure triggers** (`worker.ts`): non-zero exit, clean exit without new commits, wall-clock timeout, and stall. The timeout and stall watchdogs SIGKILL the headless `claude` process; both are covered by behavioral tests that kill real `node` child processes with tiny windows.
- **Stateless attempt history** (`tracker.ts`): a failed attempt releases its claim with a release comment embedding a hidden JSON attempt record (reason, model, transcript, abandoned branch). The observe phase counts claim-marker comments as the attempt counter and parses the records back — no local state.
- **Retry ladder** (`plan.ts`, `cli.ts`): spawn actions carry `attempt = claimCount + 1`; attempt two runs the stronger retry model (opus by default; `retry_model` config key / `--retry-model` flag). Timeout and stall windows are configurable (`worker_timeout_minutes`, default 45; `worker_stall_minutes`, default 10).
- **Escalation** (`plan.ts`, `tracker.ts`): at two claims the plan emits `escalate` instead of dispatch — forensic comment first (each attempt's failure reason, transcript location, abandoned branch), then the `ready-for-agent` → `ready-for-human` label swap. Comment-first ordering means a crash re-escalates next Tick instead of losing the forensics. Escalated tickets leave the dispatchable set by construction and stay open, so dependents remain blocked.
- **Evidence retention**: branches and transcripts are namespaced per attempt (`border-collie/ticket-N-attempt-K`), so a retry never clobbers the failed attempt's transcript or commits; the existing branch parser already tolerates the suffix.

## Deliberate choices

- Retry and escalation land on the **next Tick**, not within the failing one — cross-Tick policy is what keeps the Orchestrator stateless and idempotent (recovery story stays "re-run the Tick").
- Orphan-released claims burn attempts, per the acceptance criterion's literal wording (attempt counts derive from claim markers). Infrastructure-failure voiding and the circuit breaker are a later ticket; the escalation comment notes attempts with no failure record.
- `escalateTicket` does not unassign: only unassigned tickets qualify for escalation (every failure/orphan release unassigns first), so the glossary's "unassign" holds by construction.

## Testing

Policies (ladder, escalation criteria, ordering, slot accounting) tested at the pure plan seam; tracker and WorkerHost writes tested by faking the subprocess seam and asserting composed commands; watchdogs tested against real child processes. 85 tests, typecheck clean.

Note for merging: the in-progress PR-opening work (issue #5, uncommitted on main) touches `worker.ts`/`act.ts`/`tracker.ts` and will want the outcome's per-attempt branch name when reconciling.