### PR TITLE
Publishable package manifest and pack smoke seam

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,19 +4,39 @@
   "description": "An orchestration loop that herds a ticket DAG to Done with a fleet of Claude Code agents.",
   "type": "module",
   "license": "MIT",
+  "engines": {
+    "node": ">=24"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lyeyixian/border-collie.git"
+  },
+  "keywords": [
+    "claude-code",
+    "claude",
+    "ai-agents",
+    "orchestration",
+    "automation",
+    "cli"
+  ],
   "bin": {
     "border-collie": "./dist/cli.js"
   },
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "dev": "tsx src/cli.ts"
+    "dev": "tsx src/cli.ts",
+    "smoke": "scripts/smoke.sh"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.5",

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# smoke.sh — prove the exact tarball npm would publish actually runs.
+#
+# Builds, packs the package, installs the tarball cold into a fresh temp
+# directory (no workspace symlinks, no source tree), and runs
+# `border-collie --help` from there. Exercises the files whitelist, bin
+# wiring, ESM resolution, and shebang exactly as an npm/npx install would.
+#
+# Usage:
+#   scripts/smoke.sh
+#
+# Exits non-zero on any failure.
+
+set -euo pipefail
+
+log() { printf '==> %s\n' "$*"; }
+die() { printf 'smoke: %s\n' "$*" >&2; exit 1; }
+
+root_dir=$(cd "$(dirname "$0")/.." && pwd)
+cd "$root_dir"
+
+log "Building"
+pnpm run build
+
+log "Packing"
+tarball=$(npm pack --silent)
+tarball_path="$root_dir/$tarball"
+
+install_dir=$(mktemp -d)
+cleanup() {
+  rm -rf "$install_dir"
+  rm -f "$tarball_path"
+}
+trap cleanup EXIT
+
+log "Installing $tarball cold into $install_dir"
+npm install "$tarball_path" --no-save --prefix "$install_dir" >/dev/null
+
+bin="$install_dir/node_modules/.bin/border-collie"
+[ -x "$bin" ] || die "no executable bin at $bin"
+
+log "Running border-collie --help"
+"$bin" --help >/dev/null || die "border-collie --help exited non-zero"
+
+log "Smoke passed"


### PR DESCRIPTION
## Summary

Adds the publishable package manifest and pack smoke seam described in #17: `package.json` now declares `engines.node`, `repository`, `keywords`, and a provenance-enabled `publishConfig`, and a new `scripts/smoke.sh` proves the exact tarball npm would serve actually runs, cold, before it's ever published.

- `package.json`: `engines: { node: ">=24" }`, `repository` (git+https URL), `keywords`, and `publishConfig: { access: "public", provenance: true }`; wired up as the `smoke` package script.
- `scripts/smoke.sh`: builds, `npm pack`s the package, installs the resulting tarball cold into a fresh `mktemp -d` directory (no pnpm workspace symlinks), and runs `border-collie --help` against it — exercising the `files` whitelist, bin wiring, ESM resolution, and shebang exactly as a real install would. Exits non-zero on any failure (`set -euo pipefail` + explicit `die()` on missing bin / failed help), and cleans up the tarball and temp dir via `trap ... EXIT`.
- `dist/` was already gitignored — confirmed unchanged.

## Verification

- `pnpm run smoke` passes locally on Node 26 (satisfies "Node 24+"), and is idempotent across repeated runs with no leftover tarballs or temp dirs.
- `pnpm run typecheck` and `pnpm run test` (235 tests) both pass unchanged.
- Manually inspected the packed tarball contents to confirm only `dist/**` + `package.json`/`README.md` ship, and that `dist/cli.js` keeps its `#!/usr/bin/env node` shebang.

## Test plan

- [x] `pnpm run smoke` exits 0 and prints `Smoke passed`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] Confirmed `dist/` remains in `.gitignore`

Closes #17