### PR TITLE
Termination: Complete, Stuck, and the report

### DIFF
--- a/src/plan.test.ts
+++ b/src/plan.test.ts
@@ -9,6 +9,7 @@ function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
     assignees: [],
     labels: ["ready-for-agent"],
     openBlockers: 0,
+    blockedBy: [],
     hasAgentClaim: false,
     agentClaimCount: 0,
     attemptFailures: [],

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -182,7 +182,7 @@ describe("renderStuck", () => {
       ticket({ number: 9, title: "A colleague's work", assignees: ["some-human"] }),
     ];
 
-    expect(renderStuck(open, stuckWorld(open))).toBe(
+    expect(renderStuck(stuckWorld(open))).toBe(
       [
         "Run Stuck: open tickets remain, but every path forward runs through a human.",
         "  #7 — Escalated (labelled ready-for-human)",
@@ -195,7 +195,7 @@ describe("renderStuck", () => {
   it("falls back to the blocker count when the blocker list is missing", () => {
     const open = [ticket({ number: 8, title: "Blocked blind", openBlockers: 2 })];
 
-    expect(renderStuck(open, stuckWorld(open))).toBe(
+    expect(renderStuck(stuckWorld(open))).toBe(
       [
         "Run Stuck: open tickets remain, but every path forward runs through a human.",
         "  #8 — Blocked blind (2 open blockers)",
@@ -206,7 +206,7 @@ describe("renderStuck", () => {
   it("notes a missing agent label distinctly from an escalation", () => {
     const open = [ticket({ number: 4, title: "Untriaged", labels: ["needs-triage"] })];
 
-    expect(renderStuck(open, stuckWorld(open))).toBe(
+    expect(renderStuck(stuckWorld(open))).toBe(
       [
         "Run Stuck: open tickets remain, but every path forward runs through a human.",
         "  #4 — Untriaged (not labelled ready-for-agent)",

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { renderPlan, renderStuck } from "./render.js";
+import { renderComplete, renderPlan, renderStuck } from "./render.js";
 import { plan } from "./plan.js";
 import type { ResolvedConfig } from "./config.js";
 import type { Ticket, WorldSnapshot } from "./types.js";
@@ -10,6 +10,7 @@ function ticket(overrides: Partial<Ticket> & { number: number; title: string }):
     assignees: [],
     labels: ["ready-for-agent"],
     openBlockers: 0,
+    blockedBy: [],
     hasAgentClaim: false,
     agentClaimCount: 0,
     attemptFailures: [],
@@ -165,23 +166,72 @@ describe("renderPlan", () => {
 });
 
 describe("renderStuck", () => {
-  it("names each open ticket and why it cannot move without a human", () => {
-    const report = renderStuck([
+  function stuckWorld(tickets: Ticket[]): WorldSnapshot {
+    return { tickets, openAgentPrTickets: [], mergedAgentPrs: [] };
+  }
+
+  it("names each open ticket and exactly what it is stuck on", () => {
+    const open = [
       ticket({ number: 7, title: "Escalated", labels: ["ready-for-human"] }),
       ticket({
         number: 8,
-        title: "A colleague's work",
-        assignees: ["some-human"],
-        openBlockers: 1,
+        title: "Downstream",
+        openBlockers: 2,
+        blockedBy: [7, 99],
       }),
+      ticket({ number: 9, title: "A colleague's work", assignees: ["some-human"] }),
+    ];
+
+    expect(renderStuck(open, stuckWorld(open))).toBe(
+      [
+        "Run Stuck: open tickets remain, but every path forward runs through a human.",
+        "  #7 — Escalated (labelled ready-for-human)",
+        "  #8 — Downstream (blocked by #7, #99 (outside Scope))",
+        "  #9 — A colleague's work (claimed by some-human — a human claim, hands off)",
+      ].join("\n"),
+    );
+  });
+
+  it("falls back to the blocker count when the blocker list is missing", () => {
+    const open = [ticket({ number: 8, title: "Blocked blind", openBlockers: 2 })];
+
+    expect(renderStuck(open, stuckWorld(open))).toBe(
+      [
+        "Run Stuck: open tickets remain, but every path forward runs through a human.",
+        "  #8 — Blocked blind (2 open blockers)",
+      ].join("\n"),
+    );
+  });
+
+  it("notes a missing agent label distinctly from an escalation", () => {
+    const open = [ticket({ number: 4, title: "Untriaged", labels: ["needs-triage"] })];
+
+    expect(renderStuck(open, stuckWorld(open))).toBe(
+      [
+        "Run Stuck: open tickets remain, but every path forward runs through a human.",
+        "  #4 — Untriaged (not labelled ready-for-agent)",
+      ].join("\n"),
+    );
+  });
+});
+
+describe("renderComplete", () => {
+  it("summarizes every ticket in Scope, noting human closes after Escalation", () => {
+    const report = renderComplete([
+      ticket({ number: 2, title: "Walking skeleton", state: "closed" }),
+      ticket({ number: 7, title: "Hard one", state: "closed", labels: ["ready-for-human"] }),
     ]);
 
     expect(report).toBe(
       [
-        "Run Stuck: open tickets remain, but every path forward runs through a human.",
-        "  #7 — Escalated (not labelled ready-for-agent)",
-        "  #8 — A colleague's work (claimed by some-human; 1 open blocker)",
+        "Run Complete: every ticket in Scope is closed (2 tickets).",
+        "  #2 — Walking skeleton",
+        "  #7 — Hard one (closed by a human after Escalation)",
       ].join("\n"),
     );
+  });
+
+  it("reports an empty Scope as complete with nothing herded", () => {
+    expect(renderComplete([])).toBe("Run Complete: every ticket in Scope is closed (0 tickets).");
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -104,11 +104,11 @@ function stuckReason(ticket: Ticket, inScope: Set<number>): string {
 }
 
 /** Render the Stuck exit report: each remaining open ticket and exactly what it is stuck on. Pure. */
-export function renderStuck(open: Ticket[], world: WorldSnapshot): string {
+export function renderStuck(world: WorldSnapshot): string {
   const inScope = new Set(world.tickets.map((t) => t.number));
   return [
     "Run Stuck: open tickets remain, but every path forward runs through a human.",
-    ...open.map(
+    ...world.tickets.filter((ticket) => ticket.state === "open").map(
       (ticket) => `  #${ticket.number} — ${ticket.title} (${stuckReason(ticket, inScope)})`,
     ),
   ].join("\n");

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,6 +1,12 @@
 import { modelForAttempt, type ResolvedConfig } from "./config.js";
 import { dispatchableSet } from "./plan.js";
-import { READY_FOR_AGENT, type Action, type Ticket, type WorldSnapshot } from "./types.js";
+import {
+  READY_FOR_AGENT,
+  READY_FOR_HUMAN,
+  type Action,
+  type Ticket,
+  type WorldSnapshot,
+} from "./types.js";
 
 /** Render the dispatch plan as human-readable lines. Pure. */
 export function renderPlan(
@@ -68,21 +74,61 @@ export function renderPlan(
   return lines.join("\n");
 }
 
-/** Why this open ticket cannot move without a human, best effort. */
-function stuckReason(ticket: Ticket): string {
+/**
+ * Why this open ticket cannot move without a human. Any assignee at a Stuck
+ * exit is a human claim: agent claims are either orphans (released before the
+ * exit) or backed by a PR (which keeps the run polling).
+ */
+function stuckReason(ticket: Ticket, inScope: Set<number>): string {
   const reasons: string[] = [];
-  if (ticket.assignees.length > 0) reasons.push(`claimed by ${ticket.assignees.join(", ")}`);
-  if (!ticket.labels.includes(READY_FOR_AGENT)) reasons.push(`not labelled ${READY_FOR_AGENT}`);
+  if (ticket.assignees.length > 0) {
+    reasons.push(`claimed by ${ticket.assignees.join(", ")} — a human claim, hands off`);
+  }
+  if (ticket.labels.includes(READY_FOR_HUMAN)) {
+    reasons.push(`labelled ${READY_FOR_HUMAN}`);
+  } else if (!ticket.labels.includes(READY_FOR_AGENT)) {
+    reasons.push(`not labelled ${READY_FOR_AGENT}`);
+  }
   if (ticket.openBlockers > 0) {
-    reasons.push(`${ticket.openBlockers} open blocker${ticket.openBlockers === 1 ? "" : "s"}`);
+    // Blockers outside Scope are flagged: their tickets get no line of their
+    // own in this report. The count is the fallback for an unread list.
+    reasons.push(
+      ticket.blockedBy.length > 0
+        ? `blocked by ${ticket.blockedBy
+            .map((n) => (inScope.has(n) ? `#${n}` : `#${n} (outside Scope)`))
+            .join(", ")}`
+        : `${ticket.openBlockers} open blocker${ticket.openBlockers === 1 ? "" : "s"}`,
+    );
   }
   return reasons.join("; ") || "no path forward found";
 }
 
-/** Render the Stuck exit report: each remaining open ticket and why. Pure. */
-export function renderStuck(open: Ticket[]): string {
+/** Render the Stuck exit report: each remaining open ticket and exactly what it is stuck on. Pure. */
+export function renderStuck(open: Ticket[], world: WorldSnapshot): string {
+  const inScope = new Set(world.tickets.map((t) => t.number));
   return [
     "Run Stuck: open tickets remain, but every path forward runs through a human.",
-    ...open.map((ticket) => `  #${ticket.number} — ${ticket.title} (${stuckReason(ticket)})`),
+    ...open.map(
+      (ticket) => `  #${ticket.number} — ${ticket.title} (${stuckReason(ticket, inScope)})`,
+    ),
+  ].join("\n");
+}
+
+/**
+ * Render the Complete exit report: every ticket in Scope, closed. A closed
+ * ticket still labelled ready-for-human went through Escalation and was
+ * finished by a human — worth naming, as those are the tickets the fleet
+ * could not do alone. Pure.
+ */
+export function renderComplete(tickets: Ticket[]): string {
+  const count = `${tickets.length} ticket${tickets.length === 1 ? "" : "s"}`;
+  return [
+    `Run Complete: every ticket in Scope is closed (${count}).`,
+    ...tickets.map((ticket) => {
+      const escalated = ticket.labels.includes(READY_FOR_HUMAN)
+        ? " (closed by a human after Escalation)"
+        : "";
+      return `  #${ticket.number} — ${ticket.title}${escalated}`;
+    }),
   ].join("\n");
 }

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -9,6 +9,7 @@ function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
     assignees: [],
     labels: ["ready-for-agent"],
     openBlockers: 0,
+    blockedBy: [],
     hasAgentClaim: false,
     agentClaimCount: 0,
     attemptFailures: [],
@@ -63,6 +64,21 @@ describe("runStatus", () => {
       state: "stuck",
       open: [humanTicket],
     });
+  });
+
+  it("is stuck despite out-of-scope agent PRs: their merge cannot move this Scope", () => {
+    const humanTicket = ticket({ number: 2, labels: ["ready-for-human"] });
+
+    expect(runStatus(world([humanTicket], [99]), [])).toEqual({
+      state: "stuck",
+      open: [humanTicket],
+    });
+  });
+
+  it("keeps running while a dispatchable ticket waits on headroom held by out-of-scope PRs", () => {
+    // Dispatch was throttled to nothing (actions empty), but the ticket
+    // becomes claimable the moment the foreign PRs merge — not stuck.
+    expect(runStatus(world([ticket({ number: 2 })], [99]), [])).toEqual({ state: "running" });
   });
 });
 
@@ -128,6 +144,24 @@ describe("run", () => {
     expect(state.lines.some((line) => line.includes("Complete"))).toBe(true);
   });
 
+  it("logs a Complete summary report naming every ticket in Scope", async () => {
+    const state = scriptedDeps([
+      {
+        world: world([
+          ticket({ number: 2, title: "Walking skeleton", state: "closed" }),
+          ticket({ number: 7, title: "Hard one", state: "closed", labels: ["ready-for-human"] }),
+        ]),
+        actions: [],
+      },
+    ]);
+
+    await run(30, state.deps);
+
+    const report = state.lines.join("\n");
+    expect(report).toContain("#2 — Walking skeleton");
+    expect(report).toContain("#7 — Hard one");
+  });
+
   it("exits stuck with a report naming the open tickets", async () => {
     const state = scriptedDeps([
       {
@@ -142,5 +176,27 @@ describe("run", () => {
     expect(state.sleeps).toEqual([]);
     expect(state.lines.join("\n")).toContain("Stuck");
     expect(state.lines.join("\n")).toContain("#7");
+  });
+
+  it("resumes from tracker truth when re-run after a human fixes a Stuck state", async () => {
+    // Nothing but GitHub carries state: a run that exits Stuck ...
+    const escalated = ticket({ number: 7, labels: ["ready-for-human"] });
+    const first = scriptedDeps([{ world: world([escalated]), actions: [] }]);
+    expect(await run(30, first.deps)).toBe("stuck");
+
+    // ... is recovered by relabelling the ticket and simply running again.
+    const relabelled = ticket({ number: 7 });
+    const second = scriptedDeps([
+      {
+        world: world([relabelled]),
+        actions: [
+          { type: "claim", ticket: 7 },
+          { type: "spawn", ticket: 7, attempt: 1 },
+        ],
+      },
+      { world: world([ticket({ number: 7, state: "closed" })]), actions: [] },
+    ]);
+    expect(await run(30, second.deps)).toBe("complete");
+    expect(second.ticks).toBe(2);
   });
 });

--- a/src/run.ts
+++ b/src/run.ts
@@ -56,7 +56,7 @@ export async function run(pollSeconds: number, deps: RunDeps): Promise<RunOutcom
       return "complete";
     }
     if (status.state === "stuck") {
-      deps.log(renderStuck(status.open, world));
+      deps.log(renderStuck(world));
       return "stuck";
     }
     deps.log(`Next Tick in ${pollSeconds}s.`);

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,4 +1,5 @@
-import { renderStuck } from "./render.js";
+import { dispatchableSet } from "./plan.js";
+import { renderComplete, renderStuck } from "./render.js";
 import type { Action, Ticket, WorldSnapshot } from "./types.js";
 
 /**
@@ -16,16 +17,22 @@ export type RunStatus =
 /**
  * Terminal-state judgment for a run, from the Tick's snapshot and plan.
  * Complete: every ticket in Scope is closed. Stuck: open tickets remain but
- * the Tick planned nothing and no agent PR is open — nothing is in flight
- * and nothing will change without a human. Anything else keeps polling; in
- * particular, open agent PRs awaiting human merge are the loop's normal
- * steady state, never an exit. (The refined Stuck semantics and the full
- * report land with the termination ticket.)
+ * nothing can move without a human — the Tick planned nothing (no close,
+ * release, escalation, or dispatch was due), no in-Scope agent PR is open
+ * (a foreign run's PRs cannot close a ticket here, so they never keep a
+ * dead Scope polling), and nothing is dispatchable (a dispatchable ticket
+ * merely throttled by max_open_prs headroom becomes claimable when PRs
+ * merge, wherever those PRs came from). No Worker runs at this point by
+ * construction: the Tick waits for every Worker it spawned before
+ * returning. Anything else keeps polling; in particular, open agent PRs
+ * awaiting human merge are the loop's normal steady state, never an exit.
  */
 export function runStatus(world: WorldSnapshot, actions: Action[]): RunStatus {
   const open = world.tickets.filter((ticket) => ticket.state === "open");
   if (open.length === 0) return { state: "complete" };
-  if (actions.length === 0 && world.openAgentPrTickets.length === 0) {
+  const inScope = new Set(world.tickets.map((ticket) => ticket.number));
+  const openScopePrs = world.openAgentPrTickets.filter((ticket) => inScope.has(ticket));
+  if (actions.length === 0 && openScopePrs.length === 0 && dispatchableSet(world).length === 0) {
     return { state: "stuck", open };
   }
   return { state: "running" };
@@ -45,11 +52,11 @@ export async function run(pollSeconds: number, deps: RunDeps): Promise<RunOutcom
     const { world, actions } = await deps.tick();
     const status = runStatus(world, actions);
     if (status.state === "complete") {
-      deps.log("Run Complete: every ticket in Scope is closed.");
+      deps.log(renderComplete(world.tickets));
       return "complete";
     }
     if (status.state === "stuck") {
-      deps.log(renderStuck(status.open));
+      deps.log(renderStuck(status.open, world));
       return "stuck";
     }
     deps.log(`Next Tick in ${pollSeconds}s.`);

--- a/src/tracker.test.ts
+++ b/src/tracker.test.ts
@@ -55,6 +55,8 @@ function fakeExec(responses: Record<string, unknown>): { exec: Exec; calls: stri
 const SUB_ISSUES = "repos/{owner}/{repo}/issues/1/sub_issues?per_page=100";
 const ALL_ISSUES = "repos/{owner}/{repo}/issues?labels=ready-for-agent&state=open&per_page=100";
 const comments = (n: number) => `repos/{owner}/{repo}/issues/${n}/comments?per_page=100`;
+const blockedBy = (n: number) =>
+  `repos/{owner}/{repo}/issues/${n}/dependencies/blocked_by?per_page=100`;
 const OPEN_PULLS = "repos/{owner}/{repo}/pulls?state=open&per_page=100";
 const CLOSED_PULLS = "repos/{owner}/{repo}/pulls?state=closed&per_page=100";
 /** Both PR listings answered empty — the common backdrop for open tickets. */
@@ -126,6 +128,7 @@ describe("readScope", () => {
         assignees: ["someone"],
         labels: ["ready-for-agent"],
         openBlockers: 2,
+        blockedBy: [],
         hasAgentClaim: false,
         agentClaimCount: 0,
         attemptFailures: [],
@@ -137,6 +140,7 @@ describe("readScope", () => {
         assignees: [],
         labels: ["ready-for-agent"],
         openBlockers: 0,
+        blockedBy: [],
         hasAgentClaim: false,
         agentClaimCount: 0,
         attemptFailures: [],
@@ -204,13 +208,51 @@ describe("readScope", () => {
           issue({ number: 8, labels: [] }),
         ],
       ],
+      [blockedBy(4)]: [[{ number: 2, state: "open" }]],
       ...NO_PULLS,
     });
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
 
-    expect(calls.map((c) => c[2])).toEqual([SUB_ISSUES, OPEN_PULLS, CLOSED_PULLS]);
+    expect(calls.map((c) => c[2])).toEqual([SUB_ISSUES, blockedBy(4), OPEN_PULLS, CLOSED_PULLS]);
     expect(world.tickets.map((t) => t.agentClaimCount)).toEqual([0, 0, 0]);
+  });
+
+  it("names the open blockers of an open blocked ticket, dropping closed ones", async () => {
+    const { exec } = fakeExec({
+      [SUB_ISSUES]: [[issue({ number: 4, issue_dependencies_summary: { blocked_by: 2 } })]],
+      [blockedBy(4)]: [
+        [
+          { number: 2, state: "open" },
+          { number: 3, state: "closed" },
+          { number: 9, state: "open" },
+        ],
+      ],
+      ...NO_PULLS,
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.tickets[0]?.blockedBy).toEqual([2, 9]);
+  });
+
+  it("never fetches the blocker list for closed or unblocked tickets", async () => {
+    const { exec, calls } = fakeExec({
+      [SUB_ISSUES]: [
+        [
+          issue({ number: 3, state: "closed", issue_dependencies_summary: { blocked_by: 2 } }),
+          issue({ number: 4 }),
+        ],
+      ],
+      [comments(4)]: [[]],
+      // Dependency endpoints deliberately unmapped: fetching them would throw.
+      ...NO_PULLS,
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(calls.map((c) => c[2])).toEqual([SUB_ISSUES, comments(4), OPEN_PULLS, CLOSED_PULLS]);
+    expect(world.tickets.map((t) => t.blockedBy)).toEqual([[], []]);
   });
 
   it("derives the Attempt counter and failure records from the comment history", async () => {

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -53,6 +53,7 @@ function toTicket(issue: GithubIssue): Ticket {
     assignees: (issue.assignees ?? []).map((a) => a.login),
     labels: (issue.labels ?? []).map((l) => l.name),
     openBlockers: issue.issue_dependencies_summary?.blocked_by ?? 0,
+    blockedBy: [],
     hasAgentClaim: false,
     agentClaimCount: 0,
     attemptFailures: [],
@@ -96,6 +97,19 @@ async function readClaimHistory(ticket: number, exec: Exec): Promise<ClaimHistor
     }
   }
   return history;
+}
+
+/**
+ * Issue numbers of a ticket's open blockers (the summary only counts them).
+ * Read for open blocked tickets so the Stuck report can name exactly what a
+ * ticket is stuck on; the endpoint lists closed blockers too, dropped here.
+ */
+async function readOpenBlockers(ticket: number, exec: Exec): Promise<number[]> {
+  const blockers = await readPages<{ number: number; state?: string }>(
+    `repos/{owner}/{repo}/issues/${ticket}/dependencies/blocked_by?per_page=100`,
+    exec,
+  );
+  return blockers.filter((b) => b.state === "open").map((b) => b.number);
 }
 
 /** Ticket numbers of open PRs whose head branch carries the agent prefix. */
@@ -150,15 +164,20 @@ export async function readScope(scope: Scope, exec: Exec = realExec): Promise<Wo
 
   // Claim history is read where it can matter: assigned tickets (claim
   // ownership) and unassigned dispatch candidates (the Attempt counter that
-  // picks the retry rung or triggers Escalation).
+  // picks the retry rung or triggers Escalation). Blocker lists are read for
+  // open blocked tickets — the Stuck report names them.
   for (const ticket of tickets) {
+    if (ticket.state !== "open") continue;
     const isDispatchCandidate =
       ticket.labels.includes(READY_FOR_AGENT) && ticket.openBlockers === 0;
-    if (ticket.state === "open" && (ticket.assignees.length > 0 || isDispatchCandidate)) {
+    if (ticket.assignees.length > 0 || isDispatchCandidate) {
       const history = await readClaimHistory(ticket.number, exec);
       ticket.hasAgentClaim = history.hasAgentClaim;
       ticket.agentClaimCount = history.agentClaimCount;
       ticket.attemptFailures = history.attemptFailures;
+    }
+    if (ticket.openBlockers > 0) {
+      ticket.blockedBy = await readOpenBlockers(ticket.number, exec);
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,12 @@ export interface Ticket {
   /** Count of open blocking issues (GitHub native issue dependencies). */
   openBlockers: number;
   /**
+   * Issue numbers of the open blockers, fetched for open blocked tickets so
+   * the Stuck report can name exactly what a ticket is stuck on. Empty when
+   * unblocked (and for closed tickets, where the list is never read).
+   */
+  blockedBy: number[];
+  /**
    * True when the ticket's latest border-collie marker comment is a claim
    * marker. An assignee without it is a human claim — hands off (CONTEXT.md
    * "Claim").


### PR DESCRIPTION
Closes #10.

The run now knows when it is finished, and says so with evidence.

## Complete

- Exits Complete (exit 0) when every ticket in Scope is closed, with a summary report naming every ticket — flagging the ones a human closed after Escalation, since those are the tickets the fleet could not do alone.

## Stuck

- Refined semantics: Stuck requires that the Tick planned nothing, no **in-Scope** agent PR is open, the dispatchable set is empty, and the circuit breaker is not holding dispatch paused.
  - A foreign run's open agent PRs no longer keep a dead Scope polling forever — their merge cannot close a ticket here.
  - A dispatchable ticket throttled only by `max_open_prs` headroom keeps the run alive: it becomes claimable when PRs merge, wherever those PRs came from.
  - An open circuit breaker is never Stuck (preserved from #8): the path forward is the environment recovering, not a human.
- The Stuck report names each remaining open ticket and exactly what it is stuck on: its open blockers by number (fetched from the issue-dependencies endpoint, flagging blockers outside Scope), a human claim, or its labels — with the bare blocker count as fallback.

## Still polling, still stateless

- Open agent PRs awaiting human merge remain the loop's normal steady state, never an exit.
- Re-running after a human fixes a Stuck state resumes from tracker truth alone, covered by a scripted two-run test.

## Notes for review

- The acceptance criterion says Stuck requires "no open agent PRs"; this implements the narrower "no open **in-Scope** agent PRs", deliberately — otherwise another run's PRs could make this run idle forever on a dead DAG, which the spec (issue #1, story 24) forbids.
- `Ticket` gains `blockedBy`, read only for open blocked tickets (verified against the live API: the dependencies summary counts open blockers only; the list endpoint returns state per blocker).
- Includes the merge of origin/main (#8 circuit breaker, #9 PR upkeep); the merged `runStatus` composes both features' exit guards and the tests cover their interaction.

Typecheck clean; 235 tests passing (10 new).