### PR TITLE
PR upkeep: stale sibling updates, conflict Workers, draft to ready (issue #9)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,6 +45,14 @@ A failure caused by the environment — usage limit, rate limit, auth, network, 
 **Escalation**:
 Handing a ticket to a human after its attempts are exhausted: swap `ready-for-agent` → `ready-for-human`, unassign, leave a forensic comment. An escalated ticket stops being Dispatchable by construction; its dependents stay blocked.
 
+**PR upkeep**:
+Keeping the open agent PRs a merge left behind current, each Tick: a cleanly-mergeable PR that fell behind the base gets a mechanical branch update; a green (or CI-less) draft flips to ready-for-review; a conflicted PR gets a Conflict Worker.
+_Avoid_: rebase (the update is a merge, not a rebase)
+
+**Conflict Worker**:
+The one Worker variant dispatched against a PR rather than a Ticket: a fresh-context session, isolated in a worktree on the conflicted PR's own branch, that completes an in-progress merge of the base into it. One per conflict — on failure the PR gets a marker comment asking for a human (the PR-level analogue of Escalation), which vetoes any further session. It is not an Attempt and counts toward no ticket's cap.
+_Avoid_: conflict attempt (Attempts are ticket-scoped; this is not one)
+
 **Complete**:
 Terminal state of a run: every ticket in Scope merged and closed.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -46,11 +46,11 @@ A failure caused by the environment — usage limit, rate limit, auth, network, 
 Handing a ticket to a human after its attempts are exhausted: swap `ready-for-agent` → `ready-for-human`, unassign, leave a forensic comment. An escalated ticket stops being Dispatchable by construction; its dependents stay blocked.
 
 **PR upkeep**:
-Keeping the open agent PRs a merge left behind current, each Tick: a cleanly-mergeable PR that fell behind the base gets a mechanical branch update; a green (or CI-less) draft flips to ready-for-review; a conflicted PR gets a Conflict Worker.
-_Avoid_: rebase (the update is a merge, not a rebase)
+Keeping the open agent PRs a merge left behind current, each Tick: a cleanly-mergeable PR that fell behind the base gets a mechanical rebase onto the base; a green (or CI-less) draft flips to ready-for-review; a conflicted PR gets a Conflict Worker.
+_Avoid_: merge commit (every update is a rebase, keeping agent branches linear so the "Rebase and merge" strategy stays available)
 
 **Conflict Worker**:
-The one Worker variant dispatched against a PR rather than a Ticket: a fresh-context session, isolated in a worktree on the conflicted PR's own branch, that completes an in-progress merge of the base into it. One per conflict — on failure the PR gets a marker comment asking for a human (the PR-level analogue of Escalation), which vetoes any further session. It is not an Attempt and counts toward no ticket's cap.
+The one Worker variant dispatched against a PR rather than a Ticket: a fresh-context session, isolated in a worktree on the conflicted PR's own branch, that completes an in-progress rebase of it onto the base. One per conflict — on failure the PR gets a marker comment asking for a human (the PR-level analogue of Escalation), which vetoes any further session. It is not an Attempt and counts toward no ticket's cap.
 _Avoid_: conflict attempt (Attempts are ticket-scoped; this is not one)
 
 **Complete**:

--- a/src/act.test.ts
+++ b/src/act.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { act, type DispatchWorker, type OpenPr } from "./act.js";
+import { act, type DispatchConflictWorker, type DispatchWorker, type OpenPr } from "./act.js";
 import type { Exec } from "./tracker.js";
 import {
   attemptMarker,
   CLAIM_MARKER,
+  CONFLICT_UNRESOLVED_MARKER,
   RELEASE_MARKER,
   VOID_MARKER,
   type AttemptFailure,
 } from "./types.js";
-import type { WorkerOutcome } from "./worker.js";
+import type { ConflictOutcome, WorkerOutcome } from "./worker.js";
 
 function recordingExec(): { exec: Exec; calls: string[][] } {
   const calls: string[][] = [];
@@ -21,6 +22,10 @@ function recordingExec(): { exec: Exec; calls: string[][] } {
 
 const noDispatch: DispatchWorker = async (ticket) => {
   throw new Error(`unexpected dispatch of #${ticket}`);
+};
+
+const noConflict: DispatchConflictWorker = async (pr) => {
+  throw new Error(`unexpected conflict dispatch of PR #${pr}`);
 };
 
 /** Records which outcomes reach PR opening; answers with a predictable URL. */
@@ -53,6 +58,18 @@ function outcome(ticket: number, overrides: Partial<WorkerOutcome> = {}): Worker
   };
 }
 
+function conflictOutcome(pr: number, overrides: Partial<ConflictOutcome> = {}): ConflictOutcome {
+  return {
+    pr,
+    ticket: pr,
+    headRef: `border-collie/ticket-${pr}-attempt-1`,
+    transcript: `.border-collie/transcripts/pr-${pr}-conflict.jsonl`,
+    exitCode: 0,
+    resolved: true,
+    ...overrides,
+  };
+}
+
 describe("act", () => {
   it("executes releases and claims in plan order via the tracker", async () => {
     const { exec, calls } = recordingExec();
@@ -66,6 +83,7 @@ describe("act", () => {
       ],
       noDispatch,
       openPr,
+      noConflict,
       exec,
       (line) => lines.push(line),
     );
@@ -88,6 +106,7 @@ describe("act", () => {
       [{ type: "close", ticket: 6, prUrl: "https://github.com/o/r/pull/60" }],
       noDispatch,
       openPr,
+      noConflict,
       exec,
       (line) => lines.push(line),
     );
@@ -109,7 +128,7 @@ describe("act", () => {
     const { exec, calls } = recordingExec();
     const { openPr } = recordingOpenPr();
 
-    await act([], noDispatch, openPr, exec, () => {});
+    await act([], noDispatch, openPr, noConflict, exec, () => {});
 
     expect(calls).toEqual([]);
   });
@@ -142,6 +161,7 @@ describe("act", () => {
       ],
       dispatch,
       openPr,
+      noConflict,
       exec,
       (line) => lines.push(line),
     );
@@ -168,7 +188,14 @@ describe("act", () => {
       return outcome(ticket);
     };
 
-    await act([{ type: "spawn", ticket: 7, attempt: 2 }], dispatch, recordingOpenPr().openPr, exec, () => {});
+    await act(
+      [{ type: "spawn", ticket: 7, attempt: 2 }],
+      dispatch,
+      recordingOpenPr().openPr,
+      noConflict,
+      exec,
+      () => {},
+    );
 
     expect(attempts).toEqual([[7, 2]]);
   });
@@ -178,7 +205,14 @@ describe("act", () => {
     const dispatch: DispatchWorker = async () =>
       outcome(7, { attempt: 2, exitCode: null, failure: "stall", ok: false });
 
-    await act([{ type: "spawn", ticket: 7, attempt: 2 }], dispatch, recordingOpenPr().openPr, exec, () => {});
+    await act(
+      [{ type: "spawn", ticket: 7, attempt: 2 }],
+      dispatch,
+      recordingOpenPr().openPr,
+      noConflict,
+      exec,
+      () => {},
+    );
 
     const record: AttemptFailure = {
       attempt: 2,
@@ -197,7 +231,14 @@ describe("act", () => {
     const { exec, calls } = recordingExec();
     const dispatch: DispatchWorker = async () => outcome(7);
 
-    await act([{ type: "spawn", ticket: 7, attempt: 1 }], dispatch, recordingOpenPr().openPr, exec, () => {});
+    await act(
+      [{ type: "spawn", ticket: 7, attempt: 1 }],
+      dispatch,
+      recordingOpenPr().openPr,
+      noConflict,
+      exec,
+      () => {},
+    );
 
     expect(calls).toEqual([]);
   });
@@ -219,6 +260,7 @@ describe("act", () => {
       [{ type: "escalate", ticket: 5, failures }],
       noDispatch,
       recordingOpenPr().openPr,
+      noConflict,
       exec,
       (line) => lines.push(line),
     );
@@ -246,7 +288,7 @@ describe("act", () => {
     const dispatch: DispatchWorker = async () =>
       outcome(7, { costUsd: 25.5, turns: 80, costOverrun: true });
 
-    await act([{ type: "spawn", ticket: 7, attempt: 1 }], dispatch, openPr, exec, (line) =>
+    await act([{ type: "spawn", ticket: 7, attempt: 1 }], dispatch, openPr, noConflict, exec, (line) =>
       lines.push(line),
     );
 
@@ -267,6 +309,7 @@ describe("act", () => {
       [{ type: "spawn", ticket: 7, attempt: 1 }],
       dispatch,
       recordingOpenPr().openPr,
+      noConflict,
       exec,
       (line) => lines.push(line),
     );
@@ -291,6 +334,7 @@ describe("act", () => {
       ],
       dispatch,
       recordingOpenPr().openPr,
+      noConflict,
       exec,
       (line) => lines.push(line),
     );
@@ -313,6 +357,7 @@ describe("act", () => {
       [{ type: "spawn", ticket: 2, attempt: 1 }],
       dispatch,
       recordingOpenPr().openPr,
+      noConflict,
       exec,
       () => {},
     );
@@ -337,6 +382,7 @@ describe("act", () => {
         ],
         dispatch,
         openPr,
+        noConflict,
         exec,
         (line) => lines.push(line),
       ),
@@ -356,8 +402,170 @@ describe("act", () => {
     };
 
     await expect(
-      act([{ type: "spawn", ticket: 2, attempt: 1 }], dispatch, openPr, exec, (line) => lines.push(line)),
+      act(
+        [{ type: "spawn", ticket: 2, attempt: 1 }],
+        dispatch,
+        openPr,
+        noConflict,
+        exec,
+        (line) => lines.push(line),
+      ),
     ).rejects.toThrow("gh pr create exploded");
+
+    expect(lines).toContain(
+      "Worker for #2 succeeded: 2 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
+    );
+  });
+});
+
+describe("act: PR upkeep", () => {
+  it("mechanically updates a behind PR's branch via the tracker", async () => {
+    const { exec, calls } = recordingExec();
+    const lines: string[] = [];
+
+    await act(
+      [{ type: "update-branch", pr: 30, ticket: 3 }],
+      noDispatch,
+      recordingOpenPr().openPr,
+      noConflict,
+      exec,
+      (line) => lines.push(line),
+    );
+
+    expect(calls).toEqual([
+      ["gh", "api", "--method", "PUT", "repos/{owner}/{repo}/pulls/30/update-branch"],
+    ]);
+    expect(lines).toEqual(["updated PR #30 branch (mechanical merge of the base)"]);
+  });
+
+  it("flips a green draft PR to ready for review via the tracker", async () => {
+    const { exec, calls } = recordingExec();
+    const lines: string[] = [];
+
+    await act(
+      [{ type: "mark-ready", pr: 30, ticket: 3 }],
+      noDispatch,
+      recordingOpenPr().openPr,
+      noConflict,
+      exec,
+      (line) => lines.push(line),
+    );
+
+    expect(calls).toEqual([["gh", "pr", "ready", "30"]]);
+    expect(lines).toEqual(["marked PR #30 ready for review"]);
+  });
+
+  it("pushes the branch when the conflict Worker resolves the merge", async () => {
+    const { exec, calls } = recordingExec();
+    const lines: string[] = [];
+    const dispatchConflict: DispatchConflictWorker = async (pr, ticket, headRef) =>
+      conflictOutcome(pr, { ticket, headRef, resolved: true });
+
+    await act(
+      [{ type: "conflict-worker", pr: 30, ticket: 3, headRef: "border-collie/ticket-3-attempt-1" }],
+      noDispatch,
+      recordingOpenPr().openPr,
+      dispatchConflict,
+      exec,
+      (line) => lines.push(line),
+    );
+
+    expect(calls).toEqual([
+      ["git", "push", "--force", "origin", "border-collie/ticket-3-attempt-1"],
+    ]);
+    expect(lines).toEqual([
+      "dispatched conflict Worker for PR #30 (ticket #3)",
+      "Conflict Worker for PR #30 resolved the merge on border-collie/ticket-3-attempt-1 (transcript: .border-collie/transcripts/pr-30-conflict.jsonl)",
+      "pushed the resolved merge for PR #30",
+    ]);
+  });
+
+  it("asks for human resolution when the conflict Worker gives up (no push)", async () => {
+    const { exec, calls } = recordingExec();
+    const lines: string[] = [];
+    const dispatchConflict: DispatchConflictWorker = async (pr, ticket, headRef) =>
+      conflictOutcome(pr, { ticket, headRef, exitCode: 1, resolved: false });
+
+    await act(
+      [{ type: "conflict-worker", pr: 30, ticket: 3, headRef: "border-collie/ticket-3-attempt-1" }],
+      noDispatch,
+      recordingOpenPr().openPr,
+      dispatchConflict,
+      exec,
+      (line) => lines.push(line),
+    );
+
+    expect(calls).toEqual([
+      ["gh", "pr", "comment", "30", "--body", expect.stringContaining(CONFLICT_UNRESOLVED_MARKER)],
+    ]);
+    expect(lines).toEqual([
+      "dispatched conflict Worker for PR #30 (ticket #3)",
+      "Conflict Worker for PR #30 could not resolve the merge (exit 1) on border-collie/ticket-3-attempt-1 (transcript: .border-collie/transcripts/pr-30-conflict.jsonl)",
+      "asked for human resolution on PR #30",
+    ]);
+  });
+
+  it("runs conflict Workers concurrently with dispatch Workers and reports both", async () => {
+    const { exec } = recordingExec();
+    const lines: string[] = [];
+    const inFlight: string[] = [];
+    let bothInFlight!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      bothInFlight = resolve;
+    });
+    const dispatch: DispatchWorker = async (ticket) => {
+      inFlight.push(`worker-${ticket}`);
+      if (inFlight.length === 2) bothInFlight();
+      await gate;
+      return outcome(ticket);
+    };
+    const dispatchConflict: DispatchConflictWorker = async (pr, ticket, headRef) => {
+      inFlight.push(`conflict-${pr}`);
+      if (inFlight.length === 2) bothInFlight();
+      await gate;
+      return conflictOutcome(pr, { ticket, headRef, resolved: true });
+    };
+
+    await act(
+      [
+        { type: "conflict-worker", pr: 40, ticket: 4, headRef: "border-collie/ticket-4-attempt-1" },
+        { type: "spawn", ticket: 2, attempt: 1 },
+      ],
+      dispatch,
+      recordingOpenPr().openPr,
+      dispatchConflict,
+      exec,
+      (line) => lines.push(line),
+    );
+
+    expect(inFlight.sort()).toEqual(["conflict-40", "worker-2"]);
+    expect(lines).toContain("pushed the resolved merge for PR #40");
+    expect(lines).toContain(
+      "Worker for #2 succeeded: 2 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
+    );
+  });
+
+  it("reports settled Workers before rethrowing a conflict Worker's infrastructure failure", async () => {
+    const { exec } = recordingExec();
+    const lines: string[] = [];
+    const dispatch: DispatchWorker = async (ticket) => outcome(ticket);
+    const dispatchConflict: DispatchConflictWorker = async () => {
+      throw new Error("claude ENOENT");
+    };
+
+    await expect(
+      act(
+        [
+          { type: "conflict-worker", pr: 40, ticket: 4, headRef: "border-collie/ticket-4-attempt-1" },
+          { type: "spawn", ticket: 2, attempt: 1 },
+        ],
+        dispatch,
+        recordingOpenPr().openPr,
+        dispatchConflict,
+        exec,
+        (line) => lines.push(line),
+      ),
+    ).rejects.toThrow("claude ENOENT");
 
     expect(lines).toContain(
       "Worker for #2 succeeded: 2 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",

--- a/src/act.test.ts
+++ b/src/act.test.ts
@@ -433,9 +433,9 @@ describe("act: PR upkeep", () => {
     );
 
     expect(calls).toEqual([
-      ["gh", "api", "--method", "PUT", "repos/{owner}/{repo}/pulls/30/update-branch"],
+      ["gh", "pr", "update-branch", "30", "--rebase"],
     ]);
-    expect(lines).toEqual(["updated PR #30 branch (mechanical merge of the base)"]);
+    expect(lines).toEqual(["updated PR #30 branch (mechanical rebase onto the base)"]);
   });
 
   it("flips a green draft PR to ready for review via the tracker", async () => {
@@ -475,8 +475,8 @@ describe("act: PR upkeep", () => {
     ]);
     expect(lines).toEqual([
       "dispatched conflict Worker for PR #30 (ticket #3)",
-      "Conflict Worker for PR #30 resolved the merge on border-collie/ticket-3-attempt-1 (transcript: .border-collie/transcripts/pr-30-conflict.jsonl)",
-      "pushed the resolved merge for PR #30",
+      "Conflict Worker for PR #30 resolved the conflicts on border-collie/ticket-3-attempt-1 (transcript: .border-collie/transcripts/pr-30-conflict.jsonl)",
+      "pushed the resolved rebase for PR #30",
     ]);
   });
 
@@ -500,7 +500,7 @@ describe("act: PR upkeep", () => {
     ]);
     expect(lines).toEqual([
       "dispatched conflict Worker for PR #30 (ticket #3)",
-      "Conflict Worker for PR #30 could not resolve the merge (exit 1) on border-collie/ticket-3-attempt-1 (transcript: .border-collie/transcripts/pr-30-conflict.jsonl)",
+      "Conflict Worker for PR #30 could not resolve the conflicts (exit 1) on border-collie/ticket-3-attempt-1 (transcript: .border-collie/transcripts/pr-30-conflict.jsonl)",
       "asked for human resolution on PR #30",
     ]);
   });
@@ -539,7 +539,7 @@ describe("act: PR upkeep", () => {
     );
 
     expect(inFlight.sort()).toEqual(["conflict-40", "worker-2"]);
-    expect(lines).toContain("pushed the resolved merge for PR #40");
+    expect(lines).toContain("pushed the resolved rebase for PR #40");
     expect(lines).toContain(
       "Worker for #2 succeeded: 2 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
     );

--- a/src/act.ts
+++ b/src/act.ts
@@ -58,8 +58,8 @@ export interface ActReport {
 function describeConflict(outcome: ConflictOutcome): string {
   const where = `on ${outcome.headRef} (transcript: ${outcome.transcript})`;
   return outcome.resolved
-    ? `Conflict Worker for PR #${outcome.pr} resolved the merge ${where}`
-    : `Conflict Worker for PR #${outcome.pr} could not resolve the merge (exit ${outcome.exitCode}) ${where}`;
+    ? `Conflict Worker for PR #${outcome.pr} resolved the conflicts ${where}`
+    : `Conflict Worker for PR #${outcome.pr} could not resolve the conflicts (exit ${outcome.exitCode}) ${where}`;
 }
 
 /**
@@ -78,8 +78,8 @@ function describeConflict(outcome: ConflictOutcome): string {
  * stateless recovery story is re-running the Tick, which recomputes the
  * world and re-plans whatever is still due. PR upkeep runs alongside dispatch:
  * the mechanical branch update and draft→ready flip are immediate tracker
- * writes; a conflict Worker runs concurrently like a spawn, its resolved merge
- * pushed (or the PR handed to a human) once it settles.
+ * writes; a conflict Worker runs concurrently like a spawn, its resolved
+ * rebase pushed (or the PR handed to a human) once it settles.
  */
 export async function act(
   actions: Action[],
@@ -111,7 +111,7 @@ export async function act(
         break;
       case "update-branch":
         await updatePrBranch(action.pr, exec);
-        log(`updated PR #${action.pr} branch (mechanical merge of the base)`);
+        log(`updated PR #${action.pr} branch (mechanical rebase onto the base)`);
         break;
       case "mark-ready":
         await markPrReady(action.pr, exec);
@@ -196,7 +196,7 @@ export async function act(
     log(describeConflict(outcome));
     if (outcome.resolved) {
       await pushAgentBranch(outcome.headRef, exec);
-      log(`pushed the resolved merge for PR #${outcome.pr}`);
+      log(`pushed the resolved rebase for PR #${outcome.pr}`);
     } else {
       await commentConflictUnresolved(outcome.pr, exec);
       log(`asked for human resolution on PR #${outcome.pr}`);

--- a/src/act.ts
+++ b/src/act.ts
@@ -2,15 +2,18 @@ import { reclassifyCorrelatedFailures } from "./classify.js";
 import {
   claimTicket,
   closeTicket,
+  commentConflictUnresolved,
   escalateTicket,
+  markPrReady,
   realExec,
   releaseFailedTicket,
   releaseTicket,
+  updatePrBranch,
   voidAttempt,
   type Exec,
 } from "./tracker.js";
 import type { Action } from "./types.js";
-import type { WorkerOutcome } from "./worker.js";
+import { pushAgentBranch, type ConflictOutcome, type WorkerOutcome } from "./worker.js";
 
 /**
  * Dispatch one Worker against one claimed ticket; the caller binds the
@@ -20,6 +23,13 @@ export type DispatchWorker = (ticket: number, attempt: number) => Promise<Worker
 
 /** Open the draft PR for a successful Attempt; resolves with the PR URL. */
 export type OpenPr = (outcome: WorkerOutcome) => Promise<string>;
+
+/** Dispatch one conflict-resolution Worker against one conflicted agent PR. */
+export type DispatchConflictWorker = (
+  pr: number,
+  ticket: number,
+  headRef: string,
+) => Promise<ConflictOutcome>;
 
 /** What one spawn action came to: the Attempt, and its PR when one was opened. */
 interface SpawnResult {
@@ -45,6 +55,13 @@ export interface ActReport {
   infraFailures: number;
 }
 
+function describeConflict(outcome: ConflictOutcome): string {
+  const where = `on ${outcome.headRef} (transcript: ${outcome.transcript})`;
+  return outcome.resolved
+    ? `Conflict Worker for PR #${outcome.pr} resolved the merge ${where}`
+    : `Conflict Worker for PR #${outcome.pr} could not resolve the merge (exit ${outcome.exitCode}) ${where}`;
+}
+
 /**
  * Act phase: perform the planned writes in plan order (releases first), one
  * at a time, narrating each as it lands. Spawns are the exception: each
@@ -59,16 +76,21 @@ export interface ActReport {
  * deaths once every Worker has settled. The report's infra count is what
  * trips the caller's circuit breaker. A tracker failure mid-way throws — the
  * stateless recovery story is re-running the Tick, which recomputes the
- * world and re-plans whatever is still due.
+ * world and re-plans whatever is still due. PR upkeep runs alongside dispatch:
+ * the mechanical branch update and draft→ready flip are immediate tracker
+ * writes; a conflict Worker runs concurrently like a spawn, its resolved merge
+ * pushed (or the PR handed to a human) once it settles.
  */
 export async function act(
   actions: Action[],
   dispatch: DispatchWorker,
   openPr: OpenPr,
+  dispatchConflict: DispatchConflictWorker,
   exec: Exec = realExec,
   log: (line: string) => void = console.log,
 ): Promise<ActReport> {
   const workers: Promise<SpawnResult>[] = [];
+  const conflicts: Promise<ConflictOutcome>[] = [];
   for (const action of actions) {
     switch (action.type) {
       case "claim":
@@ -86,6 +108,18 @@ export async function act(
       case "close":
         await closeTicket(action.ticket, action.prUrl, exec);
         log(`closed #${action.ticket} (merged: ${action.prUrl})`);
+        break;
+      case "update-branch":
+        await updatePrBranch(action.pr, exec);
+        log(`updated PR #${action.pr} branch (mechanical merge of the base)`);
+        break;
+      case "mark-ready":
+        await markPrReady(action.pr, exec);
+        log(`marked PR #${action.pr} ready for review`);
+        break;
+      case "conflict-worker":
+        conflicts.push(dispatchConflict(action.pr, action.ticket, action.headRef));
+        log(`dispatched conflict Worker for PR #${action.pr} (ticket #${action.ticket})`);
         break;
       case "spawn":
         workers.push(
@@ -151,8 +185,28 @@ export async function act(
       );
     }
   }
+  // Conflict Workers settle alongside the dispatch Workers: a resolved merge is
+  // pushed to the PR's branch, an unresolved one handed to a human with the
+  // marker that vetoes a second Worker. Both writes are reported before any
+  // infrastructure failure on either fleet rethrows.
+  const settledConflicts = await Promise.allSettled(conflicts);
+  for (const result of settledConflicts) {
+    if (result.status !== "fulfilled") continue;
+    const outcome = result.value;
+    log(describeConflict(outcome));
+    if (outcome.resolved) {
+      await pushAgentBranch(outcome.headRef, exec);
+      log(`pushed the resolved merge for PR #${outcome.pr}`);
+    } else {
+      await commentConflictUnresolved(outcome.pr, exec);
+      log(`asked for human resolution on PR #${outcome.pr}`);
+    }
+  }
+
   const rejected = settled.find((result) => result.status === "rejected");
   if (rejected) throw rejected.reason;
+  const rejectedConflict = settledConflicts.find((result) => result.status === "rejected");
+  if (rejectedConflict) throw rejectedConflict.reason;
   for (const result of settled) {
     if (result.status === "fulfilled" && result.value.prFailure !== undefined) {
       throw result.value.prFailure;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,20 +14,23 @@ import { openPrForOutcome } from "./pr.js";
 import { renderPlan } from "./render.js";
 import { run } from "./run.js";
 import { readScope } from "./tracker.js";
-import { dispatchWorker, probeEnvironment } from "./worker.js";
+import { dispatchConflictWorker, dispatchWorker, probeEnvironment } from "./worker.js";
 import type { Action, WorldSnapshot } from "./types.js";
 
 const USAGE = `Usage: border-collie <tick|run> [options]
 
 tick runs one idempotent pass against the target repo in the current working
-directory: close tickets whose agent PR merged without closing them, release
-orphaned agent claims, claim dispatchable tickets (assign + marker comment),
-then dispatch one Worker per claim — an isolated worktree on an agent branch,
-running headless claude against exactly that ticket — and report each
-Worker's outcome. A successful Worker's branch is pushed and opened as a
-draft PR that closes its ticket on merge, its body taken from the Worker's
-final message (mechanical fallback: ticket + commit subjects). Dispatch
-pauses while open agent PRs sit at max_open_prs and resumes as merges land.
+directory: close tickets whose agent PR merged without closing them, keep the
+remaining open agent PRs current (mechanical branch update for clean ones that
+fell behind, a one-shot conflict-resolution Worker for conflicted ones, and a
+draft→ready flip once CI is green), release orphaned agent claims, claim
+dispatchable tickets (assign + marker comment), then dispatch one Worker per
+claim — an isolated worktree on an agent branch, running headless claude
+against exactly that ticket — and report each Worker's outcome. A successful
+Worker's branch is pushed and opened as a draft PR that closes its ticket on
+merge, its body taken from the Worker's final message (mechanical fallback:
+ticket + commit subjects). Dispatch pauses while open agent PRs sit at
+max_open_prs and resumes as merges land.
 
 run repeats ticks at the poll interval until a terminal state: Complete
 (every ticket in Scope closed, exit 0) or Stuck (open tickets remain but
@@ -98,6 +101,13 @@ async function tickOnce(
           maxCostUsd: config.maxCostUsd,
         }),
       (outcome) => openPrForOutcome(outcome, titles.get(outcome.ticket) ?? `Ticket #${outcome.ticket}`),
+      (pr, ticket, headRef) =>
+        dispatchConflictWorker(pr, ticket, headRef, {
+          model: config.model,
+          timeoutMs: config.timeoutMinutes * 60_000,
+          stallMs: config.stallMinutes * 60_000,
+          maxTurns: config.maxTurns,
+        }),
     );
     infraFailures = report.infraFailures;
   }

--- a/src/plan.test.ts
+++ b/src/plan.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { plan } from "./plan.js";
-import type { AttemptFailure, MergedAgentPr, Ticket, WorldSnapshot } from "./types.js";
+import type {
+  AttemptFailure,
+  MergedAgentPr,
+  OpenAgentPr,
+  Ticket,
+  WorldSnapshot,
+} from "./types.js";
 
 function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
   return {
@@ -26,12 +32,32 @@ function failure(attempt: number): AttemptFailure {
   };
 }
 
+/** A clean, current, non-draft open agent PR — the backdrop that triggers no upkeep. */
+function openPr(ticket: number, overrides: Partial<OpenAgentPr> = {}): OpenAgentPr {
+  return {
+    number: ticket * 10,
+    ticket,
+    headRef: `border-collie/ticket-${ticket}-attempt-1`,
+    draft: false,
+    mergeable: "mergeable",
+    behind: false,
+    ci: "passing",
+    conflictWorkerAsked: false,
+    ...overrides,
+  };
+}
+
 function world(
   tickets: Ticket[],
   openAgentPrTickets: number[] = [],
   mergedAgentPrs: MergedAgentPr[] = [],
 ): WorldSnapshot {
-  return { tickets, openAgentPrTickets, mergedAgentPrs };
+  return { tickets, openAgentPrs: openAgentPrTickets.map((t) => openPr(t)), mergedAgentPrs };
+}
+
+/** A world whose open agent PRs are given in full — for the PR-upkeep cases. */
+function worldWithPrs(tickets: Ticket[], openAgentPrs: OpenAgentPr[]): WorldSnapshot {
+  return { tickets, openAgentPrs, mergedAgentPrs: [] };
 }
 
 function mergedPr(ticket: number): MergedAgentPr {
@@ -430,6 +456,185 @@ describe("plan: circuit breaker", () => {
     expect(plan(world([voided]), { maxWorkers: 3, maxOpenPrs: 5 })).toEqual([
       { type: "claim", ticket: 4 },
       { type: "spawn", ticket: 4, attempt: 1 },
+    ]);
+  });
+});
+
+describe("plan: PR upkeep", () => {
+  it("plans no upkeep for a clean, current, non-draft PR", () => {
+    const actions = plan(
+      worldWithPrs([ticket({ number: 3, assignees: ["operator"], hasAgentClaim: true })], [openPr(3)]),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it("mechanically updates a cleanly-mergeable PR that has fallen behind the base", () => {
+    const actions = plan(
+      worldWithPrs(
+        [ticket({ number: 3, assignees: ["operator"], hasAgentClaim: true })],
+        [openPr(3, { number: 30, behind: true })],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([{ type: "update-branch", pr: 30, ticket: 3 }]);
+  });
+
+  it("dispatches one conflict Worker for a conflicted PR with no human ask yet", () => {
+    const actions = plan(
+      worldWithPrs(
+        [ticket({ number: 3, assignees: ["operator"], hasAgentClaim: true })],
+        [openPr(3, { number: 30, mergeable: "conflicted" })],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([
+      { type: "conflict-worker", pr: 30, ticket: 3, headRef: "border-collie/ticket-3-attempt-1" },
+    ]);
+  });
+
+  it("never re-dispatches a conflict Worker once one has asked for a human", () => {
+    const actions = plan(
+      worldWithPrs(
+        [ticket({ number: 3, assignees: ["operator"], hasAgentClaim: true })],
+        [openPr(3, { number: 30, mergeable: "conflicted", conflictWorkerAsked: true })],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it("neither updates nor readies a conflicted PR (conflict handling is exclusive)", () => {
+    const actions = plan(
+      worldWithPrs(
+        [ticket({ number: 3, assignees: ["operator"], hasAgentClaim: true })],
+        [openPr(3, { number: 30, mergeable: "conflicted", behind: true, draft: true, conflictWorkerAsked: true })],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it("plans no branch update while GitHub is still computing mergeability", () => {
+    // A ready (non-draft) PR with unknown mergeability: we cannot tell whether
+    // it is behind, so neither update nor ready is due — leave it for next Tick.
+    const actions = plan(
+      worldWithPrs(
+        [ticket({ number: 3, assignees: ["operator"], hasAgentClaim: true })],
+        [openPr(3, { number: 30, mergeable: "unknown", draft: false })],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it("still flips a green draft to ready even while mergeability is unknown", () => {
+    // draft→ready is decided on CI alone; a fresh no-CI draft need not wait for
+    // GitHub to finish computing whether it is behind.
+    const actions = plan(
+      worldWithPrs(
+        [ticket({ number: 3, assignees: ["operator"], hasAgentClaim: true })],
+        [openPr(3, { number: 30, mergeable: "unknown", draft: true, ci: "none" })],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([{ type: "mark-ready", pr: 30, ticket: 3 }]);
+  });
+
+  it("flips a green draft to ready for review", () => {
+    const actions = plan(
+      worldWithPrs(
+        [ticket({ number: 3, assignees: ["operator"], hasAgentClaim: true })],
+        [openPr(3, { number: 30, draft: true, ci: "passing" })],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([{ type: "mark-ready", pr: 30, ticket: 3 }]);
+  });
+
+  it("flips a draft immediately when the repo has no CI configured", () => {
+    const actions = plan(
+      worldWithPrs(
+        [ticket({ number: 3, assignees: ["operator"], hasAgentClaim: true })],
+        [openPr(3, { number: 30, draft: true, ci: "none" })],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([{ type: "mark-ready", pr: 30, ticket: 3 }]);
+  });
+
+  it("does not flip a draft while CI is pending or failing", () => {
+    const actions = plan(
+      worldWithPrs(
+        [
+          ticket({ number: 3, assignees: ["operator"], hasAgentClaim: true }),
+          ticket({ number: 4, assignees: ["operator"], hasAgentClaim: true }),
+        ],
+        [
+          openPr(3, { number: 30, draft: true, ci: "pending" }),
+          openPr(4, { number: 40, draft: true, ci: "failing" }),
+        ],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it("updates a behind draft this tick and defers the ready flip to the next", () => {
+    const actions = plan(
+      worldWithPrs(
+        [ticket({ number: 3, assignees: ["operator"], hasAgentClaim: true })],
+        [openPr(3, { number: 30, draft: true, behind: true, ci: "passing" })],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([{ type: "update-branch", pr: 30, ticket: 3 }]);
+  });
+
+  it("does not mark a non-draft (already ready) PR ready again", () => {
+    const actions = plan(
+      worldWithPrs(
+        [ticket({ number: 3, assignees: ["operator"], hasAgentClaim: true })],
+        [openPr(3, { number: 30, draft: false, ci: "passing" })],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it("plans PR upkeep after closes and before releases, lowest PR number first", () => {
+    const actions = plan(
+      {
+        tickets: [
+          ticket({ number: 2, assignees: ["operator"], hasAgentClaim: true }),
+          ticket({ number: 5, assignees: ["operator"], hasAgentClaim: true }),
+          ticket({ number: 7, assignees: ["operator"], hasAgentClaim: true }),
+        ],
+        openAgentPrs: [
+          openPr(7, { number: 70, behind: true }),
+          openPr(5, { number: 50, draft: true, ci: "none" }),
+        ],
+        mergedAgentPrs: [mergedPr(2)],
+      },
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([
+      { type: "close", ticket: 2, prUrl: "https://github.com/o/r/pull/20" },
+      { type: "mark-ready", pr: 50, ticket: 5 },
+      { type: "update-branch", pr: 70, ticket: 7 },
     ]);
   });
 });

--- a/src/plan.ts
+++ b/src/plan.ts
@@ -39,13 +39,23 @@ export function dispatchableSet(world: WorldSnapshot): Ticket[] {
  * back to unassigned; it rejoins the dispatchable set on the next Tick's
  * recomputed snapshot.
  */
+/** True when a ticket has an open agent PR — the work may still land. */
+function hasOpenAgentPr(world: WorldSnapshot, ticket: number): boolean {
+  return world.openAgentPrs.some((pr) => pr.ticket === ticket);
+}
+
+/** True when a ticket has a merged agent PR — the work landed; only closure is pending. */
+function hasMergedAgentPr(world: WorldSnapshot, ticket: number): boolean {
+  return world.mergedAgentPrs.some((pr) => pr.ticket === ticket);
+}
+
 function isOrphanedClaim(ticket: Ticket, world: WorldSnapshot): boolean {
   return (
     ticket.state === "open" &&
     ticket.assignees.length > 0 &&
     ticket.hasAgentClaim &&
-    !world.openAgentPrTickets.includes(ticket.number) &&
-    !world.mergedAgentPrs.some((pr) => pr.ticket === ticket.number)
+    !hasOpenAgentPr(world, ticket.number) &&
+    !hasMergedAgentPr(world, ticket.number)
   );
 }
 
@@ -64,9 +74,41 @@ function isEscalationDue(ticket: Ticket, world: WorldSnapshot): boolean {
     ticket.assignees.length === 0 &&
     ticket.labels.includes(READY_FOR_AGENT) &&
     ticket.agentClaimCount >= MAX_ATTEMPTS &&
-    !world.openAgentPrTickets.includes(ticket.number) &&
-    !world.mergedAgentPrs.some((pr) => pr.ticket === ticket.number)
+    !hasOpenAgentPr(world, ticket.number) &&
+    !hasMergedAgentPr(world, ticket.number)
   );
+}
+
+/**
+ * PR upkeep: after a merge advances the base, keep the remaining open agent
+ * PRs current, one Action per PR at most. Conflict handling comes first and is
+ * exclusive — a conflicted PR is neither updated nor readied until the merge is
+ * resolved: a one-shot conflict Worker unless one has already asked for a
+ * human. A cleanly-mergeable PR that has fallen behind gets the mechanical
+ * branch update, and its ready flip waits for the next Tick, judged against the
+ * updated head (the update re-runs CI). Draft→ready is otherwise decided on CI
+ * alone — a green draft, or one in a repo with no CI configured, flips to
+ * ready-for-review — and independent of mergeability, so a fresh no-CI draft
+ * surfaces even while GitHub is still computing whether it is behind.
+ */
+function prUpkeep(world: WorldSnapshot): Action[] {
+  const actions: Action[] = [];
+  for (const pr of [...world.openAgentPrs].sort((a, b) => a.number - b.number)) {
+    if (pr.mergeable === "conflicted") {
+      if (!pr.conflictWorkerAsked) {
+        actions.push({ type: "conflict-worker", pr: pr.number, ticket: pr.ticket, headRef: pr.headRef });
+      }
+      continue;
+    }
+    if (pr.mergeable === "mergeable" && pr.behind) {
+      actions.push({ type: "update-branch", pr: pr.number, ticket: pr.ticket });
+      continue;
+    }
+    if (pr.draft && (pr.ci === "passing" || pr.ci === "none")) {
+      actions.push({ type: "mark-ready", pr: pr.number, ticket: pr.ticket });
+    }
+  }
+  return actions;
 }
 
 /**
@@ -79,7 +121,9 @@ function isEscalationDue(ticket: Ticket, world: WorldSnapshot): boolean {
  * caller binds attempt ≥ 2 to the stronger retry model. Dispatch is capped
  * by both max_workers and the headroom left under max_open_prs: every spawn
  * becomes an open PR, so claiming only into that headroom throttles the
- * fleet to human review bandwidth, resuming as merges land. While the
+ * fleet to human review bandwidth, resuming as merges land. PR upkeep sits
+ * between closure and recovery: it keeps the PRs a merge just left behind
+ * current, and consumes no Worker slots (the conflict Worker aside). While the
  * circuit breaker is open (dispatchPaused) only closes are planned.
  */
 export function plan(world: WorldSnapshot, config: PlanConfig): Action[] {
@@ -115,7 +159,7 @@ export function plan(world: WorldSnapshot, config: PlanConfig): Action[] {
   // The headroom counts open agent PRs repo-wide, not per Scope: the cap
   // models the human reviewer's bandwidth, and every agent PR occupies it
   // whichever run opened it.
-  const headroom = Math.max(0, config.maxOpenPrs - world.openAgentPrTickets.length);
+  const headroom = Math.max(0, config.maxOpenPrs - world.openAgentPrs.length);
   const dispatches: Action[] = dispatchableSet(world)
     .filter((ticket) => ticket.agentClaimCount < MAX_ATTEMPTS)
     .slice(0, Math.max(0, Math.min(config.maxWorkers, headroom)))
@@ -124,5 +168,5 @@ export function plan(world: WorldSnapshot, config: PlanConfig): Action[] {
       { type: "spawn", ticket: ticket.number, attempt: ticket.agentClaimCount + 1 },
     ]);
 
-  return [...closes, ...releases, ...escalations, ...dispatches];
+  return [...closes, ...prUpkeep(world), ...releases, ...escalations, ...dispatches];
 }

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { renderPlan, renderStuck } from "./render.js";
 import { plan } from "./plan.js";
 import type { ResolvedConfig } from "./config.js";
-import type { Ticket, WorldSnapshot } from "./types.js";
+import type { OpenAgentPr, Ticket, WorldSnapshot } from "./types.js";
 
 function ticket(overrides: Partial<Ticket> & { number: number; title: string }): Ticket {
   return {
@@ -14,6 +14,19 @@ function ticket(overrides: Partial<Ticket> & { number: number; title: string }):
     agentClaimCount: 0,
     attemptFailures: [],
     ...overrides,
+  };
+}
+
+function openPr(ticket: number): OpenAgentPr {
+  return {
+    number: ticket * 10,
+    ticket,
+    headRef: `border-collie/ticket-${ticket}-attempt-1`,
+    draft: false,
+    mergeable: "mergeable",
+    behind: false,
+    ci: "passing",
+    conflictWorkerAsked: false,
   };
 }
 
@@ -40,7 +53,7 @@ describe("renderPlan", () => {
       ticket({ number: 3, title: "Claiming", openBlockers: 1 }),
       ticket({ number: 4, title: "Done already", state: "closed" }),
     ],
-    openAgentPrTickets: [],
+    openAgentPrs: [],
     mergedAgentPrs: [],
   };
 
@@ -60,7 +73,7 @@ describe("renderPlan", () => {
   });
 
   it("says so when nothing is dispatchable", () => {
-    const empty: WorldSnapshot = { tickets: [], openAgentPrTickets: [], mergedAgentPrs: [] };
+    const empty: WorldSnapshot = { tickets: [], openAgentPrs: [], mergedAgentPrs: [] };
 
     expect(
       renderPlan(config({ scope: { kind: "all" } }), empty, [], { dryRun: true }),
@@ -84,7 +97,7 @@ describe("renderPlan", () => {
           hasAgentClaim: true,
         }),
       ],
-      openAgentPrTickets: [],
+      openAgentPrs: [],
       mergedAgentPrs: [],
     };
     const actions = plan(orphaned, { maxWorkers: 3, maxOpenPrs: 5 });
@@ -105,7 +118,7 @@ describe("renderPlan", () => {
         ticket({ number: 6, title: "Failed once", agentClaimCount: 1 }),
         ticket({ number: 7, title: "Failed twice", agentClaimCount: 2 }),
       ],
-      openAgentPrTickets: [],
+      openAgentPrs: [],
       mergedAgentPrs: [],
     };
     const actions = plan(laddered, { maxWorkers: 3, maxOpenPrs: 5 });
@@ -133,7 +146,7 @@ describe("renderPlan", () => {
           hasAgentClaim: true,
         }),
       ],
-      openAgentPrTickets: [],
+      openAgentPrs: [],
       mergedAgentPrs: [{ ticket: 6, url: "https://github.com/o/r/pull/60" }],
     };
     const actions = plan(merged, { maxWorkers: 3, maxOpenPrs: 5 });
@@ -148,10 +161,39 @@ describe("renderPlan", () => {
     );
   });
 
+  it("renders the PR-upkeep actions with the PR number and the ticket title", () => {
+    const upkeep: WorldSnapshot = {
+      tickets: [
+        ticket({ number: 5, title: "Behind base", assignees: ["operator"], hasAgentClaim: true }),
+        ticket({ number: 6, title: "Conflicted", assignees: ["operator"], hasAgentClaim: true }),
+        ticket({ number: 7, title: "Green draft", assignees: ["operator"], hasAgentClaim: true }),
+      ],
+      openAgentPrs: [
+        { ...openPr(5), behind: true },
+        { ...openPr(6), mergeable: "conflicted" },
+        { ...openPr(7), draft: true },
+      ],
+      mergedAgentPrs: [],
+    };
+    const actions = plan(upkeep, { maxWorkers: 3, maxOpenPrs: 5 });
+
+    expect(renderPlan(config(), upkeep, actions, { dryRun: true })).toBe(
+      [
+        "Scope: sub-issues of #1 — 3 tickets (3 open)",
+        "Dispatchable: none",
+        "Plan (max_workers=3, max_open_prs=5):",
+        "  update PR #50 — Behind base (behind base, mechanical merge)",
+        "  conflict Worker for PR #60 — Conflicted (resolve merge conflicts)",
+        "  mark PR #70 ready — Green draft (CI green)",
+        "Dry run: no writes performed.",
+      ].join("\n"),
+    );
+  });
+
   it("notes paused dispatch when dispatchable tickets wait on max_open_prs headroom", () => {
     const throttled: WorldSnapshot = {
       ...world,
-      openAgentPrTickets: [10, 11, 12, 13, 14],
+      openAgentPrs: [10, 11, 12, 13, 14].map(openPr),
     };
     const actions = plan(throttled, { maxWorkers: 3, maxOpenPrs: 5 });
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -182,7 +182,7 @@ describe("renderPlan", () => {
         "Scope: sub-issues of #1 — 3 tickets (3 open)",
         "Dispatchable: none",
         "Plan (max_workers=3, max_open_prs=5):",
-        "  update PR #50 — Behind base (behind base, mechanical merge)",
+        "  update PR #50 — Behind base (behind base, mechanical rebase)",
         "  conflict Worker for PR #60 — Conflicted (resolve merge conflicts)",
         "  mark PR #70 ready — Green draft (CI green)",
         "Dry run: no writes performed.",

--- a/src/render.ts
+++ b/src/render.ts
@@ -26,9 +26,9 @@ export function renderPlan(
   }
   if (dispatchPaused) {
     lines.push("Dispatch paused: circuit breaker open (infrastructure failure), claims held");
-  } else if (dispatchable.length > 0 && world.openAgentPrTickets.length >= maxOpenPrs) {
+  } else if (dispatchable.length > 0 && world.openAgentPrs.length >= maxOpenPrs) {
     lines.push(
-      `Dispatch paused: ${world.openAgentPrTickets.length} open agent PRs at max_open_prs (${maxOpenPrs})`,
+      `Dispatch paused: ${world.openAgentPrs.length} open agent PRs at max_open_prs (${maxOpenPrs})`,
     );
   }
 
@@ -61,6 +61,15 @@ export function renderPlan(
           break;
         case "close":
           lines.push(`  close #${action.ticket} — ${title} (merged: ${action.prUrl})`);
+          break;
+        case "update-branch":
+          lines.push(`  update PR #${action.pr} — ${title} (behind base, mechanical merge)`);
+          break;
+        case "conflict-worker":
+          lines.push(`  conflict Worker for PR #${action.pr} — ${title} (resolve merge conflicts)`);
+          break;
+        case "mark-ready":
+          lines.push(`  mark PR #${action.pr} ready — ${title} (CI green)`);
           break;
       }
     }

--- a/src/render.ts
+++ b/src/render.ts
@@ -63,7 +63,7 @@ export function renderPlan(
           lines.push(`  close #${action.ticket} — ${title} (merged: ${action.prUrl})`);
           break;
         case "update-branch":
-          lines.push(`  update PR #${action.pr} — ${title} (behind base, mechanical merge)`);
+          lines.push(`  update PR #${action.pr} — ${title} (behind base, mechanical rebase)`);
           break;
         case "conflict-worker":
           lines.push(`  conflict Worker for PR #${action.pr} — ${title} (resolve merge conflicts)`);

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { BREAKER_BASE_COOLDOWN_MS } from "./breaker.js";
 import { run, runStatus, type RunDeps } from "./run.js";
-import type { Action, MergedAgentPr, Ticket, WorldSnapshot } from "./types.js";
+import type { Action, MergedAgentPr, OpenAgentPr, Ticket, WorldSnapshot } from "./types.js";
 
 function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
   return {
@@ -17,12 +17,25 @@ function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
   };
 }
 
+function openPr(ticket: number): OpenAgentPr {
+  return {
+    number: ticket * 10,
+    ticket,
+    headRef: `border-collie/ticket-${ticket}-attempt-1`,
+    draft: false,
+    mergeable: "mergeable",
+    behind: false,
+    ci: "passing",
+    conflictWorkerAsked: false,
+  };
+}
+
 function world(
   tickets: Ticket[],
   openAgentPrTickets: number[] = [],
   mergedAgentPrs: MergedAgentPr[] = [],
 ): WorldSnapshot {
-  return { tickets, openAgentPrTickets, mergedAgentPrs };
+  return { tickets, openAgentPrs: openAgentPrTickets.map(openPr), mergedAgentPrs };
 }
 
 describe("runStatus", () => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -33,7 +33,7 @@ export function runStatus(
 ): RunStatus {
   const open = world.tickets.filter((ticket) => ticket.state === "open");
   if (open.length === 0) return { state: "complete" };
-  if (actions.length === 0 && world.openAgentPrTickets.length === 0 && !dispatchPaused) {
+  if (actions.length === 0 && world.openAgentPrs.length === 0 && !dispatchPaused) {
     return { state: "stuck", open };
   }
   return { state: "running" };

--- a/src/tracker.test.ts
+++ b/src/tracker.test.ts
@@ -2,17 +2,21 @@ import { describe, expect, it } from "vitest";
 import {
   claimTicket,
   closeTicket,
+  commentConflictUnresolved,
   createDraftPr,
   escalateTicket,
+  markPrReady,
   readScope,
   releaseFailedTicket,
   releaseTicket,
+  updatePrBranch,
   voidAttempt,
   type Exec,
 } from "./tracker.js";
 import {
   attemptMarker,
   CLAIM_MARKER,
+  CONFLICT_UNRESOLVED_MARKER,
   RELEASE_MARKER,
   VOID_MARKER,
   type AttemptFailure,
@@ -36,20 +40,44 @@ const issue = (overrides: Record<string, unknown>) => ({
   ...overrides,
 });
 
+/** A clean `gh pr list` item for an agent branch — the shape the upkeep read parses. */
+const prItem = (overrides: Record<string, unknown> = {}) => ({
+  number: 50,
+  headRefName: "border-collie/ticket-5-attempt-1",
+  isDraft: false,
+  mergeable: "MERGEABLE",
+  statusCheckRollup: [] as unknown[],
+  ...overrides,
+});
+
 /**
- * Fake the subprocess seam: `gh api <endpoint> --paginate --slurp` calls are
- * answered from a map keyed by endpoint. An un-mapped endpoint throws, so a
- * test also asserts which reads do NOT happen.
+ * Fake the subprocess seam. `gh api <endpoint> --paginate --slurp` calls are
+ * answered from `api` keyed by endpoint; `gh pr list` from `prList`. An
+ * un-mapped gh api endpoint throws, so a test also asserts which reads do NOT
+ * happen.
  */
-function fakeExec(responses: Record<string, unknown>): { exec: Exec; calls: string[][] } {
+function fakeExec(opts: { api?: Record<string, unknown>; prList?: unknown[] }): {
+  exec: Exec;
+  calls: string[][];
+} {
   const calls: string[][] = [];
+  const api = opts.api ?? {};
   const exec: Exec = async (cmd, args) => {
     calls.push([cmd, ...args]);
-    const endpoint = args[1] ?? "";
-    if (!(endpoint in responses)) {
-      throw new Error(`unexpected gh call: ${[cmd, ...args].join(" ")}`);
+    if (args[0] === "pr" && args[1] === "list") {
+      if (opts.prList === undefined) {
+        throw new Error(`unexpected gh pr list: ${[cmd, ...args].join(" ")}`);
+      }
+      return JSON.stringify(opts.prList);
     }
-    return JSON.stringify(responses[endpoint]);
+    if (args[0] === "api") {
+      const endpoint = args[1] ?? "";
+      if (!(endpoint in api)) {
+        throw new Error(`unexpected gh api call: ${[cmd, ...args].join(" ")}`);
+      }
+      return JSON.stringify(api[endpoint]);
+    }
+    throw new Error(`unexpected gh call: ${[cmd, ...args].join(" ")}`);
   };
   return { exec, calls };
 }
@@ -57,65 +85,78 @@ function fakeExec(responses: Record<string, unknown>): { exec: Exec; calls: stri
 const SUB_ISSUES = "repos/{owner}/{repo}/issues/1/sub_issues?per_page=100";
 const ALL_ISSUES = "repos/{owner}/{repo}/issues?labels=ready-for-agent&state=open&per_page=100";
 const comments = (n: number) => `repos/{owner}/{repo}/issues/${n}/comments?per_page=100`;
-const OPEN_PULLS = "repos/{owner}/{repo}/pulls?state=open&per_page=100";
 const CLOSED_PULLS = "repos/{owner}/{repo}/pulls?state=closed&per_page=100";
-/** Both PR listings answered empty — the common backdrop for open tickets. */
-const NO_PULLS = { [OPEN_PULLS]: [[]], [CLOSED_PULLS]: [[]] };
+const compare = (base: string, head: string) => `repos/{owner}/{repo}/compare/${base}...${head}`;
+
+/** The gh operation a recorded call performed, for asserting read order. */
+const op = (call: string[]) => (call[1] === "pr" && call[2] === "list" ? "pr-list" : call[2]);
 
 describe("readScope", () => {
-  it("reads a parent's sub-issues via gh api with pagination, then comments and both PR listings", async () => {
+  it("reads a parent's sub-issues, then comments, then the open and closed PR listings", async () => {
     const { exec, calls } = fakeExec({
-      [SUB_ISSUES]: [[issue({})]],
-      [comments(2)]: [[]],
-      ...NO_PULLS,
+      api: { [SUB_ISSUES]: [[issue({})]], [comments(2)]: [[]], [CLOSED_PULLS]: [[]] },
+      prList: [],
     });
 
     await readScope({ kind: "parent", parent: 1 }, exec);
 
-    expect(calls.map((c) => c[2])).toEqual([SUB_ISSUES, comments(2), OPEN_PULLS, CLOSED_PULLS]);
+    expect(calls.map(op)).toEqual([SUB_ISSUES, comments(2), "pr-list", CLOSED_PULLS]);
     expect(calls[0]).toEqual(["gh", "api", SUB_ISSUES, "--paginate", "--slurp"]);
+    expect(calls.find((c) => c[1] === "pr")).toEqual([
+      "gh",
+      "pr",
+      "list",
+      "--state",
+      "open",
+      "--limit",
+      "100",
+      "--json",
+      "number,headRefName,baseRefName,isDraft,mergeable,statusCheckRollup",
+    ]);
   });
 
   it("reads repo-wide agent-ready issues when scope is all", async () => {
     const { exec, calls } = fakeExec({
-      [ALL_ISSUES]: [[issue({})]],
-      [comments(2)]: [[]],
-      ...NO_PULLS,
+      api: { [ALL_ISSUES]: [[issue({})]], [comments(2)]: [[]], [CLOSED_PULLS]: [[]] },
+      prList: [],
     });
 
     await readScope({ kind: "all" }, exec);
 
-    expect(calls.map((c) => c[2])).toEqual([ALL_ISSUES, comments(2), OPEN_PULLS, CLOSED_PULLS]);
+    expect(calls.map(op)).toEqual([ALL_ISSUES, comments(2), "pr-list", CLOSED_PULLS]);
   });
 
   it("skips both PR reads when no ticket in Scope is open", async () => {
     const { exec, calls } = fakeExec({
-      [SUB_ISSUES]: [[issue({ number: 3, state: "closed" })]],
-      // Pull endpoints deliberately unmapped: fetching them would throw.
+      api: { [SUB_ISSUES]: [[issue({ number: 3, state: "closed" })]] },
+      // Neither PR read is mapped: performing them would throw.
     });
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
 
-    expect(calls.map((c) => c[2])).toEqual([SUB_ISSUES]);
-    expect(world.openAgentPrTickets).toEqual([]);
+    expect(calls.map(op)).toEqual([SUB_ISSUES]);
+    expect(world.openAgentPrs).toEqual([]);
     expect(world.mergedAgentPrs).toEqual([]);
   });
 
   it("maps issues to Tickets and flattens pages", async () => {
     const { exec } = fakeExec({
-      [SUB_ISSUES]: [
-        [
-          issue({
-            number: 3,
-            state: "closed",
-            assignees: [{ login: "someone" }],
-            issue_dependencies_summary: { blocked_by: 2 },
-          }),
+      api: {
+        [SUB_ISSUES]: [
+          [
+            issue({
+              number: 3,
+              state: "closed",
+              assignees: [{ login: "someone" }],
+              issue_dependencies_summary: { blocked_by: 2 },
+            }),
+          ],
+          [issue({ number: 4, title: "Second page" })],
         ],
-        [issue({ number: 4, title: "Second page" })],
-      ],
-      [comments(4)]: [[]],
-      ...NO_PULLS,
+        [comments(4)]: [[]],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [],
     });
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
@@ -148,11 +189,12 @@ describe("readScope", () => {
 
   it("drops pull requests from a repo-wide listing", async () => {
     const { exec } = fakeExec({
-      [ALL_ISSUES]: [
-        [issue({ number: 5 }), issue({ number: 6, pull_request: { url: "x" } })],
-      ],
-      [comments(5)]: [[]],
-      ...NO_PULLS,
+      api: {
+        [ALL_ISSUES]: [[issue({ number: 5 }), issue({ number: 6, pull_request: { url: "x" } })]],
+        [comments(5)]: [[]],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [],
     });
 
     const world = await readScope({ kind: "all" }, exec);
@@ -162,9 +204,12 @@ describe("readScope", () => {
 
   it("treats a missing dependency summary as zero open blockers", async () => {
     const { exec } = fakeExec({
-      [SUB_ISSUES]: [[issue({ number: 7, issue_dependencies_summary: undefined })]],
-      [comments(7)]: [[]],
-      ...NO_PULLS,
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 7, issue_dependencies_summary: undefined })]],
+        [comments(7)]: [[]],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [],
     });
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
@@ -174,17 +219,15 @@ describe("readScope", () => {
 
   it("reads comments for assigned tickets and unassigned dispatch candidates, detecting the claim marker", async () => {
     const { exec, calls } = fakeExec({
-      [SUB_ISSUES]: [
-        [
-          issue({ number: 5, assignees: [{ login: "operator" }] }),
-          issue({ number: 6 }),
+      api: {
+        [SUB_ISSUES]: [
+          [issue({ number: 5, assignees: [{ login: "operator" }] }), issue({ number: 6 })],
         ],
-      ],
-      [comments(5)]: [
-        [{ body: "human chatter" }, { body: `${CLAIM_MARKER}\n🐕 claimed` }],
-      ],
-      [comments(6)]: [[]],
-      ...NO_PULLS,
+        [comments(5)]: [[{ body: "human chatter" }, { body: `${CLAIM_MARKER}\n🐕 claimed` }]],
+        [comments(6)]: [[]],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [],
     });
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
@@ -193,42 +236,48 @@ describe("readScope", () => {
       [5, true],
       [6, false],
     ]);
-    expect(calls.map((c) => c[2])).toContain(comments(5));
-    expect(calls.map((c) => c[2])).toContain(comments(6));
+    expect(calls.map(op)).toContain(comments(5));
+    expect(calls.map(op)).toContain(comments(6));
   });
 
   it("skips comment reads for closed, blocked, and non-agent unassigned tickets", async () => {
     const { exec, calls } = fakeExec({
-      [SUB_ISSUES]: [
-        [
-          issue({ number: 3, state: "closed" }),
-          issue({ number: 4, issue_dependencies_summary: { blocked_by: 1 } }),
-          issue({ number: 8, labels: [] }),
+      api: {
+        [SUB_ISSUES]: [
+          [
+            issue({ number: 3, state: "closed" }),
+            issue({ number: 4, issue_dependencies_summary: { blocked_by: 1 } }),
+            issue({ number: 8, labels: [] }),
+          ],
         ],
-      ],
-      ...NO_PULLS,
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [],
     });
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
 
-    expect(calls.map((c) => c[2])).toEqual([SUB_ISSUES, OPEN_PULLS, CLOSED_PULLS]);
+    expect(calls.map(op)).toEqual([SUB_ISSUES, "pr-list", CLOSED_PULLS]);
     expect(world.tickets.map((t) => t.agentClaimCount)).toEqual([0, 0, 0]);
   });
 
   it("derives the Attempt counter and failure records from the comment history", async () => {
     const { exec } = fakeExec({
-      [SUB_ISSUES]: [[issue({ number: 5 })]],
-      [comments(5)]: [
-        [
-          { body: `${CLAIM_MARKER}\n🐕 claimed` },
-          { body: `${RELEASE_MARKER}\n${attemptMarker(FAILURE)}\n🐕 Attempt 1 failed` },
-          { body: `${CLAIM_MARKER}\n🐕 claimed again` },
-          {
-            body: `${RELEASE_MARKER}\n${attemptMarker({ ...FAILURE, attempt: 2, model: "opus" })}\n🐕 Attempt 2 failed`,
-          },
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [
+          [
+            { body: `${CLAIM_MARKER}\n🐕 claimed` },
+            { body: `${RELEASE_MARKER}\n${attemptMarker(FAILURE)}\n🐕 Attempt 1 failed` },
+            { body: `${CLAIM_MARKER}\n🐕 claimed again` },
+            {
+              body: `${RELEASE_MARKER}\n${attemptMarker({ ...FAILURE, attempt: 2, model: "opus" })}\n🐕 Attempt 2 failed`,
+            },
+          ],
         ],
-      ],
-      ...NO_PULLS,
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [],
     });
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
@@ -242,14 +291,17 @@ describe("readScope", () => {
 
   it("uncounts a voided claim while keeping it agent-held (infrastructure failures burn nothing)", async () => {
     const { exec } = fakeExec({
-      [SUB_ISSUES]: [[issue({ number: 5, assignees: [{ login: "operator" }] })]],
-      [comments(5)]: [
-        [
-          { body: `${CLAIM_MARKER}\n🐕 claimed` },
-          { body: `${VOID_MARKER}\n🐕 Attempt 1 voided: the account usage limit was reached` },
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5, assignees: [{ login: "operator" }] })]],
+        [comments(5)]: [
+          [
+            { body: `${CLAIM_MARKER}\n🐕 claimed` },
+            { body: `${VOID_MARKER}\n🐕 Attempt 1 voided: the account usage limit was reached` },
+          ],
         ],
-      ],
-      ...NO_PULLS,
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [],
     });
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
@@ -263,16 +315,19 @@ describe("readScope", () => {
 
   it("counts a fresh claim after a voided one as the first Attempt again", async () => {
     const { exec } = fakeExec({
-      [SUB_ISSUES]: [[issue({ number: 5 })]],
-      [comments(5)]: [
-        [
-          { body: `${CLAIM_MARKER}\n🐕 claimed` },
-          { body: `${VOID_MARKER}\n🐕 Attempt 1 voided` },
-          { body: `${RELEASE_MARKER}\n🐕 released (orphaned after the outage)` },
-          { body: `${CLAIM_MARKER}\n🐕 claimed again` },
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [
+          [
+            { body: `${CLAIM_MARKER}\n🐕 claimed` },
+            { body: `${VOID_MARKER}\n🐕 Attempt 1 voided` },
+            { body: `${RELEASE_MARKER}\n🐕 released (orphaned after the outage)` },
+            { body: `${CLAIM_MARKER}\n🐕 claimed again` },
+          ],
         ],
-      ],
-      ...NO_PULLS,
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [],
     });
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
@@ -280,120 +335,236 @@ describe("readScope", () => {
     expect(world.tickets[0]).toMatchObject({ hasAgentClaim: true, agentClaimCount: 1 });
   });
 
-  it("reads open PRs when attempts are exhausted even with no live agent claim (the escalation veto)", async () => {
+  it("maps open agent-branch PRs with their upkeep signals, ignoring other branches", async () => {
     const { exec } = fakeExec({
-      [SUB_ISSUES]: [[issue({ number: 5 })]],
-      [comments(5)]: [
-        [
-          { body: `${CLAIM_MARKER}\nclaimed` },
-          { body: `${RELEASE_MARKER}\nreleased` },
-          { body: `${CLAIM_MARKER}\nclaimed` },
-          { body: `${RELEASE_MARKER}\nreleased` },
-        ],
+      api: { [SUB_ISSUES]: [[issue({ number: 5 })]], [comments(5)]: [[]], [CLOSED_PULLS]: [[]] },
+      prList: [
+        prItem({ number: 50, headRefName: "border-collie/ticket-5-attempt-1" }),
+        prItem({ number: 99, headRefName: "feature/unrelated" }),
       ],
-      [OPEN_PULLS]: [[{ head: { ref: "border-collie/ticket-5" } }]],
-      [CLOSED_PULLS]: [[]],
     });
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
 
-    expect(world.openAgentPrTickets).toEqual([5]);
+    expect(world.openAgentPrs).toEqual([
+      {
+        number: 50,
+        ticket: 5,
+        headRef: "border-collie/ticket-5-attempt-1",
+        draft: false,
+        mergeable: "mergeable",
+        behind: false,
+        ci: "none",
+        conflictWorkerAsked: false,
+      },
+    ]);
   });
 
-  it("treats a release marker after the claim as no agent claim", async () => {
-    const { exec } = fakeExec({
-      [SUB_ISSUES]: [[issue({ number: 5, assignees: [{ login: "a-human" }] })]],
-      [comments(5)]: [
-        [{ body: `${CLAIM_MARKER}\nclaimed` }, { body: `${RELEASE_MARKER}\nreleased` }],
+  it("reads the upkeep signals: behind (from the compare API), draft, mergeability, and CI", async () => {
+    const head = "border-collie/ticket-5-attempt-1";
+    const { exec, calls } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [[]],
+        [CLOSED_PULLS]: [[]],
+        // The head is two commits behind its base.
+        [compare("main", head)]: { behind_by: 2 },
+      },
+      prList: [
+        prItem({
+          number: 50,
+          baseRefName: "main",
+          isDraft: true,
+          statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS" }],
+        }),
       ],
-      ...NO_PULLS,
     });
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
 
-    expect(world.tickets[0]?.hasAgentClaim).toBe(false);
-    expect(world.openAgentPrTickets).toEqual([]);
+    expect(world.openAgentPrs[0]).toMatchObject({
+      draft: true,
+      mergeable: "mergeable",
+      behind: true,
+      ci: "passing",
+    });
+    expect(calls.map(op)).toContain(compare("main", head));
   });
 
-  it("maps open agent-branch PRs to ticket numbers, ignoring other branches", async () => {
-    const { exec } = fakeExec({
-      [SUB_ISSUES]: [[issue({ number: 8, assignees: [{ login: "operator" }] })]],
-      [comments(8)]: [[{ body: `${CLAIM_MARKER}\nclaimed` }]],
-      [OPEN_PULLS]: [
-        [
-          { head: { ref: "border-collie/ticket-8" } },
-          { head: { ref: "feature/unrelated" } },
-        ],
+  it("does not read the compare API for a conflicted or still-computing PR", async () => {
+    const { exec, calls } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 }), issue({ number: 6 })]],
+        [comments(5)]: [[]],
+        [comments(6)]: [[]],
+        [comments(50)]: [[]],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [
+        prItem({ number: 50, baseRefName: "main", mergeable: "CONFLICTING" }),
+        prItem({
+          number: 60,
+          baseRefName: "main",
+          headRefName: "border-collie/ticket-6-attempt-1",
+          mergeable: "UNKNOWN",
+        }),
       ],
-      [CLOSED_PULLS]: [[]],
     });
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
 
-    expect(world.openAgentPrTickets).toEqual([8]);
+    expect(world.openAgentPrs.map((pr) => pr.behind)).toEqual([false, false]);
+    expect(calls.some((c) => c[2]?.startsWith("repos/{owner}/{repo}/compare/"))).toBe(false);
+  });
+
+  it("reads a conflicted PR's comments for the unresolved marker, and skips that read otherwise", async () => {
+    const { exec, calls } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [[]],
+        // Comments for the conflicted PR #50 carry the unresolved marker.
+        [comments(50)]: [[{ body: `${CONFLICT_UNRESOLVED_MARKER}\n🐕 human, please` }]],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [
+        prItem({ number: 50, mergeable: "CONFLICTING" }),
+        prItem({ number: 60, headRefName: "border-collie/ticket-6-attempt-1" }),
+      ],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.openAgentPrs).toEqual([
+      {
+        number: 50,
+        ticket: 5,
+        headRef: "border-collie/ticket-5-attempt-1",
+        draft: false,
+        mergeable: "conflicted",
+        behind: false,
+        ci: "none",
+        conflictWorkerAsked: true,
+      },
+      {
+        number: 60,
+        ticket: 6,
+        headRef: "border-collie/ticket-6-attempt-1",
+        draft: false,
+        mergeable: "mergeable",
+        behind: false,
+        ci: "none",
+        conflictWorkerAsked: false,
+      },
+    ]);
+    // The clean PR #60's comments are never read.
+    expect(calls.map(op)).toContain(comments(50));
+    expect(calls.map(op)).not.toContain(comments(60));
+  });
+
+  it("classifies a pending check rollup as pending and a failing one as failing", async () => {
+    const { exec } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 }), issue({ number: 6 })]],
+        [comments(5)]: [[]],
+        [comments(6)]: [[]],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [
+        prItem({
+          number: 50,
+          statusCheckRollup: [
+            { status: "COMPLETED", conclusion: "SUCCESS" },
+            { status: "IN_PROGRESS" },
+          ],
+        }),
+        prItem({
+          number: 60,
+          headRefName: "border-collie/ticket-6-attempt-1",
+          statusCheckRollup: [{ status: "COMPLETED", conclusion: "FAILURE" }],
+        }),
+      ],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.openAgentPrs.map((pr) => [pr.number, pr.ci])).toEqual([
+      [50, "pending"],
+      [60, "failing"],
+    ]);
+  });
+
+  it("treats an UNKNOWN mergeability as unknown (GitHub still computing)", async () => {
+    const { exec } = fakeExec({
+      api: { [SUB_ISSUES]: [[issue({ number: 5 })]], [comments(5)]: [[]], [CLOSED_PULLS]: [[]] },
+      prList: [prItem({ number: 50, mergeable: "UNKNOWN" })],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.openAgentPrs[0]?.mergeable).toBe("unknown");
   });
 
   it("surfaces merged agent PRs for tickets in Scope, ignoring closed-unmerged and foreign ones", async () => {
     const { exec } = fakeExec({
-      [SUB_ISSUES]: [[issue({ number: 5 }), issue({ number: 6 })]],
-      [comments(5)]: [[]],
-      [comments(6)]: [[]],
-      [OPEN_PULLS]: [[]],
-      [CLOSED_PULLS]: [
-        [
-          {
-            head: { ref: "border-collie/ticket-5" },
-            merged_at: "2026-07-20T10:00:00Z",
-            html_url: "https://github.com/o/r/pull/50",
-          },
-          { head: { ref: "border-collie/ticket-6" }, merged_at: null },
-          {
-            head: { ref: "border-collie/ticket-99" },
-            merged_at: "2026-07-19T10:00:00Z",
-            html_url: "https://github.com/o/r/pull/99",
-          },
-          {
-            head: { ref: "feature/unrelated" },
-            merged_at: "2026-07-18T10:00:00Z",
-            html_url: "https://github.com/o/r/pull/40",
-          },
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 }), issue({ number: 6 })]],
+        [comments(5)]: [[]],
+        [comments(6)]: [[]],
+        [CLOSED_PULLS]: [
+          [
+            {
+              head: { ref: "border-collie/ticket-5" },
+              merged_at: "2026-07-20T10:00:00Z",
+              html_url: "https://github.com/o/r/pull/50",
+            },
+            { head: { ref: "border-collie/ticket-6" }, merged_at: null },
+            {
+              head: { ref: "border-collie/ticket-99" },
+              merged_at: "2026-07-19T10:00:00Z",
+              html_url: "https://github.com/o/r/pull/99",
+            },
+            {
+              head: { ref: "feature/unrelated" },
+              merged_at: "2026-07-18T10:00:00Z",
+              html_url: "https://github.com/o/r/pull/40",
+            },
+          ],
         ],
-      ],
+      },
+      prList: [],
     });
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
 
-    expect(world.mergedAgentPrs).toEqual([
-      { ticket: 5, url: "https://github.com/o/r/pull/50" },
-    ]);
+    expect(world.mergedAgentPrs).toEqual([{ ticket: 5, url: "https://github.com/o/r/pull/50" }]);
   });
 
   it("keeps one merged PR per ticket: the first in the newest-created-first listing", async () => {
     const { exec } = fakeExec({
-      [SUB_ISSUES]: [[issue({ number: 5 })]],
-      [comments(5)]: [[]],
-      [OPEN_PULLS]: [[]],
-      [CLOSED_PULLS]: [
-        [
-          {
-            head: { ref: "border-collie/ticket-5" },
-            merged_at: "2026-07-20T10:00:00Z",
-            html_url: "https://github.com/o/r/pull/52",
-          },
-          {
-            head: { ref: "border-collie/ticket-5" },
-            merged_at: "2026-07-10T10:00:00Z",
-            html_url: "https://github.com/o/r/pull/51",
-          },
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [[]],
+        [CLOSED_PULLS]: [
+          [
+            {
+              head: { ref: "border-collie/ticket-5" },
+              merged_at: "2026-07-20T10:00:00Z",
+              html_url: "https://github.com/o/r/pull/52",
+            },
+            {
+              head: { ref: "border-collie/ticket-5" },
+              merged_at: "2026-07-10T10:00:00Z",
+              html_url: "https://github.com/o/r/pull/51",
+            },
+          ],
         ],
-      ],
+      },
+      prList: [],
     });
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
 
-    expect(world.mergedAgentPrs).toEqual([
-      { ticket: 5, url: "https://github.com/o/r/pull/52" },
-    ]);
+    expect(world.mergedAgentPrs).toEqual([{ ticket: 5, url: "https://github.com/o/r/pull/52" }]);
   });
 });
 
@@ -569,5 +740,39 @@ describe("escalateTicket", () => {
 
     const body = calls[0]?.[5] ?? "";
     expect(body).toContain("no attempt records");
+  });
+});
+
+describe("updatePrBranch", () => {
+  it("mechanically merges the base into the PR via the update-branch API", async () => {
+    const { exec, calls } = recordingExec();
+
+    await updatePrBranch(30, exec);
+
+    expect(calls).toEqual([
+      ["gh", "api", "--method", "PUT", "repos/{owner}/{repo}/pulls/30/update-branch"],
+    ]);
+  });
+});
+
+describe("markPrReady", () => {
+  it("flips a draft PR to ready for review", async () => {
+    const { exec, calls } = recordingExec();
+
+    await markPrReady(30, exec);
+
+    expect(calls).toEqual([["gh", "pr", "ready", "30"]]);
+  });
+});
+
+describe("commentConflictUnresolved", () => {
+  it("comments the human-resolution ask carrying the unresolved marker", async () => {
+    const { exec, calls } = recordingExec();
+
+    await commentConflictUnresolved(30, exec);
+
+    expect(calls).toEqual([
+      ["gh", "pr", "comment", "30", "--body", expect.stringContaining(CONFLICT_UNRESOLVED_MARKER)],
+    ]);
   });
 });

--- a/src/tracker.test.ts
+++ b/src/tracker.test.ts
@@ -744,13 +744,13 @@ describe("escalateTicket", () => {
 });
 
 describe("updatePrBranch", () => {
-  it("mechanically merges the base into the PR via the update-branch API", async () => {
+  it("mechanically rebases the PR onto its base via gh pr update-branch", async () => {
     const { exec, calls } = recordingExec();
 
     await updatePrBranch(30, exec);
 
     expect(calls).toEqual([
-      ["gh", "api", "--method", "PUT", "repos/{owner}/{repo}/pulls/30/update-branch"],
+      ["gh", "pr", "update-branch", "30", "--rebase"],
     ]);
   });
 });

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -462,12 +462,16 @@ export async function escalateTicket(
 }
 
 /**
- * Act phase: mechanically merge the base into a cleanly-mergeable PR that has
- * fallen behind. The GitHub update-branch API does the merge server-side — no
- * worktree, no judgment — so a sibling stays current after every merge.
+ * Act phase: mechanically rebase a cleanly-mergeable PR that has fallen behind
+ * onto its base. GitHub does the rebase server-side — no worktree, no judgment
+ * — so a sibling stays current after every merge. Rebase, never a merge
+ * commit: agent branches stay linear so the operator's "Rebase and merge"
+ * strategy stays available (a merge-commit update would make GitHub refuse it
+ * — replaying the branch's commits drops the merge commit and its resolutions,
+ * so the original commits re-conflict).
  */
 export async function updatePrBranch(pr: number, exec: Exec = realExec): Promise<void> {
-  await exec("gh", ["api", "--method", "PUT", `repos/{owner}/{repo}/pulls/${pr}/update-branch`]);
+  await exec("gh", ["pr", "update-branch", String(pr), "--rebase"]);
 }
 
 /** Act phase: flip a draft PR to ready-for-review, surfacing it to the reviewer. */
@@ -475,7 +479,7 @@ export async function markPrReady(pr: number, exec: Exec = realExec): Promise<vo
   await exec("gh", ["pr", "ready", String(pr)]);
 }
 
-const CONFLICT_UNRESOLVED_COMMENT = `${CONFLICT_UNRESOLVED_MARKER}\n🐕 border-collie ran a conflict-resolution Worker here, but it could not complete the merge. This PR needs a human to resolve the conflicts — border-collie will not dispatch another Worker for it.`;
+const CONFLICT_UNRESOLVED_COMMENT = `${CONFLICT_UNRESOLVED_MARKER}\n🐕 border-collie ran a conflict-resolution Worker here, but it could not complete the rebase onto the base branch. This PR needs a human to resolve the conflicts — border-collie will not dispatch another Worker for it.`;
 
 /**
  * Act phase: mark a PR's conflict as human-owned after the conflict Worker

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -3,6 +3,7 @@ import { promisify } from "node:util";
 import {
   attemptMarker,
   CLAIM_MARKER,
+  CONFLICT_UNRESOLVED_MARKER,
   FAILURE_DESCRIPTIONS,
   INFRA_DESCRIPTIONS,
   MAX_ATTEMPTS,
@@ -13,8 +14,11 @@ import {
   ticketFromAgentBranch,
   VOID_MARKER,
   type AttemptFailure,
+  type CiState,
   type InfraReason,
+  type Mergeability,
   type MergedAgentPr,
+  type OpenAgentPr,
   type Ticket,
   type WorldSnapshot,
 } from "./types.js";
@@ -105,15 +109,129 @@ async function readClaimHistory(ticket: number, exec: Exec): Promise<ClaimHistor
   return history;
 }
 
-/** Ticket numbers of open PRs whose head branch carries the agent prefix. */
-async function listOpenAgentPrTickets(exec: Exec): Promise<number[]> {
-  const pulls = await readPages<{ head?: { ref?: string } }>(
-    "repos/{owner}/{repo}/pulls?state=open&per_page=100",
+/** One check-run (status/conclusion) or legacy status context (state) in the rollup. */
+interface RollupCheck {
+  status?: string;
+  conclusion?: string;
+  state?: string;
+}
+
+interface GhPrListItem {
+  number: number;
+  headRefName?: string;
+  baseRefName?: string;
+  isDraft?: boolean;
+  /** GraphQL mergeability: MERGEABLE | CONFLICTING | UNKNOWN. Independent of the draft flag. */
+  mergeable?: string;
+  statusCheckRollup?: RollupCheck[];
+}
+
+function mergeabilityOf(raw: string | undefined): Mergeability {
+  if (raw === "MERGEABLE") return "mergeable";
+  if (raw === "CONFLICTING") return "conflicted";
+  return "unknown";
+}
+
+/**
+ * True when the PR's head is behind its base — the base carries commits the
+ * head lacks, so a mechanical update would advance it. Read from the compare
+ * API's behind_by, deliberately NOT from the PR's mergeStateStatus: that field
+ * reports DRAFT for a draft PR (masking BEHIND, and every agent PR opens as a
+ * draft), and only surfaces BEHIND at all when "require branches up to date"
+ * branch protection is on — otherwise a stale-but-clean PR reads CLEAN. The
+ * compare is reliable under every configuration.
+ */
+async function prBehindBase(base: string, head: string, exec: Exec): Promise<boolean> {
+  const stdout = await exec("gh", ["api", `repos/{owner}/{repo}/compare/${base}...${head}`]);
+  const comparison = JSON.parse(stdout) as { behind_by?: number };
+  return (comparison.behind_by ?? 0) > 0;
+}
+
+/**
+ * The CI standing of a head commit from its check-run rollup. Empty is `none`
+ * — no checks configured, which the draft→ready gate reads as green. Otherwise
+ * any incomplete or unsuccessful check is decisive: one failure fails the
+ * whole rollup, one still-running check holds it pending, and only an all-green
+ * rollup passes. Handles both modern check-runs (status/conclusion) and legacy
+ * commit-status contexts (state).
+ */
+function ciFromRollup(rollup: RollupCheck[]): CiState {
+  if (rollup.length === 0) return "none";
+  let pending = false;
+  for (const check of rollup) {
+    if (check.status !== undefined) {
+      if (check.status !== "COMPLETED") {
+        pending = true;
+        continue;
+      }
+      if (check.conclusion === "SUCCESS" || check.conclusion === "NEUTRAL" || check.conclusion === "SKIPPED") {
+        continue;
+      }
+      return "failing";
+    }
+    if (check.state === "SUCCESS") continue;
+    if (check.state === "PENDING" || check.state === "EXPECTED") {
+      pending = true;
+      continue;
+    }
+    return "failing";
+  }
+  return pending ? "pending" : "passing";
+}
+
+/**
+ * True when a conflict-resolution Worker already asked for human help on this
+ * PR — the unresolved marker sits in its comment thread. Read only for
+ * conflicted PRs, where it alone decides whether another Worker is dispatched.
+ */
+async function readConflictWorkerAsked(pr: number, exec: Exec): Promise<boolean> {
+  const comments = await readPages<{ body?: string }>(
+    `repos/{owner}/{repo}/issues/${pr}/comments?per_page=100`,
     exec,
   );
-  return pulls
-    .map((pr) => ticketFromAgentBranch(pr.head?.ref ?? ""))
-    .filter((n): n is number => n !== undefined);
+  return comments.some((comment) => comment.body?.includes(CONFLICT_UNRESOLVED_MARKER));
+}
+
+/**
+ * Open agent PRs with the upkeep signals GitHub computes lazily (mergeability,
+ * CI rollup), read in one `gh pr list` call — capped at 100, far above the
+ * max_open_prs the fleet throttles itself to. Non-agent branches are dropped.
+ * Behind-ness is then read per cleanly-mergeable PR (a conflicted one is
+ * handled before any update, an unknown one left for the next Tick), and a
+ * conflicted PR's comments for the unresolved marker.
+ */
+async function listOpenAgentPrs(exec: Exec): Promise<OpenAgentPr[]> {
+  const stdout = await exec("gh", [
+    "pr",
+    "list",
+    "--state",
+    "open",
+    "--limit",
+    "100",
+    "--json",
+    "number,headRefName,baseRefName,isDraft,mergeable,statusCheckRollup",
+  ]);
+  const items = JSON.parse(stdout) as GhPrListItem[];
+  const prs: OpenAgentPr[] = [];
+  for (const item of items) {
+    const headRef = item.headRefName ?? "";
+    const ticket = ticketFromAgentBranch(headRef);
+    if (ticket === undefined) continue;
+    const mergeable = mergeabilityOf(item.mergeable);
+    const base = item.baseRefName ?? "";
+    prs.push({
+      number: item.number,
+      ticket,
+      headRef,
+      draft: item.isDraft ?? false,
+      mergeable,
+      behind: mergeable === "mergeable" && base !== "" ? await prBehindBase(base, headRef, exec) : false,
+      ci: ciFromRollup(item.statusCheckRollup ?? []),
+      conflictWorkerAsked:
+        mergeable === "conflicted" ? await readConflictWorkerAsked(item.number, exec) : false,
+    });
+  }
+  return prs;
 }
 
 /**
@@ -170,17 +288,17 @@ export async function readScope(scope: Scope, exec: Exec = realExec): Promise<Wo
   }
 
   // Agent PRs matter only while open tickets exist: orphan detection, the
-  // escalation veto, and the max_open_prs throttle read the open ones,
-  // closure verification the merged ones. A fully closed Scope needs
+  // escalation veto, the max_open_prs throttle, and PR upkeep read the open
+  // ones, closure verification the merged ones. A fully closed Scope needs
   // neither read.
   const hasOpenTickets = tickets.some((t) => t.state === "open");
   const inScope = new Set(tickets.map((t) => t.number));
-  const openAgentPrTickets = hasOpenTickets ? await listOpenAgentPrTickets(exec) : [];
+  const openAgentPrs = hasOpenTickets ? await listOpenAgentPrs(exec) : [];
   const mergedAgentPrs = hasOpenTickets
     ? (await listMergedAgentPrs(exec)).filter((pr) => inScope.has(pr.ticket))
     : [];
 
-  return { tickets, openAgentPrTickets, mergedAgentPrs };
+  return { tickets, openAgentPrs, mergedAgentPrs };
 }
 
 const CLAIM_COMMENT = `${CLAIM_MARKER}\n🐕 Claimed by border-collie: a Worker will be dispatched against this ticket. This assignment is agent-held — see CONTEXT.md "Claim".`;
@@ -341,4 +459,30 @@ export async function escalateTicket(
     "--add-label",
     READY_FOR_HUMAN,
   ]);
+}
+
+/**
+ * Act phase: mechanically merge the base into a cleanly-mergeable PR that has
+ * fallen behind. The GitHub update-branch API does the merge server-side — no
+ * worktree, no judgment — so a sibling stays current after every merge.
+ */
+export async function updatePrBranch(pr: number, exec: Exec = realExec): Promise<void> {
+  await exec("gh", ["api", "--method", "PUT", `repos/{owner}/{repo}/pulls/${pr}/update-branch`]);
+}
+
+/** Act phase: flip a draft PR to ready-for-review, surfacing it to the reviewer. */
+export async function markPrReady(pr: number, exec: Exec = realExec): Promise<void> {
+  await exec("gh", ["pr", "ready", String(pr)]);
+}
+
+const CONFLICT_UNRESOLVED_COMMENT = `${CONFLICT_UNRESOLVED_MARKER}\n🐕 border-collie ran a conflict-resolution Worker here, but it could not complete the merge. This PR needs a human to resolve the conflicts — border-collie will not dispatch another Worker for it.`;
+
+/**
+ * Act phase: mark a PR's conflict as human-owned after the conflict Worker
+ * gave up. The marker in this comment is what stops the next Tick dispatching
+ * a second Worker against a conflict a human now holds — the PR-level analogue
+ * of Escalation's forensic comment.
+ */
+export async function commentConflictUnresolved(pr: number, exec: Exec = realExec): Promise<void> {
+  await exec("gh", ["pr", "comment", String(pr), "--body", CONFLICT_UNRESOLVED_COMMENT]);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,6 +107,25 @@ export function parseAttemptMarker(body: string): AttemptFailure | undefined {
 }
 
 /**
+ * A Conflict Worker gave up on a PR and asked for a human: the marker that
+ * makes the ask structural, so the next Tick never re-dispatches a second
+ * Worker against a conflict a human now owns (the PR-level analogue of
+ * Escalation — see CONTEXT.md "Conflict Worker"). One failed Worker per
+ * conflict episode; a resolution that lands leaves no marker, so a PR the base
+ * later re-conflicts is eligible again.
+ *
+ * Posted only after a Worker completes and fails — deliberately not before
+ * dispatch. A pre-dispatch marker would guarantee at most one Worker even
+ * across an Orchestrator crash, but at the cost of silently stranding a PR
+ * whose Worker never ran (marker present, no human told, never retried). The
+ * post-failure marker instead lets a crash-voided session re-dispatch next
+ * Tick — the same stateless re-run recovery the Orchestrator uses everywhere
+ * (ADR 0001) — bounded because a session that actually ran and failed always
+ * lays the marker down.
+ */
+export const CONFLICT_UNRESOLVED_MARKER = "<!-- border-collie:conflict-unresolved -->";
+
+/**
  * Branch naming that makes a PR structurally an agent PR. Workers land with
  * a later ticket; the convention is fixed here because orphan detection
  * already reads it.
@@ -161,11 +180,53 @@ export interface MergedAgentPr {
   url: string;
 }
 
+/**
+ * Mergeability of an open agent PR against its base, as GitHub computes it.
+ * `unknown` is GitHub still working it out (or masked by the draft flag) — the
+ * planner leaves such a PR alone and re-reads it next Tick.
+ */
+export type Mergeability = "mergeable" | "conflicted" | "unknown";
+
+/**
+ * CI standing for a PR's head commit, from its check-run rollup. `none` means
+ * no checks at all — which the draft→ready gate reads as "no CI configured",
+ * so a repo without CI readies a PR immediately (the acceptance criterion).
+ */
+export type CiState = "none" | "pending" | "passing" | "failing";
+
+/**
+ * An open agent PR observed for a ticket, carrying the PR-upkeep signals: a
+ * merge into the base leaves clean siblings behind (mechanical update), some
+ * conflicted (a one-shot conflict Worker), and a green draft ready to surface
+ * to the reviewer. Read repo-wide, not per Scope — every agent PR is
+ * border-collie's, and keeping them current is a global concern (same reason
+ * the max_open_prs headroom counts them repo-wide).
+ */
+export interface OpenAgentPr {
+  /** PR number, the handle every upkeep write targets. */
+  number: number;
+  /** Ticket the PR implements, decoded from its agent branch. */
+  ticket: number;
+  /** Head branch — the agent branch; the conflict Worker checks it out and pushes it back. */
+  headRef: string;
+  /** GitHub draft flag: a draft is invisible to the reviewer until flipped ready. */
+  draft: boolean;
+  mergeable: Mergeability;
+  /** True when the head is behind its base and a mechanical update would advance it. */
+  behind: boolean;
+  ci: CiState;
+  /**
+   * True when a conflict-resolution Worker already asked for human help on
+   * this PR (the unresolved marker is present) — vetoes dispatching another.
+   */
+  conflictWorkerAsked: boolean;
+}
+
 /** Everything the planner knows about the world, recomputed each Tick. */
 export interface WorldSnapshot {
   tickets: Ticket[];
-  /** Ticket numbers with an open agent PR (head branch carries the agent prefix). */
-  openAgentPrTickets: number[];
+  /** Open agent PRs (head branch carries the agent prefix), read repo-wide. */
+  openAgentPrs: OpenAgentPr[];
   /** Merged agent PRs whose ticket is in Scope, latest per ticket. */
   mergedAgentPrs: MergedAgentPr[];
 }
@@ -185,14 +246,19 @@ export interface PlanConfig {
 
 /**
  * One intended write, produced by the pure plan phase.
- * A discriminated union that later tickets extend (open PR, ...). `release`
- * carries the observed assignee logins and `escalate` the observed attempt
- * records so the act phase needs no second look at the world. `spawn` carries
- * the attempt number; the caller binds it to a model (the retry ladder).
+ * A discriminated union. `release` carries the observed assignee logins and
+ * `escalate` the observed attempt records so the act phase needs no second
+ * look at the world. `spawn` carries the attempt number; the caller binds it
+ * to a model (the retry ladder). The three PR-upkeep actions carry the PR
+ * number plus the ticket (for the human-readable rendering) and, for the
+ * conflict Worker, the head branch it works in and pushes back.
  */
 export type Action =
   | { type: "claim"; ticket: number }
   | { type: "release"; ticket: number; assignees: string[] }
   | { type: "spawn"; ticket: number; attempt: number }
   | { type: "escalate"; ticket: number; failures: AttemptFailure[] }
-  | { type: "close"; ticket: number; prUrl: string };
+  | { type: "close"; ticket: number; prUrl: string }
+  | { type: "update-branch"; pr: number; ticket: number }
+  | { type: "conflict-worker"; pr: number; ticket: number; headRef: string }
+  | { type: "mark-ready"; pr: number; ticket: number };

--- a/src/worker.test.ts
+++ b/src/worker.test.ts
@@ -428,11 +428,11 @@ const CONFLICT_CONFIG: ConflictWorkerConfig = {
  * Fake the git side for a conflict Worker: the two `rev-parse HEAD` reads
  * return the head before and after the merge (distinct by default, so the
  * merge is judged to have advanced the branch); `diff` reports the unmerged
- * paths; `rev-parse MERGE_HEAD` resolves only while a merge is in progress
- * (git exits non-zero otherwise, which the code reads as "no merge in progress").
+ * paths; `rev-parse REBASE_HEAD` resolves only while a rebase is in progress
+ * (git exits non-zero otherwise, which the code reads as "no rebase in progress").
  */
 function fakeConflictExec(
-  opts: { unmerged?: string; mergeInProgress?: boolean; headBefore?: string; headAfter?: string } = {},
+  opts: { unmerged?: string; rebaseInProgress?: boolean; headBefore?: string; headAfter?: string } = {},
 ): { exec: Exec; calls: string[][] } {
   const calls: string[][] = [];
   let headReads = 0;
@@ -443,8 +443,8 @@ function fakeConflictExec(
       const sha = headReads === 1 ? (opts.headBefore ?? "head-before") : (opts.headAfter ?? "head-after");
       return `${sha}\n`;
     }
-    if (args.includes("rev-parse") && args.includes("MERGE_HEAD")) {
-      if (opts.mergeInProgress) return "merge-head-sha\n";
+    if (args.includes("rev-parse") && args.includes("REBASE_HEAD")) {
+      if (opts.rebaseInProgress) return "rebase-head-sha\n";
       throw new Error("fatal: needed a single revision");
     }
     if (args.includes("diff")) return opts.unmerged ?? "";
@@ -454,16 +454,17 @@ function fakeConflictExec(
 }
 
 describe("conflictWorkerPrompt", () => {
-  it("runs the merge-conflict skill and pins the commit-but-do-not-push contract", () => {
+  it("runs the merge-conflict skill against a rebase and pins the do-not-push contract", () => {
     const prompt = conflictWorkerPrompt();
 
     expect(prompt).toContain("/resolving-merge-conflicts");
+    expect(prompt).toContain("rebase");
     expect(prompt).toContain("do not push");
   });
 });
 
 describe("dispatchConflictWorker", () => {
-  it("checks out the PR's head branch, starts the base merge, runs claude, and cleans up", async () => {
+  it("checks out the PR's head branch, starts the rebase onto the base, runs claude, and cleans up", async () => {
     const { exec, calls } = fakeConflictExec();
     const { spawn, requests } = fakeSpawn(0);
 
@@ -475,11 +476,11 @@ describe("dispatchConflictWorker", () => {
       ["git", "fetch", "origin"],
       ["git", "worktree", "add", CONFLICT_WT, "-B", HEAD_REF, `origin/${HEAD_REF}`],
       ["git", "-C", CONFLICT_WT, "rev-parse", "HEAD"],
-      ["git", "-C", CONFLICT_WT, "merge", "--no-edit", "origin/HEAD"],
+      ["git", "-C", CONFLICT_WT, "rebase", "origin/HEAD"],
       ["git", "-C", CONFLICT_WT, "rev-parse", "HEAD"],
       ["git", "-C", CONFLICT_WT, "diff", "--name-only", "--diff-filter=U"],
-      ["git", "-C", CONFLICT_WT, "rev-parse", "-q", "--verify", "MERGE_HEAD"],
-      ["git", "-C", CONFLICT_WT, "merge", "--abort"],
+      ["git", "-C", CONFLICT_WT, "rev-parse", "-q", "--verify", "REBASE_HEAD"],
+      ["git", "-C", CONFLICT_WT, "rebase", "--abort"],
       ["git", "worktree", "remove", "--force", CONFLICT_WT],
     ]);
     expect(requests[0]).toMatchObject({
@@ -491,8 +492,8 @@ describe("dispatchConflictWorker", () => {
     expect(requests[0]?.args).toContain("sonnet");
   });
 
-  it("resolves when the Worker exits cleanly leaving no unmerged paths and no merge in progress", async () => {
-    const { exec } = fakeConflictExec({ unmerged: "", mergeInProgress: false });
+  it("resolves when the Worker exits cleanly leaving no unmerged paths and no rebase in progress", async () => {
+    const { exec } = fakeConflictExec({ unmerged: "", rebaseInProgress: false });
     const { spawn } = fakeSpawn(0);
 
     const outcome = await dispatchConflictWorker(30, 3, HEAD_REF, CONFLICT_CONFIG, exec, spawn);
@@ -509,7 +510,7 @@ describe("dispatchConflictWorker", () => {
 
   it("fails to resolve when the head did not advance (the merge never started)", async () => {
     // A merge that never began (e.g. the base ref could not be read) leaves a
-    // clean tree and no MERGE_HEAD — the head is unchanged, so it is NOT resolved.
+    // clean tree and no REBASE_HEAD — the head is unchanged, so it is NOT resolved.
     const { exec } = fakeConflictExec({ headBefore: "same-sha", headAfter: "same-sha" });
     const { spawn } = fakeSpawn(0);
 
@@ -527,8 +528,8 @@ describe("dispatchConflictWorker", () => {
     expect(outcome.resolved).toBe(false);
   });
 
-  it("fails to resolve when the merge is left in progress (uncommitted)", async () => {
-    const { exec } = fakeConflictExec({ mergeInProgress: true });
+  it("fails to resolve when the rebase is left in progress (mid-conflict)", async () => {
+    const { exec } = fakeConflictExec({ rebaseInProgress: true });
     const { spawn } = fakeSpawn(0);
 
     const outcome = await dispatchConflictWorker(30, 3, HEAD_REF, CONFLICT_CONFIG, exec, spawn);
@@ -564,7 +565,7 @@ describe("dispatchConflictWorker", () => {
     ).rejects.toThrow("ENOENT");
 
     expect(calls.slice(-2)).toEqual([
-      ["git", "-C", CONFLICT_WT, "merge", "--abort"],
+      ["git", "-C", CONFLICT_WT, "rebase", "--abort"],
       ["git", "worktree", "remove", "--force", CONFLICT_WT],
     ]);
   });

--- a/src/worker.test.ts
+++ b/src/worker.test.ts
@@ -425,29 +425,18 @@ const CONFLICT_CONFIG: ConflictWorkerConfig = {
 };
 
 /**
- * Fake the git side for a conflict Worker: the two `rev-parse HEAD` reads
- * return the head before and after the merge (distinct by default, so the
- * merge is judged to have advanced the branch); `diff` reports the unmerged
- * paths; `rev-parse REBASE_HEAD` resolves only while a rebase is in progress
- * (git exits non-zero otherwise, which the code reads as "no rebase in progress").
+ * Fake the git side for a conflict Worker: `merge-base --is-ancestor` exits
+ * cleanly when the branch was rebased onto the base (the default) and throws
+ * otherwise — git's exit-1 for "not an ancestor", which the code reads as an
+ * incomplete or never-started rebase.
  */
-function fakeConflictExec(
-  opts: { unmerged?: string; rebaseInProgress?: boolean; headBefore?: string; headAfter?: string } = {},
-): { exec: Exec; calls: string[][] } {
+function fakeConflictExec(opts: { rebased?: boolean } = {}): { exec: Exec; calls: string[][] } {
   const calls: string[][] = [];
-  let headReads = 0;
   const exec: Exec = async (cmd, args) => {
     calls.push([cmd, ...args]);
-    if (args.includes("rev-parse") && args.includes("HEAD")) {
-      headReads += 1;
-      const sha = headReads === 1 ? (opts.headBefore ?? "head-before") : (opts.headAfter ?? "head-after");
-      return `${sha}\n`;
+    if (args.includes("merge-base") && opts.rebased === false) {
+      throw new Error("exit 1: origin/HEAD is not an ancestor");
     }
-    if (args.includes("rev-parse") && args.includes("REBASE_HEAD")) {
-      if (opts.rebaseInProgress) return "rebase-head-sha\n";
-      throw new Error("fatal: needed a single revision");
-    }
-    if (args.includes("diff")) return opts.unmerged ?? "";
     return "";
   };
   return { exec, calls };
@@ -475,11 +464,8 @@ describe("dispatchConflictWorker", () => {
       ["git", "worktree", "prune"],
       ["git", "fetch", "origin"],
       ["git", "worktree", "add", CONFLICT_WT, "-B", HEAD_REF, `origin/${HEAD_REF}`],
-      ["git", "-C", CONFLICT_WT, "rev-parse", "HEAD"],
       ["git", "-C", CONFLICT_WT, "rebase", "origin/HEAD"],
-      ["git", "-C", CONFLICT_WT, "rev-parse", "HEAD"],
-      ["git", "-C", CONFLICT_WT, "diff", "--name-only", "--diff-filter=U"],
-      ["git", "-C", CONFLICT_WT, "rev-parse", "-q", "--verify", "REBASE_HEAD"],
+      ["git", "-C", CONFLICT_WT, "merge-base", "--is-ancestor", "origin/HEAD", HEAD_REF],
       ["git", "-C", CONFLICT_WT, "rebase", "--abort"],
       ["git", "worktree", "remove", "--force", CONFLICT_WT],
     ]);
@@ -492,8 +478,8 @@ describe("dispatchConflictWorker", () => {
     expect(requests[0]?.args).toContain("sonnet");
   });
 
-  it("resolves when the Worker exits cleanly leaving no unmerged paths and no rebase in progress", async () => {
-    const { exec } = fakeConflictExec({ unmerged: "", rebaseInProgress: false });
+  it("resolves when the Worker exits cleanly and the branch now sits atop the base", async () => {
+    const { exec } = fakeConflictExec({ rebased: true });
     const { spawn } = fakeSpawn(0);
 
     const outcome = await dispatchConflictWorker(30, 3, HEAD_REF, CONFLICT_CONFIG, exec, spawn);
@@ -508,10 +494,11 @@ describe("dispatchConflictWorker", () => {
     });
   });
 
-  it("fails to resolve when the head did not advance (the merge never started)", async () => {
-    // A merge that never began (e.g. the base ref could not be read) leaves a
-    // clean tree and no REBASE_HEAD — the head is unchanged, so it is NOT resolved.
-    const { exec } = fakeConflictExec({ headBefore: "same-sha", headAfter: "same-sha" });
+  it("fails to resolve when the branch never made it onto the base (mid-flight or never-started rebase)", async () => {
+    // Both a rebase left mid-conflict and one that never began (e.g. the base
+    // ref could not be read) leave the branch at its old tip, which does not
+    // contain the base — the one signal the containment check reads.
+    const { exec } = fakeConflictExec({ rebased: false });
     const { spawn } = fakeSpawn(0);
 
     const outcome = await dispatchConflictWorker(30, 3, HEAD_REF, CONFLICT_CONFIG, exec, spawn);
@@ -519,25 +506,7 @@ describe("dispatchConflictWorker", () => {
     expect(outcome.resolved).toBe(false);
   });
 
-  it("fails to resolve when unmerged paths remain", async () => {
-    const { exec } = fakeConflictExec({ unmerged: "src/app.ts\n" });
-    const { spawn } = fakeSpawn(0);
-
-    const outcome = await dispatchConflictWorker(30, 3, HEAD_REF, CONFLICT_CONFIG, exec, spawn);
-
-    expect(outcome.resolved).toBe(false);
-  });
-
-  it("fails to resolve when the rebase is left in progress (mid-conflict)", async () => {
-    const { exec } = fakeConflictExec({ rebaseInProgress: true });
-    const { spawn } = fakeSpawn(0);
-
-    const outcome = await dispatchConflictWorker(30, 3, HEAD_REF, CONFLICT_CONFIG, exec, spawn);
-
-    expect(outcome.resolved).toBe(false);
-  });
-
-  it("fails to resolve on a non-zero exit even with a clean tree", async () => {
+  it("fails to resolve on a non-zero exit even when the branch was rebased", async () => {
     const { exec } = fakeConflictExec();
     const { spawn } = fakeSpawn(1);
 
@@ -547,7 +516,7 @@ describe("dispatchConflictWorker", () => {
     expect(outcome.exitCode).toBe(1);
   });
 
-  it("fails to resolve when the Worker was killed at a watchdog, even with a clean tree", async () => {
+  it("fails to resolve when the Worker was killed at a watchdog, even when the branch was rebased", async () => {
     const { exec } = fakeConflictExec();
     const { spawn } = fakeSpawn(null, "timeout");
 

--- a/src/worker.test.ts
+++ b/src/worker.test.ts
@@ -5,11 +5,14 @@ import { describe, expect, it } from "vitest";
 import type { Exec } from "./tracker.js";
 import {
   branchCommitSubjects,
+  conflictWorkerPrompt,
+  dispatchConflictWorker,
   dispatchWorker,
   probeEnvironment,
   pushAgentBranch,
   realSpawnWorkerProcess,
   workerPrompt,
+  type ConflictWorkerConfig,
   type SpawnWorkerProcess,
   type WorkerConfig,
   type WorkerProcessExit,
@@ -408,6 +411,162 @@ describe("pushAgentBranch", () => {
     await pushAgentBranch(BRANCH, exec);
 
     expect(calls).toEqual([["git", "push", "--force", "origin", BRANCH]]);
+  });
+});
+
+const CONFLICT_WT = ".border-collie/conflict-worktrees/pr-30";
+const HEAD_REF = "border-collie/ticket-3-attempt-1";
+const CONFLICT_TRANSCRIPT = ".border-collie/transcripts/pr-30-conflict.jsonl";
+const CONFLICT_CONFIG: ConflictWorkerConfig = {
+  model: "sonnet",
+  timeoutMs: 60_000,
+  stallMs: 30_000,
+  maxTurns: 200,
+};
+
+/**
+ * Fake the git side for a conflict Worker: the two `rev-parse HEAD` reads
+ * return the head before and after the merge (distinct by default, so the
+ * merge is judged to have advanced the branch); `diff` reports the unmerged
+ * paths; `rev-parse MERGE_HEAD` resolves only while a merge is in progress
+ * (git exits non-zero otherwise, which the code reads as "no merge in progress").
+ */
+function fakeConflictExec(
+  opts: { unmerged?: string; mergeInProgress?: boolean; headBefore?: string; headAfter?: string } = {},
+): { exec: Exec; calls: string[][] } {
+  const calls: string[][] = [];
+  let headReads = 0;
+  const exec: Exec = async (cmd, args) => {
+    calls.push([cmd, ...args]);
+    if (args.includes("rev-parse") && args.includes("HEAD")) {
+      headReads += 1;
+      const sha = headReads === 1 ? (opts.headBefore ?? "head-before") : (opts.headAfter ?? "head-after");
+      return `${sha}\n`;
+    }
+    if (args.includes("rev-parse") && args.includes("MERGE_HEAD")) {
+      if (opts.mergeInProgress) return "merge-head-sha\n";
+      throw new Error("fatal: needed a single revision");
+    }
+    if (args.includes("diff")) return opts.unmerged ?? "";
+    return "";
+  };
+  return { exec, calls };
+}
+
+describe("conflictWorkerPrompt", () => {
+  it("runs the merge-conflict skill and pins the commit-but-do-not-push contract", () => {
+    const prompt = conflictWorkerPrompt();
+
+    expect(prompt).toContain("/resolving-merge-conflicts");
+    expect(prompt).toContain("do not push");
+  });
+});
+
+describe("dispatchConflictWorker", () => {
+  it("checks out the PR's head branch, starts the base merge, runs claude, and cleans up", async () => {
+    const { exec, calls } = fakeConflictExec();
+    const { spawn, requests } = fakeSpawn(0);
+
+    await dispatchConflictWorker(30, 3, HEAD_REF, CONFLICT_CONFIG, exec, spawn);
+
+    expect(calls).toEqual([
+      ["git", "worktree", "remove", "--force", CONFLICT_WT],
+      ["git", "worktree", "prune"],
+      ["git", "fetch", "origin"],
+      ["git", "worktree", "add", CONFLICT_WT, "-B", HEAD_REF, `origin/${HEAD_REF}`],
+      ["git", "-C", CONFLICT_WT, "rev-parse", "HEAD"],
+      ["git", "-C", CONFLICT_WT, "merge", "--no-edit", "origin/HEAD"],
+      ["git", "-C", CONFLICT_WT, "rev-parse", "HEAD"],
+      ["git", "-C", CONFLICT_WT, "diff", "--name-only", "--diff-filter=U"],
+      ["git", "-C", CONFLICT_WT, "rev-parse", "-q", "--verify", "MERGE_HEAD"],
+      ["git", "-C", CONFLICT_WT, "merge", "--abort"],
+      ["git", "worktree", "remove", "--force", CONFLICT_WT],
+    ]);
+    expect(requests[0]).toMatchObject({
+      cmd: "claude",
+      cwd: CONFLICT_WT,
+      transcriptPath: CONFLICT_TRANSCRIPT,
+    });
+    expect(requests[0]?.args).toContain(conflictWorkerPrompt());
+    expect(requests[0]?.args).toContain("sonnet");
+  });
+
+  it("resolves when the Worker exits cleanly leaving no unmerged paths and no merge in progress", async () => {
+    const { exec } = fakeConflictExec({ unmerged: "", mergeInProgress: false });
+    const { spawn } = fakeSpawn(0);
+
+    const outcome = await dispatchConflictWorker(30, 3, HEAD_REF, CONFLICT_CONFIG, exec, spawn);
+
+    expect(outcome).toEqual({
+      pr: 30,
+      ticket: 3,
+      headRef: HEAD_REF,
+      transcript: CONFLICT_TRANSCRIPT,
+      exitCode: 0,
+      resolved: true,
+    });
+  });
+
+  it("fails to resolve when the head did not advance (the merge never started)", async () => {
+    // A merge that never began (e.g. the base ref could not be read) leaves a
+    // clean tree and no MERGE_HEAD — the head is unchanged, so it is NOT resolved.
+    const { exec } = fakeConflictExec({ headBefore: "same-sha", headAfter: "same-sha" });
+    const { spawn } = fakeSpawn(0);
+
+    const outcome = await dispatchConflictWorker(30, 3, HEAD_REF, CONFLICT_CONFIG, exec, spawn);
+
+    expect(outcome.resolved).toBe(false);
+  });
+
+  it("fails to resolve when unmerged paths remain", async () => {
+    const { exec } = fakeConflictExec({ unmerged: "src/app.ts\n" });
+    const { spawn } = fakeSpawn(0);
+
+    const outcome = await dispatchConflictWorker(30, 3, HEAD_REF, CONFLICT_CONFIG, exec, spawn);
+
+    expect(outcome.resolved).toBe(false);
+  });
+
+  it("fails to resolve when the merge is left in progress (uncommitted)", async () => {
+    const { exec } = fakeConflictExec({ mergeInProgress: true });
+    const { spawn } = fakeSpawn(0);
+
+    const outcome = await dispatchConflictWorker(30, 3, HEAD_REF, CONFLICT_CONFIG, exec, spawn);
+
+    expect(outcome.resolved).toBe(false);
+  });
+
+  it("fails to resolve on a non-zero exit even with a clean tree", async () => {
+    const { exec } = fakeConflictExec();
+    const { spawn } = fakeSpawn(1);
+
+    const outcome = await dispatchConflictWorker(30, 3, HEAD_REF, CONFLICT_CONFIG, exec, spawn);
+
+    expect(outcome.resolved).toBe(false);
+    expect(outcome.exitCode).toBe(1);
+  });
+
+  it("fails to resolve when the Worker was killed at a watchdog, even with a clean tree", async () => {
+    const { exec } = fakeConflictExec();
+    const { spawn } = fakeSpawn(null, "timeout");
+
+    const outcome = await dispatchConflictWorker(30, 3, HEAD_REF, CONFLICT_CONFIG, exec, spawn);
+
+    expect(outcome.resolved).toBe(false);
+  });
+
+  it("still aborts the merge and removes the worktree when spawning throws, then rethrows", async () => {
+    const { exec, calls } = fakeConflictExec();
+    const { spawn } = fakeSpawn(new Error("spawn claude ENOENT"));
+
+    await expect(
+      dispatchConflictWorker(30, 3, HEAD_REF, CONFLICT_CONFIG, exec, spawn),
+    ).rejects.toThrow("ENOENT");
+
+    expect(calls.slice(-2)).toEqual([
+      ["git", "-C", CONFLICT_WT, "merge", "--abort"],
+      ["git", "worktree", "remove", "--force", CONFLICT_WT],
+    ]);
   });
 });
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -15,21 +15,25 @@ import { AGENT_BRANCH_PREFIX, type FailureReason, type InfraReason } from "./typ
 /** Orchestrator-owned scratch space at the target repo root (gitignored). */
 export const RUN_DIR = ".border-collie";
 
-export interface WorkerConfig {
+/** The headless-claude run limits shared by dispatch and conflict Workers. */
+export interface ClaudeRunConfig {
   /** Model the Worker runs on (`claude --model`). */
   model: string;
-  /**
-   * Which Attempt this dispatch is (1-based). Namespaces the branch and
-   * transcript so a retry never clobbers the prior attempt's evidence — an
-   * Escalation must be able to cite every attempt's forensics.
-   */
-  attempt: number;
   /** Wall-clock ceiling for the whole Worker process. */
   timeoutMs: number;
   /** Max quiet time between output events before the Worker counts as stalled. */
   stallMs: number;
   /** Budget backstop: max agentic turns (`claude --max-turns`); breach is a ticket failure. */
   maxTurns: number;
+}
+
+export interface WorkerConfig extends ClaudeRunConfig {
+  /**
+   * Which Attempt this dispatch is (1-based). Namespaces the branch and
+   * transcript so a retry never clobbers the prior attempt's evidence — an
+   * Escalation must be able to cite every attempt's forensics.
+   */
+  attempt: number;
   /**
    * Budget alarm: spend in USD above which an Attempt is flagged as a cost
    * overrun. Cost is only knowable post-hoc, so a finished Attempt's work is
@@ -37,6 +41,22 @@ export interface WorkerConfig {
    * turn cap and wall clock are the stoppers, this is the meter.
    */
   maxCostUsd: number;
+}
+
+/** The headless-claude argv every Worker shares: prompt, model, turn cap, stream-json, skip-permissions. */
+function claudeArgs(prompt: string, model: string, maxTurns: number): string[] {
+  return [
+    "-p",
+    prompt,
+    "--model",
+    model,
+    "--max-turns",
+    String(maxTurns),
+    "--output-format",
+    "stream-json",
+    "--verbose",
+    "--dangerously-skip-permissions",
+  ];
 }
 
 /** One finished Attempt, as observed by the Orchestrator. */
@@ -191,6 +211,21 @@ export function workerPrompt(ticket: number): string {
   ].join("\n");
 }
 
+/**
+ * The entire conflict-resolution Worker prompt: run the merge-conflict skill
+ * against a merge the Orchestrator has already started, then stop. The
+ * plain-English half stands in when the slash command is unavailable, and
+ * pins the contract the Orchestrator relies on — commit the merge, touch
+ * nothing else, do not push.
+ */
+export function conflictWorkerPrompt(): string {
+  return [
+    "/resolving-merge-conflicts",
+    "",
+    "A merge of the base branch into this pull request's branch is already in progress and has conflicts. Resolve every conflict and complete the merge with a commit. Change nothing beyond what resolving the conflicts requires, and do not push — leave the committed merge on the current branch.",
+  ].join("\n");
+}
+
 /** Best-effort worktree removal: absent or stale worktrees are fine. */
 async function removeWorktree(worktree: string, exec: Exec): Promise<void> {
   await exec("git", ["worktree", "remove", "--force", worktree]).catch(() => {});
@@ -274,18 +309,7 @@ export async function dispatchWorker(
     // own tracker.
     const { exitCode, endedBy, stdoutTail, stderrTail } = await spawnProcess({
       cmd: "claude",
-      args: [
-        "-p",
-        workerPrompt(ticket),
-        "--model",
-        config.model,
-        "--max-turns",
-        String(config.maxTurns),
-        "--output-format",
-        "stream-json",
-        "--verbose",
-        "--dangerously-skip-permissions",
-      ],
+      args: claudeArgs(workerPrompt(ticket), config.model, config.maxTurns),
       cwd: worktree,
       transcriptPath: transcript,
       stderrPath: stderrLog,
@@ -381,4 +405,104 @@ export async function probeEnvironment(
     exitCode === 0 &&
     classifyInfrastructure(`${stderrTail}\n${stdoutTail}`) === undefined
   );
+}
+
+/** What a conflict-resolution Worker runs with; no attempt ladder — one shot. */
+export type ConflictWorkerConfig = ClaudeRunConfig;
+
+/** One finished conflict-resolution session, as observed by the Orchestrator. */
+export interface ConflictOutcome {
+  pr: number;
+  ticket: number;
+  /** Head branch the Worker resolved in; pushed back on success. */
+  headRef: string;
+  /** Transcript file path, for post-mortems. */
+  transcript: string;
+  exitCode: number | null;
+  /**
+   * True when the base merged into the head and the merge is committed: the
+   * Worker exited on its own, the head advanced past the PR's original tip,
+   * no unmerged paths remain, and no merge is still in progress. The
+   * head-advanced check is load-bearing — a merge that never started (e.g. the
+   * base ref could not be read) leaves a clean tree and no MERGE_HEAD, which
+   * would otherwise read as a false success and loop Workers forever.
+   */
+  resolved: boolean;
+}
+
+/**
+ * Dispatch one conflict-resolution Worker against one conflicted agent PR: cut
+ * a worktree on the PR's own head branch, start the merge of the base into it
+ * so the merge-conflict skill has an in-progress conflict to resolve, run
+ * headless claude, then judge whether the merge landed. The branch is the PR's
+ * existing head (checked out from origin), never a fresh one — the resolution
+ * has to push back to the same branch the PR is opened from. `-B` and the
+ * up-front removal reset any leftover of a crashed run on the same branch. On
+ * success the caller pushes the branch; on failure the merge is aborted so the
+ * retained branch stays at the PR's committed head — a broken merge is never
+ * published — and the caller asks a human to take over.
+ */
+export async function dispatchConflictWorker(
+  pr: number,
+  ticket: number,
+  headRef: string,
+  config: ConflictWorkerConfig,
+  exec: Exec = realExec,
+  spawnProcess: SpawnWorkerProcess = realSpawnWorkerProcess,
+): Promise<ConflictOutcome> {
+  const worktree = join(RUN_DIR, "conflict-worktrees", `pr-${pr}`);
+  const transcript = join(RUN_DIR, "transcripts", `pr-${pr}-conflict.jsonl`);
+  const stderrLog = join(RUN_DIR, "transcripts", `pr-${pr}-conflict.stderr.log`);
+
+  let beforeSha = "";
+  await withGitLock(async () => {
+    await removeWorktree(worktree, exec);
+    await exec("git", ["worktree", "prune"]);
+    await exec("git", ["fetch", "origin"]);
+    await exec("git", ["worktree", "add", worktree, "-B", headRef, `origin/${headRef}`]);
+    beforeSha = (await exec("git", ["-C", worktree, "rev-parse", "HEAD"])).trim();
+    // A conflicting merge exits non-zero and leaves the merge in progress for
+    // the Worker; swallow that so setting up the conflict never throws.
+    await exec("git", ["-C", worktree, "merge", "--no-edit", "origin/HEAD"]).catch(() => {});
+  });
+
+  try {
+    const { exitCode, endedBy } = await spawnProcess({
+      cmd: "claude",
+      args: claudeArgs(conflictWorkerPrompt(), config.model, config.maxTurns),
+      cwd: worktree,
+      transcriptPath: transcript,
+      stderrPath: stderrLog,
+      timeoutMs: config.timeoutMs,
+      stallMs: config.stallMs,
+    });
+    const afterSha = (
+      await withGitLock(() => exec("git", ["-C", worktree, "rev-parse", "HEAD"]))
+    ).trim();
+    const unmerged = (
+      await withGitLock(() =>
+        exec("git", ["-C", worktree, "diff", "--name-only", "--diff-filter=U"]),
+      )
+    ).trim();
+    const mergeInProgress = await withGitLock(() =>
+      exec("git", ["-C", worktree, "rev-parse", "-q", "--verify", "MERGE_HEAD"]).then(
+        () => true,
+        () => false,
+      ),
+    );
+    const resolved =
+      endedBy === "exit" &&
+      exitCode === 0 &&
+      afterSha !== beforeSha &&
+      unmerged === "" &&
+      !mergeInProgress;
+    return { pr, ticket, headRef, transcript, exitCode, resolved };
+  } finally {
+    // Abort any half-finished merge before dropping the worktree; a no-op when
+    // the Worker already committed the merge cleanly.
+    await withGitLock(async () => {
+      await exec("git", ["-C", worktree, "merge", "--abort"]).catch(() => {});
+      await removeWorktree(worktree, exec);
+    });
+  }
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -421,13 +421,14 @@ export interface ConflictOutcome {
   transcript: string;
   exitCode: number | null;
   /**
-   * True when the head is fully rebased onto the base: the Worker exited on
-   * its own, the head moved off the PR's original tip (rebasing onto a new
-   * base always rewrites it), no unmerged paths remain, and no rebase is
-   * still in progress. The head-moved check is load-bearing — a rebase that
-   * never started (e.g. the base ref could not be read) leaves a clean tree
-   * and no REBASE_HEAD, which would otherwise read as a false success and
-   * loop Workers forever.
+   * True when the branch is fully rebased onto the base: the Worker exited on
+   * its own and the branch ref now contains origin/HEAD. Containment is the
+   * whole test — git moves the branch ref only when a rebase runs to
+   * completion, so a rebase left mid-flight (or never started, e.g. the base
+   * ref could not be read) leaves the branch at its conflicted old tip, which
+   * predates the base. Deliberately NOT probed via REBASE_HEAD: git leaves
+   * that ref behind after a successful `rebase --continue`, which read a
+   * finished rebase as still-in-progress (a false failure).
    */
   resolved: boolean;
 }
@@ -460,13 +461,11 @@ export async function dispatchConflictWorker(
   const transcript = join(RUN_DIR, "transcripts", `pr-${pr}-conflict.jsonl`);
   const stderrLog = join(RUN_DIR, "transcripts", `pr-${pr}-conflict.stderr.log`);
 
-  let beforeSha = "";
   await withGitLock(async () => {
     await removeWorktree(worktree, exec);
     await exec("git", ["worktree", "prune"]);
     await exec("git", ["fetch", "origin"]);
     await exec("git", ["worktree", "add", worktree, "-B", headRef, `origin/${headRef}`]);
-    beforeSha = (await exec("git", ["-C", worktree, "rev-parse", "HEAD"])).trim();
     // A conflicting rebase exits non-zero and stops in progress for the
     // Worker; swallow that so setting up the conflict never throws.
     await exec("git", ["-C", worktree, "rebase", "origin/HEAD"]).catch(() => {});
@@ -482,26 +481,15 @@ export async function dispatchConflictWorker(
       timeoutMs: config.timeoutMs,
       stallMs: config.stallMs,
     });
-    const afterSha = (
-      await withGitLock(() => exec("git", ["-C", worktree, "rev-parse", "HEAD"]))
-    ).trim();
-    const unmerged = (
-      await withGitLock(() =>
-        exec("git", ["-C", worktree, "diff", "--name-only", "--diff-filter=U"]),
-      )
-    ).trim();
-    const rebaseInProgress = await withGitLock(() =>
-      exec("git", ["-C", worktree, "rev-parse", "-q", "--verify", "REBASE_HEAD"]).then(
+    // The branch ref, not HEAD: mid-rebase HEAD is detached on the commit
+    // being replayed, while the branch only moves on completion.
+    const rebased = await withGitLock(() =>
+      exec("git", ["-C", worktree, "merge-base", "--is-ancestor", "origin/HEAD", headRef]).then(
         () => true,
         () => false,
       ),
     );
-    const resolved =
-      endedBy === "exit" &&
-      exitCode === 0 &&
-      afterSha !== beforeSha &&
-      unmerged === "" &&
-      !rebaseInProgress;
+    const resolved = endedBy === "exit" && exitCode === 0 && rebased;
     return { pr, ticket, headRef, transcript, exitCode, resolved };
   } finally {
     // Abort any half-finished rebase before dropping the worktree; a no-op

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -213,16 +213,17 @@ export function workerPrompt(ticket: number): string {
 
 /**
  * The entire conflict-resolution Worker prompt: run the merge-conflict skill
- * against a merge the Orchestrator has already started, then stop. The
+ * against a rebase the Orchestrator has already started, then stop. The
  * plain-English half stands in when the slash command is unavailable, and
- * pins the contract the Orchestrator relies on — commit the merge, touch
- * nothing else, do not push.
+ * pins the contract the Orchestrator relies on — finish the rebase, touch
+ * nothing else, do not push. A rebase, not a merge, so the agent branch stays
+ * linear and the operator's "Rebase and merge" strategy keeps working.
  */
 export function conflictWorkerPrompt(): string {
   return [
     "/resolving-merge-conflicts",
     "",
-    "A merge of the base branch into this pull request's branch is already in progress and has conflicts. Resolve every conflict and complete the merge with a commit. Change nothing beyond what resolving the conflicts requires, and do not push — leave the committed merge on the current branch.",
+    "A rebase of this pull request's branch onto the base branch is already in progress and has conflicts. Resolve every conflict and continue the rebase until every commit is applied. Change nothing beyond what resolving the conflicts requires, and do not push — leave the completed rebase on the current branch.",
   ].join("\n");
 }
 
@@ -420,27 +421,32 @@ export interface ConflictOutcome {
   transcript: string;
   exitCode: number | null;
   /**
-   * True when the base merged into the head and the merge is committed: the
-   * Worker exited on its own, the head advanced past the PR's original tip,
-   * no unmerged paths remain, and no merge is still in progress. The
-   * head-advanced check is load-bearing — a merge that never started (e.g. the
-   * base ref could not be read) leaves a clean tree and no MERGE_HEAD, which
-   * would otherwise read as a false success and loop Workers forever.
+   * True when the head is fully rebased onto the base: the Worker exited on
+   * its own, the head moved off the PR's original tip (rebasing onto a new
+   * base always rewrites it), no unmerged paths remain, and no rebase is
+   * still in progress. The head-moved check is load-bearing — a rebase that
+   * never started (e.g. the base ref could not be read) leaves a clean tree
+   * and no REBASE_HEAD, which would otherwise read as a false success and
+   * loop Workers forever.
    */
   resolved: boolean;
 }
 
 /**
  * Dispatch one conflict-resolution Worker against one conflicted agent PR: cut
- * a worktree on the PR's own head branch, start the merge of the base into it
- * so the merge-conflict skill has an in-progress conflict to resolve, run
- * headless claude, then judge whether the merge landed. The branch is the PR's
- * existing head (checked out from origin), never a fresh one — the resolution
- * has to push back to the same branch the PR is opened from. `-B` and the
- * up-front removal reset any leftover of a crashed run on the same branch. On
- * success the caller pushes the branch; on failure the merge is aborted so the
- * retained branch stays at the PR's committed head — a broken merge is never
- * published — and the caller asks a human to take over.
+ * a worktree on the PR's own head branch, start the rebase onto the base so
+ * the merge-conflict skill has an in-progress conflict to resolve, run
+ * headless claude, then judge whether the rebase completed. A rebase, never a
+ * merge commit: the branch stays linear, so the operator's "Rebase and merge"
+ * strategy keeps working (a resolution recorded in a merge commit is dropped
+ * when that strategy replays the branch's commits, re-conflicting them). The
+ * branch is the PR's existing head (checked out from origin), never a fresh
+ * one — the resolution has to force-push back to the same branch the PR is
+ * opened from. `-B` and the up-front removal reset any leftover of a crashed
+ * run on the same branch. On success the caller pushes the branch; on failure
+ * the rebase is aborted so the retained branch stays at the PR's committed
+ * head — a broken rebase is never published — and the caller asks a human to
+ * take over.
  */
 export async function dispatchConflictWorker(
   pr: number,
@@ -461,9 +467,9 @@ export async function dispatchConflictWorker(
     await exec("git", ["fetch", "origin"]);
     await exec("git", ["worktree", "add", worktree, "-B", headRef, `origin/${headRef}`]);
     beforeSha = (await exec("git", ["-C", worktree, "rev-parse", "HEAD"])).trim();
-    // A conflicting merge exits non-zero and leaves the merge in progress for
-    // the Worker; swallow that so setting up the conflict never throws.
-    await exec("git", ["-C", worktree, "merge", "--no-edit", "origin/HEAD"]).catch(() => {});
+    // A conflicting rebase exits non-zero and stops in progress for the
+    // Worker; swallow that so setting up the conflict never throws.
+    await exec("git", ["-C", worktree, "rebase", "origin/HEAD"]).catch(() => {});
   });
 
   try {
@@ -484,8 +490,8 @@ export async function dispatchConflictWorker(
         exec("git", ["-C", worktree, "diff", "--name-only", "--diff-filter=U"]),
       )
     ).trim();
-    const mergeInProgress = await withGitLock(() =>
-      exec("git", ["-C", worktree, "rev-parse", "-q", "--verify", "MERGE_HEAD"]).then(
+    const rebaseInProgress = await withGitLock(() =>
+      exec("git", ["-C", worktree, "rev-parse", "-q", "--verify", "REBASE_HEAD"]).then(
         () => true,
         () => false,
       ),
@@ -495,13 +501,13 @@ export async function dispatchConflictWorker(
       exitCode === 0 &&
       afterSha !== beforeSha &&
       unmerged === "" &&
-      !mergeInProgress;
+      !rebaseInProgress;
     return { pr, ticket, headRef, transcript, exitCode, resolved };
   } finally {
-    // Abort any half-finished merge before dropping the worktree; a no-op when
-    // the Worker already committed the merge cleanly.
+    // Abort any half-finished rebase before dropping the worktree; a no-op
+    // when the Worker already completed the rebase.
     await withGitLock(async () => {
-      await exec("git", ["-C", worktree, "merge", "--abort"]).catch(() => {});
+      await exec("git", ["-C", worktree, "rebase", "--abort"]).catch(() => {});
       await removeWorktree(worktree, exec);
     });
   }


### PR DESCRIPTION
## What this does

After each merge, the remaining open agent PRs are kept current — one upkeep Action per PR per Tick, threaded through the pure plan phase:

- **`update-branch`** — a cleanly-mergeable agent PR that fell behind its base gets a mechanical server-side rebase (`gh pr update-branch --rebase`). Behind-ness is read from the compare API's `behind_by`, not `mergeStateStatus` (which reports `DRAFT` for drafts and only surfaces `BEHIND` under branch protection).
- **`conflict-worker`** — a conflicted PR gets exactly one Conflict Worker: a fresh-context headless claude in a worktree on the PR's own branch, continuing an Orchestrator-started rebase onto the base via the merge-conflict skill. A completed rebase is force-pushed; a failure posts a marker comment asking for human resolution, which structurally vetoes any second Worker.
- **`mark-ready`** — a draft flips to ready-for-review once its CI rollup is green, or immediately when the repo has no checks configured. Decided on CI alone, independent of mergeability.

`WorldSnapshot.openAgentPrTickets: number[]` becomes `openAgentPrs: OpenAgentPr[]` carrying the upkeep signals (draft, mergeability, behind, CI rollup, conflict-marker), read via `gh pr list`. CONTEXT.md gains the **PR upkeep** and **Conflict Worker** glossary entries.

## Design decisions

- **Rebase, never merge commits.** All upkeep keeps agent branches linear so the "Rebase and merge" strategy stays available — a resolution recorded in a merge commit is dropped when that strategy replays the branch's commits, re-conflicting them (observed in pasture testing).
- **Conflict success is judged by containment** (`git merge-base --is-ancestor origin/HEAD <branch>`), not by probing `REBASE_HEAD` — git leaves that ref behind after a successful `rebase --continue` (reproduced on git 2.55), which had a finished rebase reading as still-in-progress in the pasture (PR #100 false failure).
- **The unresolved marker is posted after failure, not before dispatch**: a crash mid-Worker re-dispatches next Tick (the standard stateless re-run recovery, ADR 0001) rather than silently stranding a PR behind a pre-emptive marker.

## Verification

- 225 tests passing, typecheck and build clean.
- Pasture-tested: draft→ready flip, mechanical update, and a conflict Worker resolving a manufactured add/add conflict end to end (which surfaced and validated both design fixes above).

Closes #9