### PR TITLE
Introduce biome: lint and format gate

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended"
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,11 +13,13 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
     "test": "vitest run",
     "test:watch": "vitest",
     "dev": "tsx src/cli.ts"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.5.5",
     "@types/node": "^26.1.1",
     "tsx": "^4.23.1",
     "typescript": "^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.5.5
+        version: 2.5.5
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -22,6 +25,63 @@ importers:
         version: 4.1.10(@types/node@26.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(tsx@4.23.1))
 
 packages:
+
+  '@biomejs/biome@2.5.5':
+    resolution: {integrity: sha512-r1S8nFsAG1MY+vJFZALzIvwXAJv6ejDQ0mxP21Tgr9YK3ZFtjrvbBwDdNhx1rUqvccEIeNg20cYCNzl6Cr69pQ==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.5.5':
+    resolution: {integrity: sha512-kUrAhXVWUrwmAUnV2iXSK7umxKFysTwvqK+Ty6ptUcLY/7T3SnCAjUowE4uvwaEej6nXZ7hu/dTtbokKdsPeag==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.5.5':
+    resolution: {integrity: sha512-DamiYc5bUYZ2uxlfc+RLEPtz1Abb6PO5eTbOkufLpSGwd/7AMQAdxhFYiXmwwkJL8IsT8S7GvdgwDHqaMFAvKw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.5.5':
+    resolution: {integrity: sha512-U4WMl/sy/E/Q73vf15VspakLRRs2LDFcCeBxJnQfXzssb88zpV6PJPaQ3ezhQ7H6Ht2/8bvuZeHgJWzmoxllZg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.5.5':
+    resolution: {integrity: sha512-lRKF/pH/1RiYiBKExi3TCZVAtvzEm77aifrvcNiDFrR9WxeAnDUjDnseb6y2XV85mjitLs6SILGm2XG77cHtSQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.5.5':
+    resolution: {integrity: sha512-m7wC7tjX5Lrmo69dc4md8FeKpPU1NTCY1v7xUoQQ2vadWwNnBS0KZOG8471otFPHrTHihQJAjQPgMObpLvDe6A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.5.5':
+    resolution: {integrity: sha512-H/O39nJEw/2Zm/fm7hrmxxoF8kK/aU1uCoPp70ruXVbomaAdLpJJnCmL11Q2JotT8QVHH06So04Oq53lCSwSwQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.5.5':
+    resolution: {integrity: sha512-7BryINPuYypLUAH3o/o5ZdgomJ4zn3EDR0ChZJst7n32S6ZhKbgHXuYydLu+YAnx59ehGFR0z/MG6qnzQi3Yyw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.5.5':
+    resolution: {integrity: sha512-bIBFo+n6MIxdNcVFy5CrurbKiZQiUciK3bt8+O9I4wjFZNTfXLpi+giq47522eXqW5NBc9ulx7dR1SlZKi2J5g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -748,6 +808,41 @@ packages:
     hasBin: true
 
 snapshots:
+
+  '@biomejs/biome@2.5.5':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.5.5
+      '@biomejs/cli-darwin-x64': 2.5.5
+      '@biomejs/cli-linux-arm64': 2.5.5
+      '@biomejs/cli-linux-arm64-musl': 2.5.5
+      '@biomejs/cli-linux-x64': 2.5.5
+      '@biomejs/cli-linux-x64-musl': 2.5.5
+      '@biomejs/cli-win32-arm64': 2.5.5
+      '@biomejs/cli-win32-x64': 2.5.5
+
+  '@biomejs/cli-darwin-arm64@2.5.5':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.5.5':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.5.5':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.5.5':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.5.5':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.5.5':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.5.5':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.5.5':
+    optional: true
 
   '@emnapi/core@1.11.1':
     dependencies:

--- a/src/act.test.ts
+++ b/src/act.test.ts
@@ -1,13 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { act, type DispatchConflictWorker, type DispatchWorker, type OpenPr } from "./act.js";
+import {
+  act,
+  type DispatchConflictWorker,
+  type DispatchWorker,
+  type OpenPr,
+} from "./act.js";
 import type { Exec } from "./tracker.js";
 import {
+  type AttemptFailure,
   attemptMarker,
   CLAIM_MARKER,
   CONFLICT_UNRESOLVED_MARKER,
   RELEASE_MARKER,
   VOID_MARKER,
-  type AttemptFailure,
 } from "./types.js";
 import type { ConflictOutcome, WorkerOutcome } from "./worker.js";
 
@@ -38,7 +43,10 @@ function recordingOpenPr(): { openPr: OpenPr; opened: number[] } {
   return { openPr, opened };
 }
 
-function outcome(ticket: number, overrides: Partial<WorkerOutcome> = {}): WorkerOutcome {
+function outcome(
+  ticket: number,
+  overrides: Partial<WorkerOutcome> = {},
+): WorkerOutcome {
   return {
     ticket,
     attempt: 1,
@@ -58,7 +66,10 @@ function outcome(ticket: number, overrides: Partial<WorkerOutcome> = {}): Worker
   };
 }
 
-function conflictOutcome(pr: number, overrides: Partial<ConflictOutcome> = {}): ConflictOutcome {
+function conflictOutcome(
+  pr: number,
+  overrides: Partial<ConflictOutcome> = {},
+): ConflictOutcome {
   return {
     pr,
     ticket: pr,
@@ -90,9 +101,23 @@ describe("act", () => {
 
     expect(calls).toEqual([
       ["gh", "issue", "edit", "4", "--remove-assignee", "operator"],
-      ["gh", "issue", "comment", "4", "--body", expect.stringContaining(RELEASE_MARKER)],
+      [
+        "gh",
+        "issue",
+        "comment",
+        "4",
+        "--body",
+        expect.stringContaining(RELEASE_MARKER),
+      ],
       ["gh", "issue", "edit", "9", "--add-assignee", "@me"],
-      ["gh", "issue", "comment", "9", "--body", expect.stringContaining(CLAIM_MARKER)],
+      [
+        "gh",
+        "issue",
+        "comment",
+        "9",
+        "--body",
+        expect.stringContaining(CLAIM_MARKER),
+      ],
     ]);
     expect(lines).toEqual(["released #4 (orphaned claim)", "claimed #9"]);
   });
@@ -121,7 +146,9 @@ describe("act", () => {
         expect.stringContaining("https://github.com/o/r/pull/60"),
       ],
     ]);
-    expect(lines).toEqual(["closed #6 (merged: https://github.com/o/r/pull/60)"]);
+    expect(lines).toEqual([
+      "closed #6 (merged: https://github.com/o/r/pull/60)",
+    ]);
   });
 
   it("performs no writes for an empty plan", async () => {
@@ -149,7 +176,12 @@ describe("act", () => {
       await gate;
       return ticket === 2
         ? outcome(2, { newCommits: 3 })
-        : outcome(4, { exitCode: 1, newCommits: 0, failure: "nonzero-exit", ok: false });
+        : outcome(4, {
+            exitCode: 1,
+            newCommits: 0,
+            failure: "nonzero-exit",
+            ok: false,
+          });
     };
 
     await act(
@@ -223,7 +255,14 @@ describe("act", () => {
     };
     expect(calls).toEqual([
       ["gh", "issue", "edit", "7", "--remove-assignee", "@me"],
-      ["gh", "issue", "comment", "7", "--body", expect.stringContaining(attemptMarker(record))],
+      [
+        "gh",
+        "issue",
+        "comment",
+        "7",
+        "--body",
+        expect.stringContaining(attemptMarker(record)),
+      ],
     ]);
   });
 
@@ -266,7 +305,14 @@ describe("act", () => {
     );
 
     expect(calls).toEqual([
-      ["gh", "issue", "comment", "5", "--body", expect.stringContaining("Escalated")],
+      [
+        "gh",
+        "issue",
+        "comment",
+        "5",
+        "--body",
+        expect.stringContaining("Escalated"),
+      ],
       [
         "gh",
         "issue",
@@ -278,7 +324,9 @@ describe("act", () => {
         "ready-for-human",
       ],
     ]);
-    expect(lines).toEqual(["escalated #5 to ready-for-human (attempts exhausted)"]);
+    expect(lines).toEqual([
+      "escalated #5 to ready-for-human (attempts exhausted)",
+    ]);
   });
 
   it("flags a cost overrun on a finished attempt while still opening its PR", async () => {
@@ -288,8 +336,13 @@ describe("act", () => {
     const dispatch: DispatchWorker = async () =>
       outcome(7, { costUsd: 25.5, turns: 80, costOverrun: true });
 
-    await act([{ type: "spawn", ticket: 7, attempt: 1 }], dispatch, openPr, noConflict, exec, (line) =>
-      lines.push(line),
+    await act(
+      [{ type: "spawn", ticket: 7, attempt: 1 }],
+      dispatch,
+      openPr,
+      noConflict,
+      exec,
+      (line) => lines.push(line),
     );
 
     expect(opened).toEqual([7]); // the work is kept — discarding refunds nothing
@@ -303,7 +356,12 @@ describe("act", () => {
     const { exec, calls } = recordingExec();
     const lines: string[] = [];
     const dispatch: DispatchWorker = async () =>
-      outcome(7, { exitCode: 1, newCommits: 0, infra: "usage-limit", ok: false });
+      outcome(7, {
+        exitCode: 1,
+        newCommits: 0,
+        infra: "usage-limit",
+        ok: false,
+      });
 
     const report = await act(
       [{ type: "spawn", ticket: 7, attempt: 1 }],
@@ -315,7 +373,14 @@ describe("act", () => {
     );
 
     expect(calls).toEqual([
-      ["gh", "issue", "comment", "7", "--body", expect.stringContaining(VOID_MARKER)],
+      [
+        "gh",
+        "issue",
+        "comment",
+        "7",
+        "--body",
+        expect.stringContaining(VOID_MARKER),
+      ],
     ]);
     expect(report).toEqual({ infraFailures: 1 });
     expect(lines).toContain("voided attempt 1 of #7 (usage-limit); claim held");
@@ -325,7 +390,12 @@ describe("act", () => {
     const { exec, calls } = recordingExec();
     const lines: string[] = [];
     const dispatch: DispatchWorker = async (ticket) =>
-      outcome(ticket, { exitCode: 1, newCommits: 0, failure: "nonzero-exit", ok: false });
+      outcome(ticket, {
+        exitCode: 1,
+        newCommits: 0,
+        failure: "nonzero-exit",
+        ok: false,
+      });
 
     const report = await act(
       [
@@ -432,10 +502,10 @@ describe("act: PR upkeep", () => {
       (line) => lines.push(line),
     );
 
-    expect(calls).toEqual([
-      ["gh", "pr", "update-branch", "30", "--rebase"],
+    expect(calls).toEqual([["gh", "pr", "update-branch", "30", "--rebase"]]);
+    expect(lines).toEqual([
+      "updated PR #30 branch (mechanical rebase onto the base)",
     ]);
-    expect(lines).toEqual(["updated PR #30 branch (mechanical rebase onto the base)"]);
   });
 
   it("flips a green draft PR to ready for review via the tracker", async () => {
@@ -458,11 +528,21 @@ describe("act: PR upkeep", () => {
   it("pushes the branch when the conflict Worker resolves the merge", async () => {
     const { exec, calls } = recordingExec();
     const lines: string[] = [];
-    const dispatchConflict: DispatchConflictWorker = async (pr, ticket, headRef) =>
-      conflictOutcome(pr, { ticket, headRef, resolved: true });
+    const dispatchConflict: DispatchConflictWorker = async (
+      pr,
+      ticket,
+      headRef,
+    ) => conflictOutcome(pr, { ticket, headRef, resolved: true });
 
     await act(
-      [{ type: "conflict-worker", pr: 30, ticket: 3, headRef: "border-collie/ticket-3-attempt-1" }],
+      [
+        {
+          type: "conflict-worker",
+          pr: 30,
+          ticket: 3,
+          headRef: "border-collie/ticket-3-attempt-1",
+        },
+      ],
       noDispatch,
       recordingOpenPr().openPr,
       dispatchConflict,
@@ -483,11 +563,21 @@ describe("act: PR upkeep", () => {
   it("asks for human resolution when the conflict Worker gives up (no push)", async () => {
     const { exec, calls } = recordingExec();
     const lines: string[] = [];
-    const dispatchConflict: DispatchConflictWorker = async (pr, ticket, headRef) =>
-      conflictOutcome(pr, { ticket, headRef, exitCode: 1, resolved: false });
+    const dispatchConflict: DispatchConflictWorker = async (
+      pr,
+      ticket,
+      headRef,
+    ) => conflictOutcome(pr, { ticket, headRef, exitCode: 1, resolved: false });
 
     await act(
-      [{ type: "conflict-worker", pr: 30, ticket: 3, headRef: "border-collie/ticket-3-attempt-1" }],
+      [
+        {
+          type: "conflict-worker",
+          pr: 30,
+          ticket: 3,
+          headRef: "border-collie/ticket-3-attempt-1",
+        },
+      ],
       noDispatch,
       recordingOpenPr().openPr,
       dispatchConflict,
@@ -496,7 +586,14 @@ describe("act: PR upkeep", () => {
     );
 
     expect(calls).toEqual([
-      ["gh", "pr", "comment", "30", "--body", expect.stringContaining(CONFLICT_UNRESOLVED_MARKER)],
+      [
+        "gh",
+        "pr",
+        "comment",
+        "30",
+        "--body",
+        expect.stringContaining(CONFLICT_UNRESOLVED_MARKER),
+      ],
     ]);
     expect(lines).toEqual([
       "dispatched conflict Worker for PR #30 (ticket #3)",
@@ -519,7 +616,11 @@ describe("act: PR upkeep", () => {
       await gate;
       return outcome(ticket);
     };
-    const dispatchConflict: DispatchConflictWorker = async (pr, ticket, headRef) => {
+    const dispatchConflict: DispatchConflictWorker = async (
+      pr,
+      ticket,
+      headRef,
+    ) => {
       inFlight.push(`conflict-${pr}`);
       if (inFlight.length === 2) bothInFlight();
       await gate;
@@ -528,7 +629,12 @@ describe("act: PR upkeep", () => {
 
     await act(
       [
-        { type: "conflict-worker", pr: 40, ticket: 4, headRef: "border-collie/ticket-4-attempt-1" },
+        {
+          type: "conflict-worker",
+          pr: 40,
+          ticket: 4,
+          headRef: "border-collie/ticket-4-attempt-1",
+        },
         { type: "spawn", ticket: 2, attempt: 1 },
       ],
       dispatch,
@@ -556,7 +662,12 @@ describe("act: PR upkeep", () => {
     await expect(
       act(
         [
-          { type: "conflict-worker", pr: 40, ticket: 4, headRef: "border-collie/ticket-4-attempt-1" },
+          {
+            type: "conflict-worker",
+            pr: 40,
+            ticket: 4,
+            headRef: "border-collie/ticket-4-attempt-1",
+          },
           { type: "spawn", ticket: 2, attempt: 1 },
         ],
         dispatch,

--- a/src/act.ts
+++ b/src/act.ts
@@ -3,6 +3,7 @@ import {
   claimTicket,
   closeTicket,
   commentConflictUnresolved,
+  type Exec,
   escalateTicket,
   markPrReady,
   realExec,
@@ -10,16 +11,22 @@ import {
   releaseTicket,
   updatePrBranch,
   voidAttempt,
-  type Exec,
 } from "./tracker.js";
 import type { Action } from "./types.js";
-import { pushAgentBranch, type ConflictOutcome, type WorkerOutcome } from "./worker.js";
+import {
+  type ConflictOutcome,
+  pushAgentBranch,
+  type WorkerOutcome,
+} from "./worker.js";
 
 /**
  * Dispatch one Worker against one claimed ticket; the caller binds the
  * attempt number to a model (the retry ladder).
  */
-export type DispatchWorker = (ticket: number, attempt: number) => Promise<WorkerOutcome>;
+export type DispatchWorker = (
+  ticket: number,
+  attempt: number,
+) => Promise<WorkerOutcome>;
 
 /** Open the draft PR for a successful Attempt; resolves with the PR URL. */
 export type OpenPr = (outcome: WorkerOutcome) => Promise<string>;
@@ -42,7 +49,8 @@ interface SpawnResult {
 function describeOutcome(outcome: WorkerOutcome): string {
   const commits = `${outcome.newCommits} new commit${outcome.newCommits === 1 ? "" : "s"}`;
   const where = `on ${outcome.branch} (transcript: ${outcome.transcript})`;
-  if (outcome.ok) return `Worker for #${outcome.ticket} succeeded: ${commits} ${where}`;
+  if (outcome.ok)
+    return `Worker for #${outcome.ticket} succeeded: ${commits} ${where}`;
   if (outcome.infra !== undefined) {
     return `Worker for #${outcome.ticket} hit an infrastructure failure (${outcome.infra}): attempt ${outcome.attempt} voided, exit ${outcome.exitCode} ${where}`;
   }
@@ -103,7 +111,9 @@ export async function act(
         break;
       case "escalate":
         await escalateTicket(action.ticket, action.failures, exec);
-        log(`escalated #${action.ticket} to ready-for-human (attempts exhausted)`);
+        log(
+          `escalated #${action.ticket} to ready-for-human (attempts exhausted)`,
+        );
         break;
       case "close":
         await closeTicket(action.ticket, action.prUrl, exec);
@@ -111,26 +121,34 @@ export async function act(
         break;
       case "update-branch":
         await updatePrBranch(action.pr, exec);
-        log(`updated PR #${action.pr} branch (mechanical rebase onto the base)`);
+        log(
+          `updated PR #${action.pr} branch (mechanical rebase onto the base)`,
+        );
         break;
       case "mark-ready":
         await markPrReady(action.pr, exec);
         log(`marked PR #${action.pr} ready for review`);
         break;
       case "conflict-worker":
-        conflicts.push(dispatchConflict(action.pr, action.ticket, action.headRef));
-        log(`dispatched conflict Worker for PR #${action.pr} (ticket #${action.ticket})`);
+        conflicts.push(
+          dispatchConflict(action.pr, action.ticket, action.headRef),
+        );
+        log(
+          `dispatched conflict Worker for PR #${action.pr} (ticket #${action.ticket})`,
+        );
         break;
       case "spawn":
         workers.push(
-          dispatch(action.ticket, action.attempt).then(async (outcome): Promise<SpawnResult> => {
-            if (!outcome.ok) return { outcome };
-            try {
-              return { outcome, prUrl: await openPr(outcome) };
-            } catch (error) {
-              return { outcome, prFailure: error };
-            }
-          }),
+          dispatch(action.ticket, action.attempt).then(
+            async (outcome): Promise<SpawnResult> => {
+              if (!outcome.ok) return { outcome };
+              try {
+                return { outcome, prUrl: await openPr(outcome) };
+              } catch (error) {
+                return { outcome, prFailure: error };
+              }
+            },
+          ),
         );
         log(`spawned Worker for #${action.ticket} (attempt ${action.attempt})`);
         break;
@@ -139,18 +157,22 @@ export async function act(
 
   const settled = await Promise.allSettled(workers);
   const fulfilled = settled
-    .filter((result): result is PromiseFulfilledResult<SpawnResult> => result.status === "fulfilled")
+    .filter(
+      (result): result is PromiseFulfilledResult<SpawnResult> =>
+        result.status === "fulfilled",
+    )
     .map((result) => result.value);
   // Reclassify once every Worker has settled: only the full Tick's outcomes
   // can show several Workers dying the same way (an environment problem,
   // not a coincidence of tickets). Zipped straight back onto the spawn
   // results so each outcome keeps its own PR.
-  const outcomes = reclassifyCorrelatedFailures(fulfilled.map((spawn) => spawn.outcome)).map(
-    (outcome, i) => ({ outcome, prUrl: fulfilled[i]?.prUrl }),
-  );
+  const outcomes = reclassifyCorrelatedFailures(
+    fulfilled.map((spawn) => spawn.outcome),
+  ).map((outcome, i) => ({ outcome, prUrl: fulfilled[i]?.prUrl }));
   for (const { outcome, prUrl } of outcomes) {
     log(describeOutcome(outcome));
-    if (prUrl !== undefined) log(`opened draft PR for #${outcome.ticket}: ${prUrl}`);
+    if (prUrl !== undefined)
+      log(`opened draft PR for #${outcome.ticket}: ${prUrl}`);
     if (outcome.costOverrun && outcome.costUsd !== undefined) {
       log(
         `cost overrun on #${outcome.ticket}: attempt ${outcome.attempt} spent $${outcome.costUsd.toFixed(2)} — the ticket may be cut too big for one Worker`,
@@ -167,7 +189,9 @@ export async function act(
         },
         exec,
       );
-      log(`voided attempt ${outcome.attempt} of #${outcome.ticket} (${outcome.infra}); claim held`);
+      log(
+        `voided attempt ${outcome.attempt} of #${outcome.ticket} (${outcome.infra}); claim held`,
+      );
     } else if (outcome.failure) {
       await releaseFailedTicket(
         outcome.ticket,
@@ -205,12 +229,17 @@ export async function act(
 
   const rejected = settled.find((result) => result.status === "rejected");
   if (rejected) throw rejected.reason;
-  const rejectedConflict = settledConflicts.find((result) => result.status === "rejected");
+  const rejectedConflict = settledConflicts.find(
+    (result) => result.status === "rejected",
+  );
   if (rejectedConflict) throw rejectedConflict.reason;
   for (const result of settled) {
     if (result.status === "fulfilled" && result.value.prFailure !== undefined) {
       throw result.value.prFailure;
     }
   }
-  return { infraFailures: outcomes.filter(({ outcome }) => outcome.infra !== undefined).length };
+  return {
+    infraFailures: outcomes.filter(({ outcome }) => outcome.infra !== undefined)
+      .length,
+  };
 }

--- a/src/breaker.test.ts
+++ b/src/breaker.test.ts
@@ -9,7 +9,10 @@ import {
 
 describe("tripBreaker", () => {
   it("opens a closed breaker with one trip", () => {
-    expect(tripBreaker(undefined, 1_000)).toEqual({ openedAtMs: 1_000, trips: 1 });
+    expect(tripBreaker(undefined, 1_000)).toEqual({
+      openedAtMs: 1_000,
+      trips: 1,
+    });
   });
 
   it("re-trips an open breaker, restarting the cooldown and counting the trip", () => {

--- a/src/breaker.ts
+++ b/src/breaker.ts
@@ -30,7 +30,10 @@ export function tripBreaker(breaker: Breaker, nowMs: number): OpenBreaker {
 
 /** Cooldown before the next recovery probe: base doubled per consecutive trip, capped. */
 export function breakerCooldownMs(trips: number): number {
-  return Math.min(BREAKER_BASE_COOLDOWN_MS * 2 ** Math.max(0, trips - 1), BREAKER_MAX_COOLDOWN_MS);
+  return Math.min(
+    BREAKER_BASE_COOLDOWN_MS * 2 ** Math.max(0, trips - 1),
+    BREAKER_MAX_COOLDOWN_MS,
+  );
 }
 
 /** Whether the cooldown has elapsed and the environment should be probed. */

--- a/src/classify.test.ts
+++ b/src/classify.test.ts
@@ -9,37 +9,55 @@ import type { WorkerOutcome } from "./worker.js";
 
 describe("classifyInfrastructure", () => {
   it("classifies a usage-limit death", () => {
-    expect(classifyInfrastructure("Claude AI usage limit reached|1769000000")).toBe("usage-limit");
-    expect(classifyInfrastructure('{"error":{"type":"usage_limit_reached"}}')).toBe("usage-limit");
+    expect(
+      classifyInfrastructure("Claude AI usage limit reached|1769000000"),
+    ).toBe("usage-limit");
+    expect(
+      classifyInfrastructure('{"error":{"type":"usage_limit_reached"}}'),
+    ).toBe("usage-limit");
   });
 
   it("classifies a rate-limit death", () => {
-    expect(classifyInfrastructure('API Error: 429 {"type":"rate_limit_error"}')).toBe("rate-limit");
-    expect(classifyInfrastructure('{"type":"overloaded_error"}')).toBe("rate-limit");
-  });
-
-  it("classifies an auth death", () => {
-    expect(classifyInfrastructure('{"type":"authentication_error","message":"invalid x-api-key"}')).toBe(
-      "auth",
-    );
-    expect(classifyInfrastructure("Invalid API key · Please run /login")).toBe("auth");
-    expect(classifyInfrastructure("OAuth token has expired")).toBe("auth");
-  });
-
-  it("classifies a network death", () => {
-    expect(classifyInfrastructure("Error: getaddrinfo ENOTFOUND api.anthropic.com")).toBe("network");
-    expect(classifyInfrastructure("TypeError: fetch failed\n  cause: ECONNRESET")).toBe("network");
-  });
-
-  it("prefers the most specific class when signatures overlap", () => {
-    // A rate-limited request often also logs connection retries.
-    expect(classifyInfrastructure("rate_limit_error after retry: connection reset")).toBe(
+    expect(
+      classifyInfrastructure('API Error: 429 {"type":"rate_limit_error"}'),
+    ).toBe("rate-limit");
+    expect(classifyInfrastructure('{"type":"overloaded_error"}')).toBe(
       "rate-limit",
     );
   });
 
+  it("classifies an auth death", () => {
+    expect(
+      classifyInfrastructure(
+        '{"type":"authentication_error","message":"invalid x-api-key"}',
+      ),
+    ).toBe("auth");
+    expect(classifyInfrastructure("Invalid API key · Please run /login")).toBe(
+      "auth",
+    );
+    expect(classifyInfrastructure("OAuth token has expired")).toBe("auth");
+  });
+
+  it("classifies a network death", () => {
+    expect(
+      classifyInfrastructure("Error: getaddrinfo ENOTFOUND api.anthropic.com"),
+    ).toBe("network");
+    expect(
+      classifyInfrastructure("TypeError: fetch failed\n  cause: ECONNRESET"),
+    ).toBe("network");
+  });
+
+  it("prefers the most specific class when signatures overlap", () => {
+    // A rate-limited request often also logs connection retries.
+    expect(
+      classifyInfrastructure("rate_limit_error after retry: connection reset"),
+    ).toBe("rate-limit");
+  });
+
   it("returns undefined for ordinary ticket-failure output", () => {
-    expect(classifyInfrastructure("Error: tests failed\n  expected 2 to be 3")).toBeUndefined();
+    expect(
+      classifyInfrastructure("Error: tests failed\n  expected 2 to be 3"),
+    ).toBeUndefined();
     expect(classifyInfrastructure("")).toBeUndefined();
   });
 });
@@ -69,7 +87,9 @@ describe("parseResultEvent", () => {
   });
 
   it("returns undefined when no result event survived", () => {
-    expect(parseResultEvent('{"type":"assistant"}\nplain text')).toBeUndefined();
+    expect(
+      parseResultEvent('{"type":"assistant"}\nplain text'),
+    ).toBeUndefined();
     expect(parseResultEvent("")).toBeUndefined();
   });
 
@@ -93,11 +113,16 @@ describe("lastResultLine", () => {
   });
 
   it("returns the empty string when no result line exists", () => {
-    expect(lastResultLine('{"type":"assistant"}\nprose about rate limits')).toBe("");
+    expect(
+      lastResultLine('{"type":"assistant"}\nprose about rate limits'),
+    ).toBe("");
   });
 });
 
-function outcome(ticket: number, overrides: Partial<WorkerOutcome> = {}): WorkerOutcome {
+function outcome(
+  ticket: number,
+  overrides: Partial<WorkerOutcome> = {},
+): WorkerOutcome {
   return {
     ticket,
     attempt: 1,
@@ -136,20 +161,29 @@ describe("reclassifyCorrelatedFailures", () => {
   });
 
   it("leaves Workers that failed in different ways classified as ticket failures", () => {
-    const outcomes = reclassifyCorrelatedFailures([failed(2, "stall"), failed(4, "timeout")]);
+    const outcomes = reclassifyCorrelatedFailures([
+      failed(2, "stall"),
+      failed(4, "timeout"),
+    ]);
 
     expect(outcomes.map((o) => o.failure)).toEqual(["stall", "timeout"]);
     expect(outcomes.every((o) => o.infra === undefined)).toBe(true);
   });
 
   it("leaves a single failure alone — one death is a ticket failure until proven otherwise", () => {
-    const outcomes = reclassifyCorrelatedFailures([failed(2, "no-commits"), outcome(4)]);
+    const outcomes = reclassifyCorrelatedFailures([
+      failed(2, "no-commits"),
+      outcome(4),
+    ]);
 
     expect(outcomes[0]?.failure).toBe("no-commits");
   });
 
   it("never reclassifies budget breaches: a measured budget proves the environment was up", () => {
-    const outcomes = reclassifyCorrelatedFailures([failed(2, "budget"), failed(4, "budget")]);
+    const outcomes = reclassifyCorrelatedFailures([
+      failed(2, "budget"),
+      failed(4, "budget"),
+    ]);
 
     expect(outcomes.map((o) => o.failure)).toEqual(["budget", "budget"]);
   });
@@ -160,7 +194,10 @@ describe("reclassifyCorrelatedFailures", () => {
       failed(4, "no-commits"),
     ]);
 
-    expect(outcomes.map((o) => o.failure)).toEqual(["no-commits", "no-commits"]);
+    expect(outcomes.map((o) => o.failure)).toEqual([
+      "no-commits",
+      "no-commits",
+    ]);
     expect(outcomes.every((o) => o.infra === undefined)).toBe(true);
   });
 

--- a/src/classify.ts
+++ b/src/classify.ts
@@ -15,12 +15,18 @@ import type { WorkerOutcome } from "./worker.js";
  * classifies as the rate limit that caused it.
  */
 const INFRA_SIGNATURES: [InfraReason, RegExp][] = [
-  ["usage-limit", /usage[ _]limit|usage_limit_reached|out of extra usage|limit reached\|\d/i],
+  [
+    "usage-limit",
+    /usage[ _]limit|usage_limit_reached|out of extra usage|limit reached\|\d/i,
+  ],
   [
     "auth",
     /authentication_error|invalid api key|api key not found|please run \/login|oauth.{0,20}(expired|revoked|invalid)|401 unauthorized|credit balance is too low/i,
   ],
-  ["rate-limit", /rate[ _-]?limit|overloaded_error|too many requests|"status"\s*:\s*429|http 429/i],
+  [
+    "rate-limit",
+    /rate[ _-]?limit|overloaded_error|too many requests|"status"\s*:\s*429|http 429/i,
+  ],
   [
     "network",
     /ENOTFOUND|ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|EHOSTUNREACH|ENETUNREACH|fetch failed|network error|connection (error|refused|reset|timed out)/i,
@@ -46,7 +52,9 @@ export function classifyInfrastructure(text: string): InfraReason | undefined {
  * CLI's own error text, not the Worker's prose or tool output.
  */
 export function lastResultLine(tail: string): string {
-  return tail.split("\n").findLast((line) => line.includes('"type":"result"')) ?? "";
+  return (
+    tail.split("\n").findLast((line) => line.includes('"type":"result"')) ?? ""
+  );
 }
 
 /** The budget-relevant fields of the transcript's final stream-json result event. */
@@ -67,18 +75,21 @@ export function parseResultEvent(tail: string): ResultEvent | undefined {
     if (!line.includes('"type":"result"')) continue;
     try {
       const event = JSON.parse(line) as unknown;
-      if (typeof event === "object" && event !== null && !Array.isArray(event)) {
+      if (
+        typeof event === "object" &&
+        event !== null &&
+        !Array.isArray(event)
+      ) {
         const record = event as Record<string, unknown>;
         if (record.type === "result") last = record;
       }
-    } catch {
-      continue;
-    }
+    } catch {}
   }
   if (last === undefined) return undefined;
   return {
     subtype: typeof last.subtype === "string" ? last.subtype : undefined,
-    totalCostUsd: typeof last.total_cost_usd === "number" ? last.total_cost_usd : undefined,
+    totalCostUsd:
+      typeof last.total_cost_usd === "number" ? last.total_cost_usd : undefined,
     numTurns: typeof last.num_turns === "number" ? last.num_turns : undefined,
   };
 }
@@ -90,7 +101,11 @@ export function parseResultEvent(tail: string): ResultEvent | undefined {
  * same evidence: both are measured from a Worker that ran to completion,
  * which proves the environment was up.
  */
-const CORRELATABLE: ReadonlySet<string> = new Set(["nonzero-exit", "timeout", "stall"]);
+const CORRELATABLE: ReadonlySet<string> = new Set([
+  "nonzero-exit",
+  "timeout",
+  "stall",
+]);
 
 /**
  * The same-way-same-Tick heuristic: two or more Workers dying with the same
@@ -100,7 +115,9 @@ const CORRELATABLE: ReadonlySet<string> = new Set(["nonzero-exit", "timeout", "s
  * false positive costs a delay while a false negative burns Attempts across
  * the whole DAG.
  */
-export function reclassifyCorrelatedFailures(outcomes: WorkerOutcome[]): WorkerOutcome[] {
+export function reclassifyCorrelatedFailures(
+  outcomes: WorkerOutcome[],
+): WorkerOutcome[] {
   const counts = new Map<string, number>();
   for (const outcome of outcomes) {
     if (outcome.failure !== undefined && CORRELATABLE.has(outcome.failure)) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,19 +3,23 @@ import { parseArgs } from "node:util";
 import { act } from "./act.js";
 import {
   ConfigError,
+  type Flags,
   loadConfigFile,
   modelForAttempt,
-  resolveConfig,
-  type Flags,
   type ResolvedConfig,
+  resolveConfig,
 } from "./config.js";
 import { plan } from "./plan.js";
 import { openPrForOutcome } from "./pr.js";
 import { renderPlan } from "./render.js";
 import { run } from "./run.js";
 import { readScope } from "./tracker.js";
-import { dispatchConflictWorker, dispatchWorker, probeEnvironment } from "./worker.js";
 import type { Action, WorldSnapshot } from "./types.js";
+import {
+  dispatchConflictWorker,
+  dispatchWorker,
+  probeEnvironment,
+} from "./worker.js";
 
 const USAGE = `Usage: border-collie <tick|run> [options]
 
@@ -65,7 +69,10 @@ e.g. {"parent": 1, "max_workers": 3, "max_open_prs": 5, "poll_seconds": 30,
 "worker_timeout_minutes": 45, "worker_stall_minutes": 10,
 "worker_max_turns": 200, "worker_max_cost_usd": 20}`;
 
-function parseIntFlag(value: string | undefined, name: string): number | undefined {
+function parseIntFlag(
+  value: string | undefined,
+  name: string,
+): number | undefined {
   if (value === undefined) return undefined;
   if (!/^\d+$/.test(value)) {
     throw new ConfigError(`${name} must be an integer, got "${value}"`);
@@ -100,7 +107,11 @@ async function tickOnce(
           maxTurns: config.maxTurns,
           maxCostUsd: config.maxCostUsd,
         }),
-      (outcome) => openPrForOutcome(outcome, titles.get(outcome.ticket) ?? `Ticket #${outcome.ticket}`),
+      (outcome) =>
+        openPrForOutcome(
+          outcome,
+          titles.get(outcome.ticket) ?? `Ticket #${outcome.ticket}`,
+        ),
       (pr, ticket, headRef) =>
         dispatchConflictWorker(pr, ticket, headRef, {
           model: config.model,
@@ -151,7 +162,8 @@ async function main(argv: string[]): Promise<number> {
   if (pollSeconds !== undefined) flags.pollSeconds = pollSeconds;
   if (values.all) flags.all = true;
   if (values.model !== undefined) flags.model = values.model;
-  if (values["retry-model"] !== undefined) flags.retryModel = values["retry-model"];
+  if (values["retry-model"] !== undefined)
+    flags.retryModel = values["retry-model"];
 
   const config = resolveConfig(loadConfigFile(process.cwd()), flags);
 
@@ -169,7 +181,9 @@ async function main(argv: string[]): Promise<number> {
   }
 
   if (dryRun) {
-    throw new ConfigError("--dry-run only applies to tick: a dry run never progresses the loop");
+    throw new ConfigError(
+      "--dry-run only applies to tick: a dry run never progresses the loop",
+    );
   }
   const outcome = await run(config.pollSeconds, {
     tick: (dispatchPaused) => tickOnce(config, false, dispatchPaused),

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -65,7 +65,11 @@ describe("resolveConfig", () => {
   it("requires an explicit all flag for repo-wide scope", () => {
     const resolved = resolveConfig({ max_workers: 2 }, { all: true });
 
-    expect(resolved).toMatchObject({ scope: { kind: "all" }, maxWorkers: 2, model: "sonnet" });
+    expect(resolved).toMatchObject({
+      scope: { kind: "all" },
+      maxWorkers: 2,
+      model: "sonnet",
+    });
   });
 
   it("takes the worker model from the config file", () => {
@@ -75,19 +79,30 @@ describe("resolveConfig", () => {
   });
 
   it("rejects a worker model that is not a non-empty string", () => {
-    expect(() => resolveConfig({ parent: 1, worker_model: "" }, {})).toThrow(ConfigError);
-    expect(() => resolveConfig({ parent: 1, worker_model: 4 }, {})).toThrow(ConfigError);
+    expect(() => resolveConfig({ parent: 1, worker_model: "" }, {})).toThrow(
+      ConfigError,
+    );
+    expect(() => resolveConfig({ parent: 1, worker_model: 4 }, {})).toThrow(
+      ConfigError,
+    );
   });
 
   it("takes the retry model from the config file, with a flag override", () => {
-    expect(resolveConfig({ parent: 1, retry_model: "sonnet" }, {}).retryModel).toBe("sonnet");
     expect(
-      resolveConfig({ parent: 1, retry_model: "sonnet" }, { retryModel: "haiku" }).retryModel,
+      resolveConfig({ parent: 1, retry_model: "sonnet" }, {}).retryModel,
+    ).toBe("sonnet");
+    expect(
+      resolveConfig(
+        { parent: 1, retry_model: "sonnet" },
+        { retryModel: "haiku" },
+      ).retryModel,
     ).toBe("haiku");
   });
 
   it("rejects a retry model that is not a non-empty string", () => {
-    expect(() => resolveConfig({ parent: 1, retry_model: "" }, {})).toThrow(ConfigError);
+    expect(() => resolveConfig({ parent: 1, retry_model: "" }, {})).toThrow(
+      ConfigError,
+    );
   });
 
   it("takes the Worker timeout and stall windows from the config file", () => {
@@ -101,8 +116,12 @@ describe("resolveConfig", () => {
   });
 
   it("rejects non-positive timeout and stall windows", () => {
-    expect(() => resolveConfig({ parent: 1, worker_timeout_minutes: 0 }, {})).toThrow(ConfigError);
-    expect(() => resolveConfig({ parent: 1, worker_stall_minutes: -1 }, {})).toThrow(ConfigError);
+    expect(() =>
+      resolveConfig({ parent: 1, worker_timeout_minutes: 0 }, {}),
+    ).toThrow(ConfigError);
+    expect(() =>
+      resolveConfig({ parent: 1, worker_stall_minutes: -1 }, {}),
+    ).toThrow(ConfigError);
   });
 
   it("takes the Worker budget backstops from the config file, allowing a fractional cost cap", () => {
@@ -116,10 +135,18 @@ describe("resolveConfig", () => {
   });
 
   it("rejects non-positive or non-numeric budget backstops", () => {
-    expect(() => resolveConfig({ parent: 1, worker_max_turns: 0 }, {})).toThrow(ConfigError);
-    expect(() => resolveConfig({ parent: 1, worker_max_turns: 1.5 }, {})).toThrow(ConfigError);
-    expect(() => resolveConfig({ parent: 1, worker_max_cost_usd: -2 }, {})).toThrow(ConfigError);
-    expect(() => resolveConfig({ parent: 1, worker_max_cost_usd: "20" }, {})).toThrow(ConfigError);
+    expect(() => resolveConfig({ parent: 1, worker_max_turns: 0 }, {})).toThrow(
+      ConfigError,
+    );
+    expect(() =>
+      resolveConfig({ parent: 1, worker_max_turns: 1.5 }, {}),
+    ).toThrow(ConfigError);
+    expect(() =>
+      resolveConfig({ parent: 1, worker_max_cost_usd: -2 }, {}),
+    ).toThrow(ConfigError);
+    expect(() =>
+      resolveConfig({ parent: 1, worker_max_cost_usd: "20" }, {}),
+    ).toThrow(ConfigError);
   });
 
   it("rejects a run with neither a parent nor the all flag", () => {
@@ -156,7 +183,10 @@ describe("resolveConfig", () => {
   });
 
   it("takes max_open_prs and poll_seconds from the config file", () => {
-    const resolved = resolveConfig({ parent: 1, max_open_prs: 2, poll_seconds: 60 }, {});
+    const resolved = resolveConfig(
+      { parent: 1, max_open_prs: 2, poll_seconds: 60 },
+      {},
+    );
 
     expect(resolved.maxOpenPrs).toBe(2);
     expect(resolved.pollSeconds).toBe(60);
@@ -173,8 +203,12 @@ describe("resolveConfig", () => {
   });
 
   it("rejects a non-positive max_open_prs or poll_seconds", () => {
-    expect(() => resolveConfig({ parent: 1, max_open_prs: 0 }, {})).toThrow(ConfigError);
-    expect(() => resolveConfig({ parent: 1 }, { pollSeconds: 0 })).toThrow(ConfigError);
+    expect(() => resolveConfig({ parent: 1, max_open_prs: 0 }, {})).toThrow(
+      ConfigError,
+    );
+    expect(() => resolveConfig({ parent: 1 }, { pollSeconds: 0 })).toThrow(
+      ConfigError,
+    );
   });
 
   it("rejects a malformed config file", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,7 +54,9 @@ export interface ResolvedConfig {
 
 function asPositiveInt(value: unknown, name: string): number {
   if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
-    throw new ConfigError(`${name} must be a positive integer, got ${JSON.stringify(value)}`);
+    throw new ConfigError(
+      `${name} must be a positive integer, got ${JSON.stringify(value)}`,
+    );
   }
   return value;
 }
@@ -62,14 +64,18 @@ function asPositiveInt(value: unknown, name: string): number {
 /** Costs are money, not counts: any positive finite number is fine. */
 function asPositiveNumber(value: unknown, name: string): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
-    throw new ConfigError(`${name} must be a positive number, got ${JSON.stringify(value)}`);
+    throw new ConfigError(
+      `${name} must be a positive number, got ${JSON.stringify(value)}`,
+    );
   }
   return value;
 }
 
 function asNonEmptyString(value: unknown, name: string): string {
   if (typeof value !== "string" || value === "") {
-    throw new ConfigError(`${name} must be a non-empty string, got ${JSON.stringify(value)}`);
+    throw new ConfigError(
+      `${name} must be a non-empty string, got ${JSON.stringify(value)}`,
+    );
   }
   return value;
 }
@@ -79,43 +85,54 @@ function asNonEmptyString(value: unknown, name: string): string {
  * scope is never implicit: only the explicit `all` flag selects it, and it
  * refuses to combine with a `parent` flag.
  */
-export function resolveConfig(fileConfig: unknown, flags: Flags): ResolvedConfig {
-  if (fileConfig !== undefined && (typeof fileConfig !== "object" || fileConfig === null || Array.isArray(fileConfig))) {
+export function resolveConfig(
+  fileConfig: unknown,
+  flags: Flags,
+): ResolvedConfig {
+  if (
+    fileConfig !== undefined &&
+    (typeof fileConfig !== "object" ||
+      fileConfig === null ||
+      Array.isArray(fileConfig))
+  ) {
     throw new ConfigError(`${CONFIG_FILE} must contain a JSON object`);
   }
   const file = (fileConfig ?? {}) as Record<string, unknown>;
 
   const maxWorkers = asPositiveInt(
-    flags.maxWorkers ?? file["max_workers"] ?? DEFAULT_MAX_WORKERS,
+    flags.maxWorkers ?? file.max_workers ?? DEFAULT_MAX_WORKERS,
     "max_workers",
   );
   const maxOpenPrs = asPositiveInt(
-    flags.maxOpenPrs ?? file["max_open_prs"] ?? DEFAULT_MAX_OPEN_PRS,
+    flags.maxOpenPrs ?? file.max_open_prs ?? DEFAULT_MAX_OPEN_PRS,
     "max_open_prs",
   );
   const pollSeconds = asPositiveInt(
-    flags.pollSeconds ?? file["poll_seconds"] ?? DEFAULT_POLL_SECONDS,
+    flags.pollSeconds ?? file.poll_seconds ?? DEFAULT_POLL_SECONDS,
     "poll_seconds",
   );
   const model = asNonEmptyString(
-    flags.model ?? file["worker_model"] ?? DEFAULT_WORKER_MODEL,
+    flags.model ?? file.worker_model ?? DEFAULT_WORKER_MODEL,
     "worker_model",
   );
   const retryModel = asNonEmptyString(
-    flags.retryModel ?? file["retry_model"] ?? DEFAULT_RETRY_MODEL,
+    flags.retryModel ?? file.retry_model ?? DEFAULT_RETRY_MODEL,
     "retry_model",
   );
   const timeoutMinutes = asPositiveInt(
-    file["worker_timeout_minutes"] ?? DEFAULT_TIMEOUT_MINUTES,
+    file.worker_timeout_minutes ?? DEFAULT_TIMEOUT_MINUTES,
     "worker_timeout_minutes",
   );
   const stallMinutes = asPositiveInt(
-    file["worker_stall_minutes"] ?? DEFAULT_STALL_MINUTES,
+    file.worker_stall_minutes ?? DEFAULT_STALL_MINUTES,
     "worker_stall_minutes",
   );
-  const maxTurns = asPositiveInt(file["worker_max_turns"] ?? DEFAULT_MAX_TURNS, "worker_max_turns");
+  const maxTurns = asPositiveInt(
+    file.worker_max_turns ?? DEFAULT_MAX_TURNS,
+    "worker_max_turns",
+  );
   const maxCostUsd = asPositiveNumber(
-    file["worker_max_cost_usd"] ?? DEFAULT_MAX_COST_USD,
+    file.worker_max_cost_usd ?? DEFAULT_MAX_COST_USD,
     "worker_max_cost_usd",
   );
   const shared = {
@@ -137,17 +154,23 @@ export function resolveConfig(fileConfig: unknown, flags: Flags): ResolvedConfig
     return { scope: { kind: "all" }, ...shared };
   }
 
-  const parent = flags.parent ?? file["parent"];
+  const parent = flags.parent ?? file.parent;
   if (parent === undefined) {
     throw new ConfigError(
       `no scope: set "parent" in ${CONFIG_FILE} or pass --parent <n> (repo-wide scope requires the explicit --all flag)`,
     );
   }
-  return { scope: { kind: "parent", parent: asPositiveInt(parent, "parent") }, ...shared };
+  return {
+    scope: { kind: "parent", parent: asPositiveInt(parent, "parent") },
+    ...shared,
+  };
 }
 
 /** The retry ladder's model binding: attempt two runs the stronger retry model. */
-export function modelForAttempt(config: ResolvedConfig, attempt: number): string {
+export function modelForAttempt(
+  config: ResolvedConfig,
+  attempt: number,
+): string {
   return attempt >= 2 ? config.retryModel : config.model;
 }
 

--- a/src/plan.test.ts
+++ b/src/plan.test.ts
@@ -34,7 +34,10 @@ function failure(attempt: number): AttemptFailure {
 }
 
 /** A clean, current, non-draft open agent PR — the backdrop that triggers no upkeep. */
-function openPr(ticket: number, overrides: Partial<OpenAgentPr> = {}): OpenAgentPr {
+function openPr(
+  ticket: number,
+  overrides: Partial<OpenAgentPr> = {},
+): OpenAgentPr {
   return {
     number: ticket * 10,
     ticket,
@@ -53,11 +56,18 @@ function world(
   openAgentPrTickets: number[] = [],
   mergedAgentPrs: MergedAgentPr[] = [],
 ): WorldSnapshot {
-  return { tickets, openAgentPrs: openAgentPrTickets.map((t) => openPr(t)), mergedAgentPrs };
+  return {
+    tickets,
+    openAgentPrs: openAgentPrTickets.map((t) => openPr(t)),
+    mergedAgentPrs,
+  };
 }
 
 /** A world whose open agent PRs are given in full — for the PR-upkeep cases. */
-function worldWithPrs(tickets: Ticket[], openAgentPrs: OpenAgentPr[]): WorldSnapshot {
+function worldWithPrs(
+  tickets: Ticket[],
+  openAgentPrs: OpenAgentPr[],
+): WorldSnapshot {
   return { tickets, openAgentPrs, mergedAgentPrs: [] };
 }
 
@@ -67,7 +77,10 @@ function mergedPr(ticket: number): MergedAgentPr {
 
 describe("plan", () => {
   it("claims a dispatchable ticket and spawns a Worker for it", () => {
-    const actions = plan(world([ticket({ number: 7 })]), { maxWorkers: 3, maxOpenPrs: 5 });
+    const actions = plan(world([ticket({ number: 7 })]), {
+      maxWorkers: 3,
+      maxOpenPrs: 5,
+    });
 
     expect(actions).toEqual([
       { type: "claim", ticket: 7 },
@@ -80,10 +93,10 @@ describe("plan", () => {
   });
 
   it("excludes closed tickets", () => {
-    const actions = plan(
-      world([ticket({ number: 1, state: "closed" })]),
-      { maxWorkers: 3, maxOpenPrs: 5 },
-    );
+    const actions = plan(world([ticket({ number: 1, state: "closed" })]), {
+      maxWorkers: 3,
+      maxOpenPrs: 5,
+    });
 
     expect(actions).toEqual([]);
   });
@@ -110,21 +123,25 @@ describe("plan", () => {
   });
 
   it("excludes tickets with open blockers", () => {
-    const actions = plan(
-      world([ticket({ number: 1, openBlockers: 2 })]),
-      { maxWorkers: 3, maxOpenPrs: 5 },
-    );
+    const actions = plan(world([ticket({ number: 1, openBlockers: 2 })]), {
+      maxWorkers: 3,
+      maxOpenPrs: 5,
+    });
 
     expect(actions).toEqual([]);
   });
 
   it("releases an orphaned agent claim: assigned with marker, no open agent PR", () => {
     const actions = plan(
-      world([ticket({ number: 5, assignees: ["operator"], hasAgentClaim: true })]),
+      world([
+        ticket({ number: 5, assignees: ["operator"], hasAgentClaim: true }),
+      ]),
       { maxWorkers: 3, maxOpenPrs: 5 },
     );
 
-    expect(actions).toEqual([{ type: "release", ticket: 5, assignees: ["operator"] }]);
+    expect(actions).toEqual([
+      { type: "release", ticket: 5, assignees: ["operator"] },
+    ]);
   });
 
   it("keeps an agent claim whose ticket has an open agent PR", () => {
@@ -151,7 +168,12 @@ describe("plan", () => {
   it("does not release a closed ticket that still carries the marker", () => {
     const actions = plan(
       world([
-        ticket({ number: 5, state: "closed", assignees: ["operator"], hasAgentClaim: true }),
+        ticket({
+          number: 5,
+          state: "closed",
+          assignees: ["operator"],
+          hasAgentClaim: true,
+        }),
       ]),
       { maxWorkers: 3, maxOpenPrs: 5 },
     );
@@ -219,7 +241,13 @@ describe("plan", () => {
 describe("plan: retry ladder and Escalation", () => {
   it("re-claims a once-failed ticket as attempt 2 (the retry ladder)", () => {
     const actions = plan(
-      world([ticket({ number: 7, agentClaimCount: 1, attemptFailures: [failure(1)] })]),
+      world([
+        ticket({
+          number: 7,
+          agentClaimCount: 1,
+          attemptFailures: [failure(1)],
+        }),
+      ]),
       { maxWorkers: 3, maxOpenPrs: 5 },
     );
 
@@ -232,7 +260,9 @@ describe("plan: retry ladder and Escalation", () => {
   it("escalates instead of dispatching once attempts are exhausted, citing the failure records", () => {
     const failures = [failure(1), failure(2)];
     const actions = plan(
-      world([ticket({ number: 7, agentClaimCount: 2, attemptFailures: failures })]),
+      world([
+        ticket({ number: 7, agentClaimCount: 2, attemptFailures: failures }),
+      ]),
       { maxWorkers: 3, maxOpenPrs: 5 },
     );
 
@@ -241,11 +271,19 @@ describe("plan: retry ladder and Escalation", () => {
 
   it("escalates a ticket with more claims than failure records (orphan-released attempts)", () => {
     const actions = plan(
-      world([ticket({ number: 7, agentClaimCount: 3, attemptFailures: [failure(2)] })]),
+      world([
+        ticket({
+          number: 7,
+          agentClaimCount: 3,
+          attemptFailures: [failure(2)],
+        }),
+      ]),
       { maxWorkers: 3, maxOpenPrs: 5 },
     );
 
-    expect(actions).toEqual([{ type: "escalate", ticket: 7, failures: [failure(2)] }]);
+    expect(actions).toEqual([
+      { type: "escalate", ticket: 7, failures: [failure(2)] },
+    ]);
   });
 
   it("never escalates an already-escalated ticket (label swap removed ready-for-agent)", () => {
@@ -282,19 +320,30 @@ describe("plan: retry ladder and Escalation", () => {
   it("does not escalate an assigned ticket this tick: the orphan release goes first", () => {
     const actions = plan(
       world([
-        ticket({ number: 7, assignees: ["operator"], hasAgentClaim: true, agentClaimCount: 2 }),
+        ticket({
+          number: 7,
+          assignees: ["operator"],
+          hasAgentClaim: true,
+          agentClaimCount: 2,
+        }),
       ]),
       { maxWorkers: 3, maxOpenPrs: 5 },
     );
 
-    expect(actions).toEqual([{ type: "release", ticket: 7, assignees: ["operator"] }]);
+    expect(actions).toEqual([
+      { type: "release", ticket: 7, assignees: ["operator"] },
+    ]);
   });
 
   it("orders escalations after releases and before dispatches, without consuming Worker slots", () => {
     const actions = plan(
       world([
         ticket({ number: 3 }),
-        ticket({ number: 5, agentClaimCount: 2, attemptFailures: [failure(1), failure(2)] }),
+        ticket({
+          number: 5,
+          agentClaimCount: 2,
+          attemptFailures: [failure(1), failure(2)],
+        }),
         ticket({ number: 6, assignees: ["operator"], hasAgentClaim: true }),
       ]),
       { maxWorkers: 1, maxOpenPrs: 5 },
@@ -310,7 +359,11 @@ describe("plan: retry ladder and Escalation", () => {
 
   it("closes an open ticket whose agent PR merged, with the PR linked", () => {
     const actions = plan(
-      world([ticket({ number: 6, assignees: ["operator"], hasAgentClaim: true })], [], [mergedPr(6)]),
+      world(
+        [ticket({ number: 6, assignees: ["operator"], hasAgentClaim: true })],
+        [],
+        [mergedPr(6)],
+      ),
       { maxWorkers: 3, maxOpenPrs: 5 },
     );
 
@@ -331,10 +384,10 @@ describe("plan: retry ladder and Escalation", () => {
   it("does not release or re-dispatch a merged ticket awaiting closure", () => {
     // Unassigned, labelled, unblocked — but its PR already merged. Claiming it
     // again would dispatch duplicate work in the same tick as the close.
-    const actions = plan(
-      world([ticket({ number: 6 })], [], [mergedPr(6)]),
-      { maxWorkers: 3, maxOpenPrs: 5 },
-    );
+    const actions = plan(world([ticket({ number: 6 })], [], [mergedPr(6)]), {
+      maxWorkers: 3,
+      maxOpenPrs: 5,
+    });
 
     expect(actions).toEqual([
       { type: "close", ticket: 6, prUrl: "https://github.com/o/r/pull/60" },
@@ -381,10 +434,10 @@ describe("plan: retry ladder and Escalation", () => {
   });
 
   it("pauses dispatch entirely while open agent PRs are at max_open_prs", () => {
-    const actions = plan(
-      world([ticket({ number: 6 })], [1, 2, 3, 4, 5]),
-      { maxWorkers: 3, maxOpenPrs: 5 },
-    );
+    const actions = plan(world([ticket({ number: 6 })], [1, 2, 3, 4, 5]), {
+      maxWorkers: 3,
+      maxOpenPrs: 5,
+    });
 
     expect(actions).toEqual([]);
   });
@@ -413,7 +466,11 @@ describe("plan: retry ladder and Escalation", () => {
 describe("plan: circuit breaker", () => {
   it("plans only closure verification while dispatch is paused: no claims, no spawns", () => {
     const actions = plan(
-      world([ticket({ number: 4 }), ticket({ number: 6, state: "closed" })], [], [mergedPr(6)]),
+      world(
+        [ticket({ number: 4 }), ticket({ number: 6, state: "closed" })],
+        [],
+        [mergedPr(6)],
+      ),
       { maxWorkers: 3, maxOpenPrs: 5, dispatchPaused: true },
     );
 
@@ -440,13 +497,29 @@ describe("plan: circuit breaker", () => {
       agentClaimCount: 1,
     });
 
-    expect(plan(world([held]), { maxWorkers: 3, maxOpenPrs: 5, dispatchPaused: true })).toEqual([]);
+    expect(
+      plan(world([held]), {
+        maxWorkers: 3,
+        maxOpenPrs: 5,
+        dispatchPaused: true,
+      }),
+    ).toEqual([]);
   });
 
   it("does not escalate while paused: tickets are judged only against a healthy environment", () => {
-    const exhausted = ticket({ number: 7, agentClaimCount: 2, attemptFailures: [failure(1), failure(2)] });
+    const exhausted = ticket({
+      number: 7,
+      agentClaimCount: 2,
+      attemptFailures: [failure(1), failure(2)],
+    });
 
-    expect(plan(world([exhausted]), { maxWorkers: 3, maxOpenPrs: 5, dispatchPaused: true })).toEqual([]);
+    expect(
+      plan(world([exhausted]), {
+        maxWorkers: 3,
+        maxOpenPrs: 5,
+        dispatchPaused: true,
+      }),
+    ).toEqual([]);
   });
 
   it("does not count a voided attempt: a claim history net of voids re-dispatches at the same rung", () => {
@@ -464,7 +537,10 @@ describe("plan: circuit breaker", () => {
 describe("plan: PR upkeep", () => {
   it("plans no upkeep for a clean, current, non-draft PR", () => {
     const actions = plan(
-      worldWithPrs([ticket({ number: 3, assignees: ["operator"], hasAgentClaim: true })], [openPr(3)]),
+      worldWithPrs(
+        [ticket({ number: 3, assignees: ["operator"], hasAgentClaim: true })],
+        [openPr(3)],
+      ),
       { maxWorkers: 3, maxOpenPrs: 5 },
     );
 
@@ -493,7 +569,12 @@ describe("plan: PR upkeep", () => {
     );
 
     expect(actions).toEqual([
-      { type: "conflict-worker", pr: 30, ticket: 3, headRef: "border-collie/ticket-3-attempt-1" },
+      {
+        type: "conflict-worker",
+        pr: 30,
+        ticket: 3,
+        headRef: "border-collie/ticket-3-attempt-1",
+      },
     ]);
   });
 
@@ -501,7 +582,13 @@ describe("plan: PR upkeep", () => {
     const actions = plan(
       worldWithPrs(
         [ticket({ number: 3, assignees: ["operator"], hasAgentClaim: true })],
-        [openPr(3, { number: 30, mergeable: "conflicted", conflictWorkerAsked: true })],
+        [
+          openPr(3, {
+            number: 30,
+            mergeable: "conflicted",
+            conflictWorkerAsked: true,
+          }),
+        ],
       ),
       { maxWorkers: 3, maxOpenPrs: 5 },
     );
@@ -513,7 +600,15 @@ describe("plan: PR upkeep", () => {
     const actions = plan(
       worldWithPrs(
         [ticket({ number: 3, assignees: ["operator"], hasAgentClaim: true })],
-        [openPr(3, { number: 30, mergeable: "conflicted", behind: true, draft: true, conflictWorkerAsked: true })],
+        [
+          openPr(3, {
+            number: 30,
+            mergeable: "conflicted",
+            behind: true,
+            draft: true,
+            conflictWorkerAsked: true,
+          }),
+        ],
       ),
       { maxWorkers: 3, maxOpenPrs: 5 },
     );
@@ -541,7 +636,14 @@ describe("plan: PR upkeep", () => {
     const actions = plan(
       worldWithPrs(
         [ticket({ number: 3, assignees: ["operator"], hasAgentClaim: true })],
-        [openPr(3, { number: 30, mergeable: "unknown", draft: true, ci: "none" })],
+        [
+          openPr(3, {
+            number: 30,
+            mergeable: "unknown",
+            draft: true,
+            ci: "none",
+          }),
+        ],
       ),
       { maxWorkers: 3, maxOpenPrs: 5 },
     );

--- a/src/plan.ts
+++ b/src/plan.ts
@@ -1,8 +1,8 @@
 import {
-  MAX_ATTEMPTS,
-  READY_FOR_AGENT,
   type Action,
+  MAX_ATTEMPTS,
   type PlanConfig,
+  READY_FOR_AGENT,
   type Ticket,
   type WorldSnapshot,
 } from "./types.js";
@@ -93,10 +93,17 @@ function isEscalationDue(ticket: Ticket, world: WorldSnapshot): boolean {
  */
 function prUpkeep(world: WorldSnapshot): Action[] {
   const actions: Action[] = [];
-  for (const pr of [...world.openAgentPrs].sort((a, b) => a.number - b.number)) {
+  for (const pr of [...world.openAgentPrs].sort(
+    (a, b) => a.number - b.number,
+  )) {
     if (pr.mergeable === "conflicted") {
       if (!pr.conflictWorkerAsked) {
-        actions.push({ type: "conflict-worker", pr: pr.number, ticket: pr.ticket, headRef: pr.headRef });
+        actions.push({
+          type: "conflict-worker",
+          pr: pr.number,
+          ticket: pr.ticket,
+          headRef: pr.headRef,
+        });
       }
       continue;
     }
@@ -145,7 +152,11 @@ export function plan(world: WorldSnapshot, config: PlanConfig): Action[] {
   const releases: Action[] = world.tickets
     .filter((ticket) => isOrphanedClaim(ticket, world))
     .sort((a, b) => a.number - b.number)
-    .map((ticket) => ({ type: "release", ticket: ticket.number, assignees: ticket.assignees }));
+    .map((ticket) => ({
+      type: "release",
+      ticket: ticket.number,
+      assignees: ticket.assignees,
+    }));
 
   const escalations: Action[] = world.tickets
     .filter((ticket) => isEscalationDue(ticket, world))
@@ -165,8 +176,18 @@ export function plan(world: WorldSnapshot, config: PlanConfig): Action[] {
     .slice(0, Math.max(0, Math.min(config.maxWorkers, headroom)))
     .flatMap((ticket) => [
       { type: "claim", ticket: ticket.number },
-      { type: "spawn", ticket: ticket.number, attempt: ticket.agentClaimCount + 1 },
+      {
+        type: "spawn",
+        ticket: ticket.number,
+        attempt: ticket.agentClaimCount + 1,
+      },
     ]);
 
-  return [...closes, ...prUpkeep(world), ...releases, ...escalations, ...dispatches];
+  return [
+    ...closes,
+    ...prUpkeep(world),
+    ...releases,
+    ...escalations,
+    ...dispatches,
+  ];
 }

--- a/src/pr.test.ts
+++ b/src/pr.test.ts
@@ -5,8 +5,8 @@ import {
   isSanePrBody,
   MAX_WORKER_BODY_LENGTH,
   openPrForOutcome,
-  workerFinalMessage,
   type ReadFile,
+  workerFinalMessage,
 } from "./pr.js";
 import type { Exec } from "./tracker.js";
 import type { WorkerOutcome } from "./worker.js";
@@ -32,7 +32,11 @@ describe("workerFinalMessage", () => {
   });
 
   it("returns undefined when the run did not end in success", () => {
-    const transcript = event({ type: "result", subtype: "error_max_turns", is_error: true });
+    const transcript = event({
+      type: "result",
+      subtype: "error_max_turns",
+      is_error: true,
+    });
 
     expect(workerFinalMessage(transcript)).toBeUndefined();
   });
@@ -49,13 +53,19 @@ describe("workerFinalMessage", () => {
   });
 
   it("tolerates stray non-JSON lines around the events", () => {
-    const transcript = ["not json at all", successResult("Still found."), ""].join("\n");
+    const transcript = [
+      "not json at all",
+      successResult("Still found."),
+      "",
+    ].join("\n");
 
     expect(workerFinalMessage(transcript)).toBe("Still found.");
   });
 
   it("uses the last result event when several exist", () => {
-    const transcript = [successResult("first"), successResult("second")].join("\n");
+    const transcript = [successResult("first"), successResult("second")].join(
+      "\n",
+    );
 
     expect(workerFinalMessage(transcript)).toBe("second");
   });
@@ -85,12 +95,18 @@ describe("ensureCloseKeyword", () => {
   });
 
   it("leaves the body alone when it already closes the ticket", () => {
-    expect(ensureCloseKeyword("A body.\n\nCloses #5", 5)).toBe("A body.\n\nCloses #5");
-    expect(ensureCloseKeyword("Fixes #5 for real", 5)).toBe("Fixes #5 for real");
+    expect(ensureCloseKeyword("A body.\n\nCloses #5", 5)).toBe(
+      "A body.\n\nCloses #5",
+    );
+    expect(ensureCloseKeyword("Fixes #5 for real", 5)).toBe(
+      "Fixes #5 for real",
+    );
   });
 
   it("appends for keyword forms GitHub may not recognize (colon, newline)", () => {
-    expect(ensureCloseKeyword("resolved: #5", 5)).toBe("resolved: #5\n\nCloses #5");
+    expect(ensureCloseKeyword("resolved: #5", 5)).toBe(
+      "resolved: #5\n\nCloses #5",
+    );
     expect(ensureCloseKeyword("closes\n#5", 5)).toBe("closes\n#5\n\nCloses #5");
   });
 
@@ -130,7 +146,8 @@ function fakeExec(): { exec: Exec; calls: string[][] } {
   const calls: string[][] = [];
   const exec: Exec = async (cmd, args) => {
     calls.push([cmd, ...args]);
-    if (cmd === "git" && args[0] === "log") return "First commit\nSecond commit\n";
+    if (cmd === "git" && args[0] === "log")
+      return "First commit\nSecond commit\n";
     if (cmd === "gh") return "https://github.com/o/r/pull/9\n";
     return "";
   };
@@ -178,7 +195,9 @@ describe("openPrForOutcome", () => {
 
   it("falls back to a mechanical body from the ticket and commit subjects when the sanity check fails", async () => {
     const { exec, calls } = fakeExec();
-    const read = readAs(event({ type: "result", subtype: "error_during_execution" }));
+    const read = readAs(
+      event({ type: "result", subtype: "error_during_execution" }),
+    );
 
     await openPrForOutcome(OUTCOME, "PR opening", exec, read);
 
@@ -210,7 +229,10 @@ describe("openPrForOutcome", () => {
 
 describe("fallbackBody", () => {
   it("names the ticket and lists the branch's commit subjects", () => {
-    const body = fallbackBody(5, "PR opening", ["First commit", "Second commit"]);
+    const body = fallbackBody(5, "PR opening", [
+      "First commit",
+      "Second commit",
+    ]);
 
     expect(body).toContain("#5");
     expect(body).toContain("PR opening");

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -1,6 +1,10 @@
 import { readFile } from "node:fs/promises";
-import { createDraftPr, realExec, type Exec } from "./tracker.js";
-import { branchCommitSubjects, pushAgentBranch, type WorkerOutcome } from "./worker.js";
+import { createDraftPr, type Exec, realExec } from "./tracker.js";
+import {
+  branchCommitSubjects,
+  pushAgentBranch,
+  type WorkerOutcome,
+} from "./worker.js";
 
 /**
  * PR opening: a successful Attempt's branch becomes a draft PR that closes
@@ -41,7 +45,12 @@ export function workerFinalMessage(transcript: string): string | undefined {
       if (record.type === "result") last = record;
     }
   }
-  if (last === undefined || last.subtype !== "success" || last.is_error === true) return undefined;
+  if (
+    last === undefined ||
+    last.subtype !== "success" ||
+    last.is_error === true
+  )
+    return undefined;
   return typeof last.result === "string" ? last.result : undefined;
 }
 
@@ -51,7 +60,11 @@ export function workerFinalMessage(transcript: string): string | undefined {
  * judgment about prose quality.
  */
 export function isSanePrBody(body: string | undefined): body is string {
-  return body !== undefined && body.trim() !== "" && body.length <= MAX_WORKER_BODY_LENGTH;
+  return (
+    body !== undefined &&
+    body.trim() !== "" &&
+    body.length <= MAX_WORKER_BODY_LENGTH
+  );
 }
 
 /**
@@ -61,7 +74,8 @@ export function isSanePrBody(body: string | undefined): body is string {
  * `Closes #n`, while an over-match would leave a merged PR whose ticket
  * never closes, freezing the DAG.
  */
-const CLOSE_KEYWORD = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)[ \t]+#(\d+)\b/gi;
+const CLOSE_KEYWORD =
+  /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)[ \t]+#(\d+)\b/gi;
 
 /**
  * Guarantee the body carries the close-on-merge keyword for its ticket, so a
@@ -76,7 +90,11 @@ export function ensureCloseKeyword(body: string, ticket: number): string {
 }
 
 /** Mechanical fallback body: the ticket plus the branch's commit subjects. */
-export function fallbackBody(ticket: number, title: string, commitSubjects: string[]): string {
+export function fallbackBody(
+  ticket: number,
+  title: string,
+  commitSubjects: string[],
+): string {
   return [
     `Automated draft PR for #${ticket}: ${title}`,
     "",
@@ -100,7 +118,9 @@ export async function openPrForOutcome(
   read: ReadFile = realReadFile,
 ): Promise<string> {
   await pushAgentBranch(outcome.branch, exec);
-  const finalMessage = workerFinalMessage(await read(outcome.transcript).catch(() => ""));
+  const finalMessage = workerFinalMessage(
+    await read(outcome.transcript).catch(() => ""),
+  );
   const body = isSanePrBody(finalMessage)
     ? finalMessage
     : fallbackBody(
@@ -109,7 +129,11 @@ export async function openPrForOutcome(
         await branchCommitSubjects(outcome.base, outcome.branch, exec),
       );
   return createDraftPr(
-    { head: outcome.branch, title: ticketTitle, body: ensureCloseKeyword(body, outcome.ticket) },
+    {
+      head: outcome.branch,
+      title: ticketTitle,
+      body: ensureCloseKeyword(body, outcome.ticket),
+    },
     exec,
   );
 }

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { renderComplete, renderPlan, renderStuck } from "./render.js";
-import { plan } from "./plan.js";
 import type { ResolvedConfig } from "./config.js";
+import { plan } from "./plan.js";
+import { renderComplete, renderPlan, renderStuck } from "./render.js";
 import type { OpenAgentPr, Ticket, WorldSnapshot } from "./types.js";
 
-function ticket(overrides: Partial<Ticket> & { number: number; title: string }): Ticket {
+function ticket(
+  overrides: Partial<Ticket> & { number: number; title: string },
+): Ticket {
   return {
     state: "open",
     assignees: [],
@@ -74,10 +76,16 @@ describe("renderPlan", () => {
   });
 
   it("says so when nothing is dispatchable", () => {
-    const empty: WorldSnapshot = { tickets: [], openAgentPrs: [], mergedAgentPrs: [] };
+    const empty: WorldSnapshot = {
+      tickets: [],
+      openAgentPrs: [],
+      mergedAgentPrs: [],
+    };
 
     expect(
-      renderPlan(config({ scope: { kind: "all" } }), empty, [], { dryRun: true }),
+      renderPlan(config({ scope: { kind: "all" } }), empty, [], {
+        dryRun: true,
+      }),
     ).toBe(
       [
         "Scope: repo-wide (--all) — 0 tickets (0 open)",
@@ -165,9 +173,24 @@ describe("renderPlan", () => {
   it("renders the PR-upkeep actions with the PR number and the ticket title", () => {
     const upkeep: WorldSnapshot = {
       tickets: [
-        ticket({ number: 5, title: "Behind base", assignees: ["operator"], hasAgentClaim: true }),
-        ticket({ number: 6, title: "Conflicted", assignees: ["operator"], hasAgentClaim: true }),
-        ticket({ number: 7, title: "Green draft", assignees: ["operator"], hasAgentClaim: true }),
+        ticket({
+          number: 5,
+          title: "Behind base",
+          assignees: ["operator"],
+          hasAgentClaim: true,
+        }),
+        ticket({
+          number: 6,
+          title: "Conflicted",
+          assignees: ["operator"],
+          hasAgentClaim: true,
+        }),
+        ticket({
+          number: 7,
+          title: "Green draft",
+          assignees: ["operator"],
+          hasAgentClaim: true,
+        }),
       ],
       openAgentPrs: [
         { ...openPr(5), behind: true },
@@ -209,9 +232,18 @@ describe("renderPlan", () => {
   });
 
   it("notes the open circuit breaker when dispatch is paused for infrastructure failure", () => {
-    const actions = plan(world, { maxWorkers: 3, maxOpenPrs: 5, dispatchPaused: true });
+    const actions = plan(world, {
+      maxWorkers: 3,
+      maxOpenPrs: 5,
+      dispatchPaused: true,
+    });
 
-    expect(renderPlan(config(), world, actions, { dryRun: false, dispatchPaused: true })).toBe(
+    expect(
+      renderPlan(config(), world, actions, {
+        dryRun: false,
+        dispatchPaused: true,
+      }),
+    ).toBe(
       [
         "Scope: sub-issues of #1 — 3 tickets (2 open)",
         "Dispatchable: #2",
@@ -236,7 +268,11 @@ describe("renderStuck", () => {
         openBlockers: 2,
         blockedBy: [7, 99],
       }),
-      ticket({ number: 9, title: "A colleague's work", assignees: ["some-human"] }),
+      ticket({
+        number: 9,
+        title: "A colleague's work",
+        assignees: ["some-human"],
+      }),
     ];
 
     expect(renderStuck(stuckWorld(open))).toBe(
@@ -250,7 +286,9 @@ describe("renderStuck", () => {
   });
 
   it("falls back to the blocker count when the blocker list is missing", () => {
-    const open = [ticket({ number: 8, title: "Blocked blind", openBlockers: 2 })];
+    const open = [
+      ticket({ number: 8, title: "Blocked blind", openBlockers: 2 }),
+    ];
 
     expect(renderStuck(stuckWorld(open))).toBe(
       [
@@ -261,7 +299,9 @@ describe("renderStuck", () => {
   });
 
   it("notes a missing agent label distinctly from an escalation", () => {
-    const open = [ticket({ number: 4, title: "Untriaged", labels: ["needs-triage"] })];
+    const open = [
+      ticket({ number: 4, title: "Untriaged", labels: ["needs-triage"] }),
+    ];
 
     expect(renderStuck(stuckWorld(open))).toBe(
       [
@@ -276,7 +316,12 @@ describe("renderComplete", () => {
   it("summarizes every ticket in Scope, noting human closes after Escalation", () => {
     const report = renderComplete([
       ticket({ number: 2, title: "Walking skeleton", state: "closed" }),
-      ticket({ number: 7, title: "Hard one", state: "closed", labels: ["ready-for-human"] }),
+      ticket({
+        number: 7,
+        title: "Hard one",
+        state: "closed",
+        labels: ["ready-for-human"],
+      }),
     ]);
 
     expect(report).toBe(
@@ -289,6 +334,8 @@ describe("renderComplete", () => {
   });
 
   it("reports an empty Scope as complete with nothing herded", () => {
-    expect(renderComplete([])).toBe("Run Complete: every ticket in Scope is closed (0 tickets).");
+    expect(renderComplete([])).toBe(
+      "Run Complete: every ticket in Scope is closed (0 tickets).",
+    );
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,9 +1,9 @@
 import { modelForAttempt, type ResolvedConfig } from "./config.js";
 import { dispatchableSet } from "./plan.js";
 import {
+  type Action,
   READY_FOR_AGENT,
   READY_FOR_HUMAN,
-  type Action,
   type Ticket,
   type WorldSnapshot,
 } from "./types.js";
@@ -13,7 +13,10 @@ export function renderPlan(
   config: ResolvedConfig,
   world: WorldSnapshot,
   actions: Action[],
-  { dryRun, dispatchPaused = false }: { dryRun: boolean; dispatchPaused?: boolean },
+  {
+    dryRun,
+    dispatchPaused = false,
+  }: { dryRun: boolean; dispatchPaused?: boolean },
 ): string {
   const { scope, maxWorkers, maxOpenPrs } = config;
   const lines: string[] = [];
@@ -22,17 +25,26 @@ export function renderPlan(
     scope.kind === "parent"
       ? `sub-issues of #${scope.parent}`
       : "repo-wide (--all)";
-  lines.push(`Scope: ${scopeLabel} — ${world.tickets.length} tickets (${open} open)`);
+  lines.push(
+    `Scope: ${scopeLabel} — ${world.tickets.length} tickets (${open} open)`,
+  );
 
   const dispatchable = dispatchableSet(world);
   if (dispatchable.length === 0) {
     lines.push("Dispatchable: none");
   } else {
-    lines.push(`Dispatchable: ${dispatchable.map((t) => `#${t.number}`).join(", ")}`);
+    lines.push(
+      `Dispatchable: ${dispatchable.map((t) => `#${t.number}`).join(", ")}`,
+    );
   }
   if (dispatchPaused) {
-    lines.push("Dispatch paused: circuit breaker open (infrastructure failure), claims held");
-  } else if (dispatchable.length > 0 && world.openAgentPrs.length >= maxOpenPrs) {
+    lines.push(
+      "Dispatch paused: circuit breaker open (infrastructure failure), claims held",
+    );
+  } else if (
+    dispatchable.length > 0 &&
+    world.openAgentPrs.length >= maxOpenPrs
+  ) {
     lines.push(
       `Dispatch paused: ${world.openAgentPrs.length} open agent PRs at max_open_prs (${maxOpenPrs})`,
     );
@@ -40,7 +52,9 @@ export function renderPlan(
 
   const titles = new Map(world.tickets.map((t) => [t.number, t.title]));
   if (actions.length === 0) {
-    lines.push(`Plan (max_workers=${maxWorkers}, max_open_prs=${maxOpenPrs}): nothing to do`);
+    lines.push(
+      `Plan (max_workers=${maxWorkers}, max_open_prs=${maxOpenPrs}): nothing to do`,
+    );
   } else {
     lines.push(`Plan (max_workers=${maxWorkers}, max_open_prs=${maxOpenPrs}):`);
     for (const action of actions) {
@@ -50,7 +64,9 @@ export function renderPlan(
           lines.push(`  claim #${action.ticket} — ${title}`);
           break;
         case "release":
-          lines.push(`  release #${action.ticket} — ${title} (orphaned agent claim)`);
+          lines.push(
+            `  release #${action.ticket} — ${title} (orphaned agent claim)`,
+          );
           break;
         case "spawn":
           lines.push(
@@ -66,13 +82,19 @@ export function renderPlan(
           );
           break;
         case "close":
-          lines.push(`  close #${action.ticket} — ${title} (merged: ${action.prUrl})`);
+          lines.push(
+            `  close #${action.ticket} — ${title} (merged: ${action.prUrl})`,
+          );
           break;
         case "update-branch":
-          lines.push(`  update PR #${action.pr} — ${title} (behind base, mechanical rebase)`);
+          lines.push(
+            `  update PR #${action.pr} — ${title} (behind base, mechanical rebase)`,
+          );
           break;
         case "conflict-worker":
-          lines.push(`  conflict Worker for PR #${action.pr} — ${title} (resolve merge conflicts)`);
+          lines.push(
+            `  conflict Worker for PR #${action.pr} — ${title} (resolve merge conflicts)`,
+          );
           break;
         case "mark-ready":
           lines.push(`  mark PR #${action.pr} ready — ${title} (CI green)`);
@@ -93,7 +115,9 @@ export function renderPlan(
 function stuckReason(ticket: Ticket, inScope: Set<number>): string {
   const reasons: string[] = [];
   if (ticket.assignees.length > 0) {
-    reasons.push(`claimed by ${ticket.assignees.join(", ")} — a human claim, hands off`);
+    reasons.push(
+      `claimed by ${ticket.assignees.join(", ")} — a human claim, hands off`,
+    );
   }
   if (ticket.labels.includes(READY_FOR_HUMAN)) {
     reasons.push(`labelled ${READY_FOR_HUMAN}`);
@@ -119,9 +143,12 @@ export function renderStuck(world: WorldSnapshot): string {
   const inScope = new Set(world.tickets.map((t) => t.number));
   return [
     "Run Stuck: open tickets remain, but every path forward runs through a human.",
-    ...world.tickets.filter((ticket) => ticket.state === "open").map(
-      (ticket) => `  #${ticket.number} — ${ticket.title} (${stuckReason(ticket, inScope)})`,
-    ),
+    ...world.tickets
+      .filter((ticket) => ticket.state === "open")
+      .map(
+        (ticket) =>
+          `  #${ticket.number} — ${ticket.title} (${stuckReason(ticket, inScope)})`,
+      ),
   ].join("\n");
 }
 

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { BREAKER_BASE_COOLDOWN_MS } from "./breaker.js";
-import { run, runStatus, type RunDeps } from "./run.js";
-import type { Action, MergedAgentPr, OpenAgentPr, Ticket, WorldSnapshot } from "./types.js";
+import { type RunDeps, run, runStatus } from "./run.js";
+import type {
+  Action,
+  MergedAgentPr,
+  OpenAgentPr,
+  Ticket,
+  WorldSnapshot,
+} from "./types.js";
 
 function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
   return {
@@ -36,13 +42,20 @@ function world(
   openAgentPrTickets: number[] = [],
   mergedAgentPrs: MergedAgentPr[] = [],
 ): WorldSnapshot {
-  return { tickets, openAgentPrs: openAgentPrTickets.map(openPr), mergedAgentPrs };
+  return {
+    tickets,
+    openAgentPrs: openAgentPrTickets.map(openPr),
+    mergedAgentPrs,
+  };
 }
 
 describe("runStatus", () => {
   it("is complete when every ticket in Scope is closed", () => {
     const status = runStatus(
-      world([ticket({ number: 2, state: "closed" }), ticket({ number: 3, state: "closed" })]),
+      world([
+        ticket({ number: 2, state: "closed" }),
+        ticket({ number: 3, state: "closed" }),
+      ]),
       [],
     );
 
@@ -59,7 +72,9 @@ describe("runStatus", () => {
       { type: "spawn", ticket: 2, attempt: 1 },
     ];
 
-    expect(runStatus(world([ticket({ number: 2 })]), actions)).toEqual({ state: "running" });
+    expect(runStatus(world([ticket({ number: 2 })]), actions)).toEqual({
+      state: "running",
+    });
   });
 
   it("keeps running while agent PRs await human merge, even with nothing planned", () => {
@@ -92,11 +107,17 @@ describe("runStatus", () => {
   it("keeps running while a dispatchable ticket waits on headroom held by out-of-scope PRs", () => {
     // Dispatch was throttled to nothing (actions empty), but the ticket
     // becomes claimable the moment the foreign PRs merge — not stuck.
-    expect(runStatus(world([ticket({ number: 2 })], [99]), [])).toEqual({ state: "running" });
+    expect(runStatus(world([ticket({ number: 2 })], [99]), [])).toEqual({
+      state: "running",
+    });
   });
 
   it("is never stuck while the circuit breaker holds dispatch paused — recovery is the path forward", () => {
-    const held = ticket({ number: 2, assignees: ["operator"], hasAgentClaim: true });
+    const held = ticket({
+      number: 2,
+      assignees: ["operator"],
+      hasAgentClaim: true,
+    });
 
     expect(runStatus(world([held]), [], true)).toEqual({ state: "running" });
   });
@@ -131,7 +152,8 @@ function scriptedDeps(
   state.deps = {
     tick: async (dispatchPaused) => {
       const next = script.shift();
-      if (next === undefined) throw new Error("tick called past the end of the script");
+      if (next === undefined)
+        throw new Error("tick called past the end of the script");
       state.ticks += 1;
       state.pausedFlags.push(dispatchPaused);
       return { infraFailures: 0, ...next };
@@ -139,7 +161,8 @@ function scriptedDeps(
     probe: async () => {
       state.probes += 1;
       const answer = opts.probeAnswers?.shift();
-      if (answer === undefined) throw new Error("probe called past the end of the script");
+      if (answer === undefined)
+        throw new Error("probe called past the end of the script");
       return answer;
     },
     now: () => nowMs,
@@ -191,7 +214,12 @@ describe("run", () => {
       {
         world: world([
           ticket({ number: 2, title: "Walking skeleton", state: "closed" }),
-          ticket({ number: 7, title: "Hard one", state: "closed", labels: ["ready-for-human"] }),
+          ticket({
+            number: 7,
+            title: "Hard one",
+            state: "closed",
+            labels: ["ready-for-human"],
+          }),
         ]),
         actions: [],
       },
@@ -205,7 +233,9 @@ describe("run", () => {
   });
 
   it("trips the breaker on infrastructure failure, ticks paused, and resumes when the probe passes", async () => {
-    const held = world([ticket({ number: 2, assignees: ["operator"], hasAgentClaim: true })]);
+    const held = world([
+      ticket({ number: 2, assignees: ["operator"], hasAgentClaim: true }),
+    ]);
     const state = scriptedDeps(
       [
         {
@@ -233,7 +263,9 @@ describe("run", () => {
   });
 
   it("re-trips on a failed probe and waits the doubled cooldown before probing again", async () => {
-    const held = world([ticket({ number: 2, assignees: ["operator"], hasAgentClaim: true })]);
+    const held = world([
+      ticket({ number: 2, assignees: ["operator"], hasAgentClaim: true }),
+    ]);
     const state = scriptedDeps(
       [
         { world: held, actions: [], infraFailures: 1 },
@@ -256,7 +288,13 @@ describe("run", () => {
   it("exits stuck with a report naming the open tickets", async () => {
     const state = scriptedDeps([
       {
-        world: world([ticket({ number: 7, title: "Needs a human", labels: ["ready-for-human"] })]),
+        world: world([
+          ticket({
+            number: 7,
+            title: "Needs a human",
+            labels: ["ready-for-human"],
+          }),
+        ]),
         actions: [],
       },
     ]);

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,4 +1,9 @@
-import { breakerCooldownMs, probeDue, tripBreaker, type Breaker } from "./breaker.js";
+import {
+  type Breaker,
+  breakerCooldownMs,
+  probeDue,
+  tripBreaker,
+} from "./breaker.js";
 import { dispatchableSet } from "./plan.js";
 import { renderComplete, renderStuck } from "./render.js";
 import type { Action, Ticket, WorldSnapshot } from "./types.js";
@@ -41,7 +46,9 @@ export function runStatus(
   const open = world.tickets.filter((ticket) => ticket.state === "open");
   if (open.length === 0) return { state: "complete" };
   const inScope = new Set(world.tickets.map((ticket) => ticket.number));
-  const openScopePrs = world.openAgentPrs.filter((pr) => inScope.has(pr.ticket));
+  const openScopePrs = world.openAgentPrs.filter((pr) =>
+    inScope.has(pr.ticket),
+  );
   if (
     actions.length === 0 &&
     openScopePrs.length === 0 &&
@@ -57,9 +64,11 @@ export type RunOutcome = "complete" | "stuck";
 
 /** The loop's effects, injectable for tests; `tick` is one full observe → plan → act pass. */
 export interface RunDeps {
-  tick: (
-    dispatchPaused: boolean,
-  ) => Promise<{ world: WorldSnapshot; actions: Action[]; infraFailures: number }>;
+  tick: (dispatchPaused: boolean) => Promise<{
+    world: WorldSnapshot;
+    actions: Action[];
+    infraFailures: number;
+  }>;
   /** The circuit breaker's recovery probe: true when the environment answers. */
   probe: () => Promise<boolean>;
   now: () => number;
@@ -67,13 +76,18 @@ export interface RunDeps {
   log: (line: string) => void;
 }
 
-export async function run(pollSeconds: number, deps: RunDeps): Promise<RunOutcome> {
+export async function run(
+  pollSeconds: number,
+  deps: RunDeps,
+): Promise<RunOutcome> {
   let breaker: Breaker;
   for (;;) {
     if (breaker !== undefined && probeDue(breaker, deps.now())) {
       if (await deps.probe()) {
         breaker = undefined;
-        deps.log("circuit breaker closed: the environment recovered — dispatch resumes.");
+        deps.log(
+          "circuit breaker closed: the environment recovered — dispatch resumes.",
+        );
       } else {
         breaker = tripBreaker(breaker, deps.now());
         deps.log(
@@ -81,7 +95,9 @@ export async function run(pollSeconds: number, deps: RunDeps): Promise<RunOutcom
         );
       }
     }
-    const { world, actions, infraFailures } = await deps.tick(breaker !== undefined);
+    const { world, actions, infraFailures } = await deps.tick(
+      breaker !== undefined,
+    );
     if (infraFailures > 0) {
       breaker = tripBreaker(breaker, deps.now());
       deps.log(

--- a/src/tracker.test.ts
+++ b/src/tracker.test.ts
@@ -4,6 +4,7 @@ import {
   closeTicket,
   commentConflictUnresolved,
   createDraftPr,
+  type Exec,
   escalateTicket,
   markPrReady,
   readScope,
@@ -11,15 +12,14 @@ import {
   releaseTicket,
   updatePrBranch,
   voidAttempt,
-  type Exec,
 } from "./tracker.js";
 import {
+  type AttemptFailure,
   attemptMarker,
   CLAIM_MARKER,
   CONFLICT_UNRESOLVED_MARKER,
   RELEASE_MARKER,
   VOID_MARKER,
-  type AttemptFailure,
 } from "./types.js";
 
 const FAILURE: AttemptFailure = {
@@ -56,7 +56,10 @@ const prItem = (overrides: Record<string, unknown> = {}) => ({
  * un-mapped gh api endpoint throws, so a test also asserts which reads do NOT
  * happen.
  */
-function fakeExec(opts: { api?: Record<string, unknown>; prList?: unknown[] }): {
+function fakeExec(opts: {
+  api?: Record<string, unknown>;
+  prList?: unknown[];
+}): {
   exec: Exec;
   calls: string[][];
 } {
@@ -83,27 +86,46 @@ function fakeExec(opts: { api?: Record<string, unknown>; prList?: unknown[] }): 
 }
 
 const SUB_ISSUES = "repos/{owner}/{repo}/issues/1/sub_issues?per_page=100";
-const ALL_ISSUES = "repos/{owner}/{repo}/issues?labels=ready-for-agent&state=open&per_page=100";
-const comments = (n: number) => `repos/{owner}/{repo}/issues/${n}/comments?per_page=100`;
+const ALL_ISSUES =
+  "repos/{owner}/{repo}/issues?labels=ready-for-agent&state=open&per_page=100";
+const comments = (n: number) =>
+  `repos/{owner}/{repo}/issues/${n}/comments?per_page=100`;
 const blockedBy = (n: number) =>
   `repos/{owner}/{repo}/issues/${n}/dependencies/blocked_by?per_page=100`;
 const CLOSED_PULLS = "repos/{owner}/{repo}/pulls?state=closed&per_page=100";
-const compare = (base: string, head: string) => `repos/{owner}/{repo}/compare/${base}...${head}`;
+const compare = (base: string, head: string) =>
+  `repos/{owner}/{repo}/compare/${base}...${head}`;
 
 /** The gh operation a recorded call performed, for asserting read order. */
-const op = (call: string[]) => (call[1] === "pr" && call[2] === "list" ? "pr-list" : call[2]);
+const op = (call: string[]) =>
+  call[1] === "pr" && call[2] === "list" ? "pr-list" : call[2];
 
 describe("readScope", () => {
   it("reads a parent's sub-issues, then comments, then the open and closed PR listings", async () => {
     const { exec, calls } = fakeExec({
-      api: { [SUB_ISSUES]: [[issue({})]], [comments(2)]: [[]], [CLOSED_PULLS]: [[]] },
+      api: {
+        [SUB_ISSUES]: [[issue({})]],
+        [comments(2)]: [[]],
+        [CLOSED_PULLS]: [[]],
+      },
       prList: [],
     });
 
     await readScope({ kind: "parent", parent: 1 }, exec);
 
-    expect(calls.map(op)).toEqual([SUB_ISSUES, comments(2), "pr-list", CLOSED_PULLS]);
-    expect(calls[0]).toEqual(["gh", "api", SUB_ISSUES, "--paginate", "--slurp"]);
+    expect(calls.map(op)).toEqual([
+      SUB_ISSUES,
+      comments(2),
+      "pr-list",
+      CLOSED_PULLS,
+    ]);
+    expect(calls[0]).toEqual([
+      "gh",
+      "api",
+      SUB_ISSUES,
+      "--paginate",
+      "--slurp",
+    ]);
     expect(calls.find((c) => c[1] === "pr")).toEqual([
       "gh",
       "pr",
@@ -119,13 +141,22 @@ describe("readScope", () => {
 
   it("reads repo-wide agent-ready issues when scope is all", async () => {
     const { exec, calls } = fakeExec({
-      api: { [ALL_ISSUES]: [[issue({})]], [comments(2)]: [[]], [CLOSED_PULLS]: [[]] },
+      api: {
+        [ALL_ISSUES]: [[issue({})]],
+        [comments(2)]: [[]],
+        [CLOSED_PULLS]: [[]],
+      },
       prList: [],
     });
 
     await readScope({ kind: "all" }, exec);
 
-    expect(calls.map(op)).toEqual([ALL_ISSUES, comments(2), "pr-list", CLOSED_PULLS]);
+    expect(calls.map(op)).toEqual([
+      ALL_ISSUES,
+      comments(2),
+      "pr-list",
+      CLOSED_PULLS,
+    ]);
   });
 
   it("skips both PR reads when no ticket in Scope is open", async () => {
@@ -194,7 +225,12 @@ describe("readScope", () => {
   it("drops pull requests from a repo-wide listing", async () => {
     const { exec } = fakeExec({
       api: {
-        [ALL_ISSUES]: [[issue({ number: 5 }), issue({ number: 6, pull_request: { url: "x" } })]],
+        [ALL_ISSUES]: [
+          [
+            issue({ number: 5 }),
+            issue({ number: 6, pull_request: { url: "x" } }),
+          ],
+        ],
         [comments(5)]: [[]],
         [CLOSED_PULLS]: [[]],
       },
@@ -209,7 +245,9 @@ describe("readScope", () => {
   it("treats a missing dependency summary as zero open blockers", async () => {
     const { exec } = fakeExec({
       api: {
-        [SUB_ISSUES]: [[issue({ number: 7, issue_dependencies_summary: undefined })]],
+        [SUB_ISSUES]: [
+          [issue({ number: 7, issue_dependencies_summary: undefined })],
+        ],
         [comments(7)]: [[]],
         [CLOSED_PULLS]: [[]],
       },
@@ -225,9 +263,14 @@ describe("readScope", () => {
     const { exec, calls } = fakeExec({
       api: {
         [SUB_ISSUES]: [
-          [issue({ number: 5, assignees: [{ login: "operator" }] }), issue({ number: 6 })],
+          [
+            issue({ number: 5, assignees: [{ login: "operator" }] }),
+            issue({ number: 6 }),
+          ],
         ],
-        [comments(5)]: [[{ body: "human chatter" }, { body: `${CLAIM_MARKER}\n🐕 claimed` }]],
+        [comments(5)]: [
+          [{ body: "human chatter" }, { body: `${CLAIM_MARKER}\n🐕 claimed` }],
+        ],
         [comments(6)]: [[]],
         [CLOSED_PULLS]: [[]],
       },
@@ -262,14 +305,21 @@ describe("readScope", () => {
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
 
-    expect(calls.map(op)).toEqual([SUB_ISSUES, blockedBy(4), "pr-list", CLOSED_PULLS]);
+    expect(calls.map(op)).toEqual([
+      SUB_ISSUES,
+      blockedBy(4),
+      "pr-list",
+      CLOSED_PULLS,
+    ]);
     expect(world.tickets.map((t) => t.agentClaimCount)).toEqual([0, 0, 0]);
   });
 
   it("names the open blockers of an open blocked ticket, dropping closed ones", async () => {
     const { exec } = fakeExec({
       api: {
-        [SUB_ISSUES]: [[issue({ number: 4, issue_dependencies_summary: { blocked_by: 2 } })]],
+        [SUB_ISSUES]: [
+          [issue({ number: 4, issue_dependencies_summary: { blocked_by: 2 } })],
+        ],
         [blockedBy(4)]: [
           [
             { number: 2, state: "open" },
@@ -292,7 +342,11 @@ describe("readScope", () => {
       api: {
         [SUB_ISSUES]: [
           [
-            issue({ number: 3, state: "closed", issue_dependencies_summary: { blocked_by: 2 } }),
+            issue({
+              number: 3,
+              state: "closed",
+              issue_dependencies_summary: { blocked_by: 2 },
+            }),
             issue({ number: 4 }),
           ],
         ],
@@ -305,7 +359,12 @@ describe("readScope", () => {
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
 
-    expect(calls.map(op)).toEqual([SUB_ISSUES, comments(4), "pr-list", CLOSED_PULLS]);
+    expect(calls.map(op)).toEqual([
+      SUB_ISSUES,
+      comments(4),
+      "pr-list",
+      CLOSED_PULLS,
+    ]);
     expect(world.tickets.map((t) => t.blockedBy)).toEqual([[], []]);
   });
 
@@ -316,7 +375,9 @@ describe("readScope", () => {
         [comments(5)]: [
           [
             { body: `${CLAIM_MARKER}\n🐕 claimed` },
-            { body: `${RELEASE_MARKER}\n${attemptMarker(FAILURE)}\n🐕 Attempt 1 failed` },
+            {
+              body: `${RELEASE_MARKER}\n${attemptMarker(FAILURE)}\n🐕 Attempt 1 failed`,
+            },
             { body: `${CLAIM_MARKER}\n🐕 claimed again` },
             {
               body: `${RELEASE_MARKER}\n${attemptMarker({ ...FAILURE, attempt: 2, model: "opus" })}\n🐕 Attempt 2 failed`,
@@ -340,11 +401,15 @@ describe("readScope", () => {
   it("uncounts a voided claim while keeping it agent-held (infrastructure failures burn nothing)", async () => {
     const { exec } = fakeExec({
       api: {
-        [SUB_ISSUES]: [[issue({ number: 5, assignees: [{ login: "operator" }] })]],
+        [SUB_ISSUES]: [
+          [issue({ number: 5, assignees: [{ login: "operator" }] })],
+        ],
         [comments(5)]: [
           [
             { body: `${CLAIM_MARKER}\n🐕 claimed` },
-            { body: `${VOID_MARKER}\n🐕 Attempt 1 voided: the account usage limit was reached` },
+            {
+              body: `${VOID_MARKER}\n🐕 Attempt 1 voided: the account usage limit was reached`,
+            },
           ],
         ],
         [CLOSED_PULLS]: [[]],
@@ -369,7 +434,9 @@ describe("readScope", () => {
           [
             { body: `${CLAIM_MARKER}\n🐕 claimed` },
             { body: `${VOID_MARKER}\n🐕 Attempt 1 voided` },
-            { body: `${RELEASE_MARKER}\n🐕 released (orphaned after the outage)` },
+            {
+              body: `${RELEASE_MARKER}\n🐕 released (orphaned after the outage)`,
+            },
             { body: `${CLAIM_MARKER}\n🐕 claimed again` },
           ],
         ],
@@ -380,12 +447,19 @@ describe("readScope", () => {
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
 
-    expect(world.tickets[0]).toMatchObject({ hasAgentClaim: true, agentClaimCount: 1 });
+    expect(world.tickets[0]).toMatchObject({
+      hasAgentClaim: true,
+      agentClaimCount: 1,
+    });
   });
 
   it("maps open agent-branch PRs with their upkeep signals, ignoring other branches", async () => {
     const { exec } = fakeExec({
-      api: { [SUB_ISSUES]: [[issue({ number: 5 })]], [comments(5)]: [[]], [CLOSED_PULLS]: [[]] },
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [[]],
+        [CLOSED_PULLS]: [[]],
+      },
       prList: [
         prItem({ number: 50, headRefName: "border-collie/ticket-5-attempt-1" }),
         prItem({ number: 99, headRefName: "feature/unrelated" }),
@@ -462,7 +536,9 @@ describe("readScope", () => {
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
 
     expect(world.openAgentPrs.map((pr) => pr.behind)).toEqual([false, false]);
-    expect(calls.some((c) => c[2]?.startsWith("repos/{owner}/{repo}/compare/"))).toBe(false);
+    expect(
+      calls.some((c) => c[2]?.startsWith("repos/{owner}/{repo}/compare/")),
+    ).toBe(false);
   });
 
   it("reads a conflicted PR's comments for the unresolved marker, and skips that read otherwise", async () => {
@@ -471,7 +547,9 @@ describe("readScope", () => {
         [SUB_ISSUES]: [[issue({ number: 5 })]],
         [comments(5)]: [[]],
         // Comments for the conflicted PR #50 carry the unresolved marker.
-        [comments(50)]: [[{ body: `${CONFLICT_UNRESOLVED_MARKER}\n🐕 human, please` }]],
+        [comments(50)]: [
+          [{ body: `${CONFLICT_UNRESOLVED_MARKER}\n🐕 human, please` }],
+        ],
         [CLOSED_PULLS]: [[]],
       },
       prList: [
@@ -543,7 +621,11 @@ describe("readScope", () => {
 
   it("treats an UNKNOWN mergeability as unknown (GitHub still computing)", async () => {
     const { exec } = fakeExec({
-      api: { [SUB_ISSUES]: [[issue({ number: 5 })]], [comments(5)]: [[]], [CLOSED_PULLS]: [[]] },
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [[]],
+        [CLOSED_PULLS]: [[]],
+      },
       prList: [prItem({ number: 50, mergeable: "UNKNOWN" })],
     });
 
@@ -584,7 +666,9 @@ describe("readScope", () => {
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
 
-    expect(world.mergedAgentPrs).toEqual([{ ticket: 5, url: "https://github.com/o/r/pull/50" }]);
+    expect(world.mergedAgentPrs).toEqual([
+      { ticket: 5, url: "https://github.com/o/r/pull/50" },
+    ]);
   });
 
   it("keeps one merged PR per ticket: the first in the newest-created-first listing", async () => {
@@ -612,7 +696,9 @@ describe("readScope", () => {
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
 
-    expect(world.mergedAgentPrs).toEqual([{ ticket: 5, url: "https://github.com/o/r/pull/52" }]);
+    expect(world.mergedAgentPrs).toEqual([
+      { ticket: 5, url: "https://github.com/o/r/pull/52" },
+    ]);
   });
 });
 
@@ -634,7 +720,14 @@ describe("claimTicket", () => {
 
     expect(calls).toEqual([
       ["gh", "issue", "edit", "5", "--add-assignee", "@me"],
-      ["gh", "issue", "comment", "5", "--body", expect.stringContaining(CLAIM_MARKER)],
+      [
+        "gh",
+        "issue",
+        "comment",
+        "5",
+        "--body",
+        expect.stringContaining(CLAIM_MARKER),
+      ],
     ]);
   });
 });
@@ -647,7 +740,14 @@ describe("releaseTicket", () => {
 
     expect(calls).toEqual([
       ["gh", "issue", "edit", "5", "--remove-assignee", "operator,other"],
-      ["gh", "issue", "comment", "5", "--body", expect.stringContaining(RELEASE_MARKER)],
+      [
+        "gh",
+        "issue",
+        "comment",
+        "5",
+        "--body",
+        expect.stringContaining(RELEASE_MARKER),
+      ],
     ]);
   });
 });
@@ -680,7 +780,11 @@ describe("createDraftPr", () => {
     };
 
     const url = await createDraftPr(
-      { head: "border-collie/ticket-5", title: "PR opening", body: "A body.\n\nCloses #5" },
+      {
+        head: "border-collie/ticket-5",
+        title: "PR opening",
+        body: "A body.\n\nCloses #5",
+      },
       exec,
     );
 
@@ -710,7 +814,14 @@ describe("releaseFailedTicket", () => {
 
     expect(calls).toEqual([
       ["gh", "issue", "edit", "5", "--remove-assignee", "@me"],
-      ["gh", "issue", "comment", "5", "--body", expect.stringContaining(RELEASE_MARKER)],
+      [
+        "gh",
+        "issue",
+        "comment",
+        "5",
+        "--body",
+        expect.stringContaining(RELEASE_MARKER),
+      ],
     ]);
     const body = calls[1]?.[5] ?? "";
     expect(body).toContain(attemptMarker(FAILURE));
@@ -735,13 +846,22 @@ describe("voidAttempt", () => {
     );
 
     expect(calls).toEqual([
-      ["gh", "issue", "comment", "5", "--body", expect.stringContaining(VOID_MARKER)],
+      [
+        "gh",
+        "issue",
+        "comment",
+        "5",
+        "--body",
+        expect.stringContaining(VOID_MARKER),
+      ],
     ]);
     const body = calls[0]?.[5] ?? "";
     expect(body).not.toContain(RELEASE_MARKER);
     expect(body).toContain("usage limit");
     expect(body).toContain("burns nothing");
-    expect(body).toContain(".border-collie/transcripts/ticket-5-attempt-1.jsonl");
+    expect(body).toContain(
+      ".border-collie/transcripts/ticket-5-attempt-1.jsonl",
+    );
   });
 });
 
@@ -759,7 +879,14 @@ describe("escalateTicket", () => {
     await escalateTicket(5, [FAILURE, second], exec);
 
     expect(calls).toEqual([
-      ["gh", "issue", "comment", "5", "--body", expect.stringContaining("Escalated")],
+      [
+        "gh",
+        "issue",
+        "comment",
+        "5",
+        "--body",
+        expect.stringContaining("Escalated"),
+      ],
       [
         "gh",
         "issue",
@@ -797,9 +924,7 @@ describe("updatePrBranch", () => {
 
     await updatePrBranch(30, exec);
 
-    expect(calls).toEqual([
-      ["gh", "pr", "update-branch", "30", "--rebase"],
-    ]);
+    expect(calls).toEqual([["gh", "pr", "update-branch", "30", "--rebase"]]);
   });
 });
 
@@ -820,7 +945,14 @@ describe("commentConflictUnresolved", () => {
     await commentConflictUnresolved(30, exec);
 
     expect(calls).toEqual([
-      ["gh", "pr", "comment", "30", "--body", expect.stringContaining(CONFLICT_UNRESOLVED_MARKER)],
+      [
+        "gh",
+        "pr",
+        "comment",
+        "30",
+        "--body",
+        expect.stringContaining(CONFLICT_UNRESOLVED_MARKER),
+      ],
     ]);
   });
 });

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -1,28 +1,28 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import type { Scope } from "./config.js";
 import {
+  type AttemptFailure,
   attemptMarker,
+  type CiState,
   CLAIM_MARKER,
   CONFLICT_UNRESOLVED_MARKER,
   FAILURE_DESCRIPTIONS,
   INFRA_DESCRIPTIONS,
+  type InfraReason,
   MAX_ATTEMPTS,
+  type Mergeability,
+  type MergedAgentPr,
+  type OpenAgentPr,
   parseAttemptMarker,
   READY_FOR_AGENT,
   READY_FOR_HUMAN,
   RELEASE_MARKER,
+  type Ticket,
   ticketFromAgentBranch,
   VOID_MARKER,
-  type AttemptFailure,
-  type CiState,
-  type InfraReason,
-  type Mergeability,
-  type MergedAgentPr,
-  type OpenAgentPr,
-  type Ticket,
   type WorldSnapshot,
 } from "./types.js";
-import type { Scope } from "./config.js";
 
 /**
  * The Tracker seam (ADR 0002): every tracker operation lives here, with the
@@ -89,12 +89,19 @@ interface ClaimHistory {
  * failed attempts' forensic records. All append-only, so history stays
  * auditable and attempt state needs no local store.
  */
-async function readClaimHistory(ticket: number, exec: Exec): Promise<ClaimHistory> {
+async function readClaimHistory(
+  ticket: number,
+  exec: Exec,
+): Promise<ClaimHistory> {
   const comments = await readPages<{ body?: string }>(
     `repos/{owner}/{repo}/issues/${ticket}/comments?per_page=100`,
     exec,
   );
-  const history: ClaimHistory = { hasAgentClaim: false, agentClaimCount: 0, attemptFailures: [] };
+  const history: ClaimHistory = {
+    hasAgentClaim: false,
+    agentClaimCount: 0,
+    attemptFailures: [],
+  };
   for (const comment of comments) {
     if (comment.body?.includes(CLAIM_MARKER)) {
       history.hasAgentClaim = true;
@@ -155,8 +162,15 @@ function mergeabilityOf(raw: string | undefined): Mergeability {
  * branch protection is on — otherwise a stale-but-clean PR reads CLEAN. The
  * compare is reliable under every configuration.
  */
-async function prBehindBase(base: string, head: string, exec: Exec): Promise<boolean> {
-  const stdout = await exec("gh", ["api", `repos/{owner}/{repo}/compare/${base}...${head}`]);
+async function prBehindBase(
+  base: string,
+  head: string,
+  exec: Exec,
+): Promise<boolean> {
+  const stdout = await exec("gh", [
+    "api",
+    `repos/{owner}/{repo}/compare/${base}...${head}`,
+  ]);
   const comparison = JSON.parse(stdout) as { behind_by?: number };
   return (comparison.behind_by ?? 0) > 0;
 }
@@ -178,7 +192,11 @@ function ciFromRollup(rollup: RollupCheck[]): CiState {
         pending = true;
         continue;
       }
-      if (check.conclusion === "SUCCESS" || check.conclusion === "NEUTRAL" || check.conclusion === "SKIPPED") {
+      if (
+        check.conclusion === "SUCCESS" ||
+        check.conclusion === "NEUTRAL" ||
+        check.conclusion === "SKIPPED"
+      ) {
         continue;
       }
       return "failing";
@@ -198,12 +216,17 @@ function ciFromRollup(rollup: RollupCheck[]): CiState {
  * PR — the unresolved marker sits in its comment thread. Read only for
  * conflicted PRs, where it alone decides whether another Worker is dispatched.
  */
-async function readConflictWorkerAsked(pr: number, exec: Exec): Promise<boolean> {
+async function readConflictWorkerAsked(
+  pr: number,
+  exec: Exec,
+): Promise<boolean> {
   const comments = await readPages<{ body?: string }>(
     `repos/{owner}/{repo}/issues/${pr}/comments?per_page=100`,
     exec,
   );
-  return comments.some((comment) => comment.body?.includes(CONFLICT_UNRESOLVED_MARKER));
+  return comments.some((comment) =>
+    comment.body?.includes(CONFLICT_UNRESOLVED_MARKER),
+  );
 }
 
 /**
@@ -239,10 +262,15 @@ async function listOpenAgentPrs(exec: Exec): Promise<OpenAgentPr[]> {
       headRef,
       draft: item.isDraft ?? false,
       mergeable,
-      behind: mergeable === "mergeable" && base !== "" ? await prBehindBase(base, headRef, exec) : false,
+      behind:
+        mergeable === "mergeable" && base !== ""
+          ? await prBehindBase(base, headRef, exec)
+          : false,
       ci: ciFromRollup(item.statusCheckRollup ?? []),
       conflictWorkerAsked:
-        mergeable === "conflicted" ? await readConflictWorkerAsked(item.number, exec) : false,
+        mergeable === "conflicted"
+          ? await readConflictWorkerAsked(item.number, exec)
+          : false,
     });
   }
   return prs;
@@ -276,7 +304,10 @@ async function listMergedAgentPrs(exec: Exec): Promise<MergedAgentPr[]> {
  * later); repo-wide scope lists open agent-ready issues, excluding PRs
  * (GitHub's issues listing includes them).
  */
-export async function readScope(scope: Scope, exec: Exec = realExec): Promise<WorldSnapshot> {
+export async function readScope(
+  scope: Scope,
+  exec: Exec = realExec,
+): Promise<WorldSnapshot> {
   const endpoint =
     scope.kind === "parent"
       ? `repos/{owner}/{repo}/issues/${scope.parent}/sub_issues?per_page=100`
@@ -330,9 +361,18 @@ const RELEASE_COMMENT = `${RELEASE_MARKER}\n🐕 border-collie released an orpha
  * first (the wayfinder protocol border-collie inherits); a crash in between
  * leaves the ticket looking human-claimed, which fails safe: hands off.
  */
-export async function claimTicket(ticket: number, exec: Exec = realExec): Promise<void> {
+export async function claimTicket(
+  ticket: number,
+  exec: Exec = realExec,
+): Promise<void> {
   await exec("gh", ["issue", "edit", String(ticket), "--add-assignee", "@me"]);
-  await exec("gh", ["issue", "comment", String(ticket), "--body", CLAIM_COMMENT]);
+  await exec("gh", [
+    "issue",
+    "comment",
+    String(ticket),
+    "--body",
+    CLAIM_COMMENT,
+  ]);
 }
 
 /**
@@ -341,8 +381,19 @@ export async function claimTicket(ticket: number, exec: Exec = realExec): Promis
  * afresh (self-healing). The release marker then neutralizes the claim
  * marker so a later human assignment is never misread as agent-held.
  */
-async function release(ticket: number, assignees: string, body: string, exec: Exec): Promise<void> {
-  await exec("gh", ["issue", "edit", String(ticket), "--remove-assignee", assignees]);
+async function release(
+  ticket: number,
+  assignees: string,
+  body: string,
+  exec: Exec,
+): Promise<void> {
+  await exec("gh", [
+    "issue",
+    "edit",
+    String(ticket),
+    "--remove-assignee",
+    assignees,
+  ]);
   await exec("gh", ["issue", "comment", String(ticket), "--body", body]);
 }
 
@@ -368,7 +419,13 @@ export async function closeTicket(
   prUrl: string,
   exec: Exec = realExec,
 ): Promise<void> {
-  await exec("gh", ["issue", "close", String(ticket), "--comment", closeComment(prUrl)]);
+  await exec("gh", [
+    "issue",
+    "close",
+    String(ticket),
+    "--comment",
+    closeComment(prUrl),
+  ]);
 }
 
 /**
@@ -458,7 +515,9 @@ export async function escalateTicket(
 ): Promise<void> {
   const evidence =
     failures.length === 0
-      ? ["(no attempt records found — the claims were likely released as orphans after crashes)"]
+      ? [
+          "(no attempt records found — the claims were likely released as orphans after crashes)",
+        ]
       : failures.map(
           (f) =>
             `- Attempt ${f.attempt} (${f.model}): ${FAILURE_DESCRIPTIONS[f.reason]} — transcript \`${f.transcript}\`, abandoned branch \`${f.branch}\``,
@@ -489,12 +548,18 @@ export async function escalateTicket(
  * — replaying the branch's commits drops the merge commit and its resolutions,
  * so the original commits re-conflict).
  */
-export async function updatePrBranch(pr: number, exec: Exec = realExec): Promise<void> {
+export async function updatePrBranch(
+  pr: number,
+  exec: Exec = realExec,
+): Promise<void> {
   await exec("gh", ["pr", "update-branch", String(pr), "--rebase"]);
 }
 
 /** Act phase: flip a draft PR to ready-for-review, surfacing it to the reviewer. */
-export async function markPrReady(pr: number, exec: Exec = realExec): Promise<void> {
+export async function markPrReady(
+  pr: number,
+  exec: Exec = realExec,
+): Promise<void> {
   await exec("gh", ["pr", "ready", String(pr)]);
 }
 
@@ -506,6 +571,15 @@ const CONFLICT_UNRESOLVED_COMMENT = `${CONFLICT_UNRESOLVED_MARKER}\n🐕 border-
  * a second Worker against a conflict a human now holds — the PR-level analogue
  * of Escalation's forensic comment.
  */
-export async function commentConflictUnresolved(pr: number, exec: Exec = realExec): Promise<void> {
-  await exec("gh", ["pr", "comment", String(pr), "--body", CONFLICT_UNRESOLVED_COMMENT]);
+export async function commentConflictUnresolved(
+  pr: number,
+  exec: Exec = realExec,
+): Promise<void> {
+  await exec("gh", [
+    "pr",
+    "comment",
+    String(pr),
+    "--body",
+    CONFLICT_UNRESOLVED_COMMENT,
+  ]);
 }

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  type AttemptFailure,
   attemptMarker,
   parseAttemptMarker,
   ticketFromAgentBranch,
-  type AttemptFailure,
 } from "./types.js";
 
 const FAILURE: AttemptFailure = {
@@ -26,12 +26,18 @@ describe("attemptMarker", () => {
   });
 
   it("parses nothing from a mangled marker payload", () => {
-    expect(parseAttemptMarker("<!-- border-collie:attempt not-json -->")).toBeUndefined();
+    expect(
+      parseAttemptMarker("<!-- border-collie:attempt not-json -->"),
+    ).toBeUndefined();
   });
 
   it("parses nothing from valid JSON that is not an attempt record", () => {
-    expect(parseAttemptMarker('<!-- border-collie:attempt {"attempt":1} -->')).toBeUndefined();
-    expect(parseAttemptMarker("<!-- border-collie:attempt null -->")).toBeUndefined();
+    expect(
+      parseAttemptMarker('<!-- border-collie:attempt {"attempt":1} -->'),
+    ).toBeUndefined();
+    expect(
+      parseAttemptMarker("<!-- border-collie:attempt null -->"),
+    ).toBeUndefined();
     expect(
       parseAttemptMarker(
         `<!-- border-collie:attempt ${JSON.stringify({ ...FAILURE, reason: "made-up" })} -->`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,14 +21,20 @@ export const RELEASE_MARKER = "<!-- border-collie:release -->";
  * The ticket-failure triggers (CONTEXT.md "Ticket failure"): every way a
  * Worker can die that counts against the ticket's Attempts.
  */
-export type FailureReason = "nonzero-exit" | "no-commits" | "timeout" | "stall" | "budget";
+export type FailureReason =
+  | "nonzero-exit"
+  | "no-commits"
+  | "timeout"
+  | "stall"
+  | "budget";
 
 export const FAILURE_DESCRIPTIONS: Record<FailureReason, string> = {
   "nonzero-exit": "the Worker process exited non-zero",
   "no-commits": "the Worker exited cleanly but committed nothing",
   timeout: "the Worker hit the wall-clock timeout",
   stall: "the Worker produced no output events for the stall window",
-  budget: "the Worker hit the turn-cap budget backstop and was halted mid-flight",
+  budget:
+    "the Worker hit the turn-cap budget backstop and was halted mid-flight",
 };
 
 /**
@@ -38,7 +44,12 @@ export const FAILURE_DESCRIPTIONS: Record<FailureReason, string> = {
  * heuristic: several Workers dying identically is an environment problem,
  * not a coincidence of tickets.
  */
-export type InfraReason = "usage-limit" | "rate-limit" | "auth" | "network" | "correlated";
+export type InfraReason =
+  | "usage-limit"
+  | "rate-limit"
+  | "auth"
+  | "network"
+  | "correlated";
 
 export const INFRA_DESCRIPTIONS: Record<InfraReason, string> = {
   "usage-limit": "the account usage limit was reached",
@@ -123,7 +134,8 @@ export function parseAttemptMarker(body: string): AttemptFailure | undefined {
  * (ADR 0001) — bounded because a session that actually ran and failed always
  * lays the marker down.
  */
-export const CONFLICT_UNRESOLVED_MARKER = "<!-- border-collie:conflict-unresolved -->";
+export const CONFLICT_UNRESOLVED_MARKER =
+  "<!-- border-collie:conflict-unresolved -->";
 
 /**
  * Branch naming that makes a PR structurally an agent PR. Workers land with

--- a/src/worker.test.ts
+++ b/src/worker.test.ts
@@ -5,18 +5,18 @@ import { describe, expect, it } from "vitest";
 import type { Exec } from "./tracker.js";
 import {
   branchCommitSubjects,
+  type ConflictWorkerConfig,
   conflictWorkerPrompt,
   dispatchConflictWorker,
   dispatchWorker,
   probeEnvironment,
   pushAgentBranch,
   realSpawnWorkerProcess,
-  workerPrompt,
-  type ConflictWorkerConfig,
   type SpawnWorkerProcess,
   type WorkerConfig,
   type WorkerProcessExit,
   type WorkerProcessRequest,
+  workerPrompt,
 } from "./worker.js";
 
 const WORKTREE = ".border-collie/worktrees/ticket-4";
@@ -143,7 +143,13 @@ describe("dispatchWorker", () => {
     ]);
 
     const setupBlock = (ticket: number) => [
-      ["git", "worktree", "remove", "--force", `.border-collie/worktrees/ticket-${ticket}`],
+      [
+        "git",
+        "worktree",
+        "remove",
+        "--force",
+        `.border-collie/worktrees/ticket-${ticket}`,
+      ],
       ["git", "worktree", "prune"],
       ["git", "fetch", "origin"],
       [
@@ -191,7 +197,12 @@ describe("dispatchWorker", () => {
 
     const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
 
-    expect(outcome).toMatchObject({ ok: false, exitCode: 0, newCommits: 0, failure: "no-commits" });
+    expect(outcome).toMatchObject({
+      ok: false,
+      exitCode: 0,
+      newCommits: 0,
+      failure: "no-commits",
+    });
   });
 
   it("fails the attempt on a non-zero exit even when commits exist", async () => {
@@ -200,7 +211,12 @@ describe("dispatchWorker", () => {
 
     const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
 
-    expect(outcome).toMatchObject({ ok: false, exitCode: 1, newCommits: 2, failure: "nonzero-exit" });
+    expect(outcome).toMatchObject({
+      ok: false,
+      exitCode: 1,
+      newCommits: 2,
+      failure: "nonzero-exit",
+    });
   });
 
   it("fails the attempt as a timeout when the process was killed at the wall clock, even with commits", async () => {
@@ -209,7 +225,11 @@ describe("dispatchWorker", () => {
 
     const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
 
-    expect(outcome).toMatchObject({ ok: false, newCommits: 2, failure: "timeout" });
+    expect(outcome).toMatchObject({
+      ok: false,
+      newCommits: 2,
+      failure: "timeout",
+    });
   });
 
   it("fails the attempt as a stall when the process went quiet past the stall window", async () => {
@@ -234,9 +254,17 @@ describe("dispatchWorker", () => {
     const { exec, calls } = fakeExec();
     const { spawn } = fakeSpawn(new Error("spawn claude ENOENT"));
 
-    await expect(dispatchWorker(4, CONFIG, exec, spawn)).rejects.toThrow("ENOENT");
+    await expect(dispatchWorker(4, CONFIG, exec, spawn)).rejects.toThrow(
+      "ENOENT",
+    );
 
-    expect(calls.at(-1)).toEqual(["git", "worktree", "remove", "--force", WORKTREE]);
+    expect(calls.at(-1)).toEqual([
+      "git",
+      "worktree",
+      "remove",
+      "--force",
+      WORKTREE,
+    ]);
   });
 
   it("runs the configured model", async () => {
@@ -251,7 +279,8 @@ describe("dispatchWorker", () => {
   it("fails the attempt as a budget breach when the Worker hit the turn cap", async () => {
     const { exec } = fakeExec({ newCommits: "2" });
     const { spawn } = fakeSpawn(1, "exit", {
-      stdoutTail: '{"type":"result","subtype":"error_max_turns","total_cost_usd":3.2,"num_turns":200}',
+      stdoutTail:
+        '{"type":"result","subtype":"error_max_turns","total_cost_usd":3.2,"num_turns":200}',
     });
 
     const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
@@ -268,7 +297,8 @@ describe("dispatchWorker", () => {
   it("keeps a finished attempt that spent past the cost cap, flagging the overrun instead of failing", async () => {
     const { exec } = fakeExec({ newCommits: "3" });
     const { spawn } = fakeSpawn(0, "exit", {
-      stdoutTail: '{"type":"result","subtype":"success","total_cost_usd":25.5,"num_turns":80}',
+      stdoutTail:
+        '{"type":"result","subtype":"success","total_cost_usd":25.5,"num_turns":80}',
     });
 
     const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
@@ -284,23 +314,34 @@ describe("dispatchWorker", () => {
   it("keeps the underlying failure reason when a failed attempt also overran the cost cap", async () => {
     const { exec } = fakeExec({ newCommits: "0" });
     const { spawn } = fakeSpawn(1, "exit", {
-      stdoutTail: '{"type":"result","subtype":"error_during_execution","total_cost_usd":25.5,"num_turns":80}',
+      stdoutTail:
+        '{"type":"result","subtype":"error_during_execution","total_cost_usd":25.5,"num_turns":80}',
     });
 
     const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
 
-    expect(outcome).toMatchObject({ ok: false, failure: "nonzero-exit", costOverrun: true });
+    expect(outcome).toMatchObject({
+      ok: false,
+      failure: "nonzero-exit",
+      costOverrun: true,
+    });
   });
 
   it("succeeds under the cost cap, reporting the spend and turns", async () => {
     const { exec } = fakeExec({ newCommits: "3" });
     const { spawn } = fakeSpawn(0, "exit", {
-      stdoutTail: '{"type":"result","subtype":"success","total_cost_usd":4.1,"num_turns":52}',
+      stdoutTail:
+        '{"type":"result","subtype":"success","total_cost_usd":4.1,"num_turns":52}',
     });
 
     const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
 
-    expect(outcome).toMatchObject({ ok: true, failure: undefined, costUsd: 4.1, turns: 52 });
+    expect(outcome).toMatchObject({
+      ok: true,
+      failure: undefined,
+      costUsd: 4.1,
+      turns: 52,
+    });
   });
 
   it("classifies a failed Worker with a rate-limit signature as an infrastructure failure", async () => {
@@ -311,18 +352,27 @@ describe("dispatchWorker", () => {
 
     const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
 
-    expect(outcome).toMatchObject({ ok: false, failure: undefined, infra: "rate-limit" });
+    expect(outcome).toMatchObject({
+      ok: false,
+      failure: undefined,
+      infra: "rate-limit",
+    });
   });
 
   it("classifies a stalled Worker with a network signature as infrastructure, not a stall", async () => {
     const { exec } = fakeExec({ newCommits: "0" });
     const { spawn } = fakeSpawn(null, "stall", {
-      stderrTail: "TypeError: fetch failed\n  cause: Error: getaddrinfo ENOTFOUND api.anthropic.com",
+      stderrTail:
+        "TypeError: fetch failed\n  cause: Error: getaddrinfo ENOTFOUND api.anthropic.com",
     });
 
     const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
 
-    expect(outcome).toMatchObject({ ok: false, failure: undefined, infra: "network" });
+    expect(outcome).toMatchObject({
+      ok: false,
+      failure: undefined,
+      infra: "network",
+    });
   });
 
   it("never voids on infra-looking text in the transcript body: classification is by cause, not content", async () => {
@@ -338,41 +388,62 @@ describe("dispatchWorker", () => {
 
     const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
 
-    expect(outcome).toMatchObject({ ok: false, failure: "nonzero-exit", infra: undefined });
+    expect(outcome).toMatchObject({
+      ok: false,
+      failure: "nonzero-exit",
+      infra: undefined,
+    });
   });
 
   it("lets a budget breach trump an infra signature: the result event proves the environment was up", async () => {
     const { exec } = fakeExec({ newCommits: "2" });
     const { spawn } = fakeSpawn(1, "exit", {
-      stdoutTail: '{"type":"result","subtype":"error_max_turns","total_cost_usd":9,"num_turns":200}',
+      stdoutTail:
+        '{"type":"result","subtype":"error_max_turns","total_cost_usd":9,"num_turns":200}',
       stderrTail: "retrying after rate_limit_error",
     });
 
     const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
 
-    expect(outcome).toMatchObject({ ok: false, failure: "budget", infra: undefined });
+    expect(outcome).toMatchObject({
+      ok: false,
+      failure: "budget",
+      infra: undefined,
+    });
   });
 
   it("never voids a successful Worker, whatever transient noise its logs carry", async () => {
     const { exec } = fakeExec({ newCommits: "2" });
     const { spawn } = fakeSpawn(0, "exit", {
-      stdoutTail: '{"type":"result","subtype":"success","total_cost_usd":2,"num_turns":30}',
+      stdoutTail:
+        '{"type":"result","subtype":"success","total_cost_usd":2,"num_turns":30}',
       stderrTail: "retrying after ECONNRESET",
     });
 
     const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
 
-    expect(outcome).toMatchObject({ ok: true, failure: undefined, infra: undefined });
+    expect(outcome).toMatchObject({
+      ok: true,
+      failure: undefined,
+      infra: undefined,
+    });
   });
 
   it("namespaces branch and transcript per attempt, so a retry never clobbers prior evidence", async () => {
     const { exec } = fakeExec({ newCommits: "0" });
     const { spawn } = fakeSpawn(1);
 
-    const outcome = await dispatchWorker(7, { ...CONFIG, attempt: 2 }, exec, spawn);
+    const outcome = await dispatchWorker(
+      7,
+      { ...CONFIG, attempt: 2 },
+      exec,
+      spawn,
+    );
 
     expect(outcome.branch).toBe("border-collie/ticket-7-attempt-2");
-    expect(outcome.transcript).toBe(".border-collie/transcripts/ticket-7-attempt-2.jsonl");
+    expect(outcome.transcript).toBe(
+      ".border-collie/transcripts/ticket-7-attempt-2.jsonl",
+    );
   });
 });
 
@@ -392,7 +463,9 @@ describe("probeEnvironment", () => {
   });
 
   it("answers false on a clean exit that still carries an infrastructure signature", async () => {
-    const { spawn } = fakeSpawn(0, "exit", { stdoutTail: "Claude AI usage limit reached|123" });
+    const { spawn } = fakeSpawn(0, "exit", {
+      stdoutTail: "Claude AI usage limit reached|123",
+    });
 
     await expect(probeEnvironment("sonnet", spawn)).resolves.toBe(false);
   });
@@ -430,7 +503,10 @@ const CONFLICT_CONFIG: ConflictWorkerConfig = {
  * otherwise — git's exit-1 for "not an ancestor", which the code reads as an
  * incomplete or never-started rebase.
  */
-function fakeConflictExec(opts: { rebased?: boolean } = {}): { exec: Exec; calls: string[][] } {
+function fakeConflictExec(opts: { rebased?: boolean } = {}): {
+  exec: Exec;
+  calls: string[][];
+} {
   const calls: string[][] = [];
   const exec: Exec = async (cmd, args) => {
     calls.push([cmd, ...args]);
@@ -463,9 +539,25 @@ describe("dispatchConflictWorker", () => {
       ["git", "worktree", "remove", "--force", CONFLICT_WT],
       ["git", "worktree", "prune"],
       ["git", "fetch", "origin"],
-      ["git", "worktree", "add", CONFLICT_WT, "-B", HEAD_REF, `origin/${HEAD_REF}`],
+      [
+        "git",
+        "worktree",
+        "add",
+        CONFLICT_WT,
+        "-B",
+        HEAD_REF,
+        `origin/${HEAD_REF}`,
+      ],
       ["git", "-C", CONFLICT_WT, "rebase", "origin/HEAD"],
-      ["git", "-C", CONFLICT_WT, "merge-base", "--is-ancestor", "origin/HEAD", HEAD_REF],
+      [
+        "git",
+        "-C",
+        CONFLICT_WT,
+        "merge-base",
+        "--is-ancestor",
+        "origin/HEAD",
+        HEAD_REF,
+      ],
       ["git", "-C", CONFLICT_WT, "rebase", "--abort"],
       ["git", "worktree", "remove", "--force", CONFLICT_WT],
     ]);
@@ -482,7 +574,14 @@ describe("dispatchConflictWorker", () => {
     const { exec } = fakeConflictExec({ rebased: true });
     const { spawn } = fakeSpawn(0);
 
-    const outcome = await dispatchConflictWorker(30, 3, HEAD_REF, CONFLICT_CONFIG, exec, spawn);
+    const outcome = await dispatchConflictWorker(
+      30,
+      3,
+      HEAD_REF,
+      CONFLICT_CONFIG,
+      exec,
+      spawn,
+    );
 
     expect(outcome).toEqual({
       pr: 30,
@@ -501,7 +600,14 @@ describe("dispatchConflictWorker", () => {
     const { exec } = fakeConflictExec({ rebased: false });
     const { spawn } = fakeSpawn(0);
 
-    const outcome = await dispatchConflictWorker(30, 3, HEAD_REF, CONFLICT_CONFIG, exec, spawn);
+    const outcome = await dispatchConflictWorker(
+      30,
+      3,
+      HEAD_REF,
+      CONFLICT_CONFIG,
+      exec,
+      spawn,
+    );
 
     expect(outcome.resolved).toBe(false);
   });
@@ -510,7 +616,14 @@ describe("dispatchConflictWorker", () => {
     const { exec } = fakeConflictExec();
     const { spawn } = fakeSpawn(1);
 
-    const outcome = await dispatchConflictWorker(30, 3, HEAD_REF, CONFLICT_CONFIG, exec, spawn);
+    const outcome = await dispatchConflictWorker(
+      30,
+      3,
+      HEAD_REF,
+      CONFLICT_CONFIG,
+      exec,
+      spawn,
+    );
 
     expect(outcome.resolved).toBe(false);
     expect(outcome.exitCode).toBe(1);
@@ -520,7 +633,14 @@ describe("dispatchConflictWorker", () => {
     const { exec } = fakeConflictExec();
     const { spawn } = fakeSpawn(null, "timeout");
 
-    const outcome = await dispatchConflictWorker(30, 3, HEAD_REF, CONFLICT_CONFIG, exec, spawn);
+    const outcome = await dispatchConflictWorker(
+      30,
+      3,
+      HEAD_REF,
+      CONFLICT_CONFIG,
+      exec,
+      spawn,
+    );
 
     expect(outcome.resolved).toBe(false);
   });
@@ -550,14 +670,19 @@ describe("branchCommitSubjects", () => {
 
     const subjects = await branchCommitSubjects("base-sha", BRANCH, exec);
 
-    expect(calls).toEqual([["git", "log", "--format=%s", "--reverse", `base-sha..${BRANCH}`]]);
+    expect(calls).toEqual([
+      ["git", "log", "--format=%s", "--reverse", `base-sha..${BRANCH}`],
+    ]);
     expect(subjects).toEqual(["First commit", "Second commit"]);
   });
 });
 
 /** Drive real node child processes through the seam with tiny windows. */
 describe("realSpawnWorkerProcess", () => {
-  function request(script: string, windows: { timeoutMs: number; stallMs: number }): WorkerProcessRequest {
+  function request(
+    script: string,
+    windows: { timeoutMs: number; stallMs: number },
+  ): WorkerProcessRequest {
     const dir = mkdtempSync(join(tmpdir(), "border-collie-test-"));
     return {
       cmd: "node",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,9 +1,17 @@
 import { spawn } from "node:child_process";
 import { createWriteStream, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { classifyInfrastructure, lastResultLine, parseResultEvent } from "./classify.js";
-import { realExec, type Exec } from "./tracker.js";
-import { AGENT_BRANCH_PREFIX, type FailureReason, type InfraReason } from "./types.js";
+import {
+  classifyInfrastructure,
+  lastResultLine,
+  parseResultEvent,
+} from "./classify.js";
+import { type Exec, realExec } from "./tracker.js";
+import {
+  AGENT_BRANCH_PREFIX,
+  type FailureReason,
+  type InfraReason,
+} from "./types.js";
 
 /**
  * The WorkerHost seam: everything a dispatched Worker needs around it —
@@ -130,7 +138,10 @@ export interface WorkerProcessExit {
 export const TAIL_LIMIT = 64 * 1024;
 
 /** Accumulate a stream into a bounded tail: only the last TAIL_LIMIT chars survive. */
-function makeTail(): { push: (chunk: Buffer | string) => void; read: () => string } {
+function makeTail(): {
+  push: (chunk: Buffer | string) => void;
+  read: () => string;
+} {
   let tail = "";
   return {
     push: (chunk) => {
@@ -141,7 +152,9 @@ function makeTail(): { push: (chunk: Buffer | string) => void; read: () => strin
 }
 
 /** Process seam: run the Worker to completion under both watchdogs. */
-export type SpawnWorkerProcess = (request: WorkerProcessRequest) => Promise<WorkerProcessExit>;
+export type SpawnWorkerProcess = (
+  request: WorkerProcessRequest,
+) => Promise<WorkerProcessExit>;
 
 export const realSpawnWorkerProcess: SpawnWorkerProcess = (request) =>
   new Promise((resolve, reject) => {
@@ -207,7 +220,7 @@ export function workerPrompt(ticket: number): string {
   return [
     `/implement issue #${ticket}`,
     "",
-    "When the work is committed, make your final message a pull request description for this branch. It is used verbatim as the PR body, so it must contain nothing but the description itself — no preamble like \"Here's the PR description:\", no status narration, no text before or after it.",
+    'When the work is committed, make your final message a pull request description for this branch. It is used verbatim as the PR body, so it must contain nothing but the description itself — no preamble like "Here\'s the PR description:", no status narration, no text before or after it.',
   ].join("\n");
 }
 
@@ -229,7 +242,9 @@ export function conflictWorkerPrompt(): string {
 
 /** Best-effort worktree removal: absent or stale worktrees are fine. */
 async function removeWorktree(worktree: string, exec: Exec): Promise<void> {
-  await exec("git", ["worktree", "remove", "--force", worktree]).catch(() => {});
+  await exec("git", ["worktree", "remove", "--force", worktree]).catch(
+    () => {},
+  );
 }
 
 /**
@@ -250,7 +265,10 @@ function withGitLock<T>(operation: () => Promise<T>): Promise<T> {
  * remote is superseded, never recorded progress (ADR 0001). Only ever called
  * on agent-prefixed branches.
  */
-export async function pushAgentBranch(branch: string, exec: Exec = realExec): Promise<void> {
+export async function pushAgentBranch(
+  branch: string,
+  exec: Exec = realExec,
+): Promise<void> {
   await withGitLock(() => exec("git", ["push", "--force", "origin", branch]));
 }
 
@@ -289,7 +307,11 @@ export async function dispatchWorker(
 ): Promise<WorkerOutcome> {
   const branch = `${AGENT_BRANCH_PREFIX}${ticket}-attempt-${config.attempt}`;
   const worktree = join(RUN_DIR, "worktrees", `ticket-${ticket}`);
-  const transcript = join(RUN_DIR, "transcripts", `ticket-${ticket}-attempt-${config.attempt}.jsonl`);
+  const transcript = join(
+    RUN_DIR,
+    "transcripts",
+    `ticket-${ticket}-attempt-${config.attempt}.jsonl`,
+  );
   const stderrLog = join(
     RUN_DIR,
     "transcripts",
@@ -300,7 +322,14 @@ export async function dispatchWorker(
     await removeWorktree(worktree, exec);
     await exec("git", ["worktree", "prune"]);
     await exec("git", ["fetch", "origin"]);
-    await exec("git", ["worktree", "add", worktree, "-B", branch, "origin/HEAD"]);
+    await exec("git", [
+      "worktree",
+      "add",
+      worktree,
+      "-B",
+      branch,
+      "origin/HEAD",
+    ]);
     return (await exec("git", ["rev-parse", branch])).trim();
   });
 
@@ -318,7 +347,11 @@ export async function dispatchWorker(
       stallMs: config.stallMs,
     });
     const newCommits = Number(
-      (await withGitLock(() => exec("git", ["rev-list", "--count", `${base}..${branch}`]))).trim(),
+      (
+        await withGitLock(() =>
+          exec("git", ["rev-list", "--count", `${base}..${branch}`]),
+        )
+      ).trim(),
     );
     // A killed Worker fails even with commits on the branch: it never got to
     // finish, so the work is unverified and the PR description is missing.
@@ -349,8 +382,11 @@ export async function dispatchWorker(
       trigger !== undefined && !turnCapHit
         ? classifyInfrastructure(`${stderrTail}\n${lastResultLine(stdoutTail)}`)
         : undefined;
-    const failure: FailureReason | undefined =
-      turnCapHit ? "budget" : infra !== undefined ? undefined : trigger;
+    const failure: FailureReason | undefined = turnCapHit
+      ? "budget"
+      : infra !== undefined
+        ? undefined
+        : trigger;
     return {
       ticket,
       attempt: config.attempt,
@@ -365,7 +401,8 @@ export async function dispatchWorker(
       costUsd: result?.totalCostUsd,
       turns: result?.numTurns,
       costOverrun:
-        result?.totalCostUsd !== undefined && result.totalCostUsd > config.maxCostUsd,
+        result?.totalCostUsd !== undefined &&
+        result.totalCostUsd > config.maxCostUsd,
       ok: failure === undefined && infra === undefined,
     };
   } finally {
@@ -459,16 +496,29 @@ export async function dispatchConflictWorker(
 ): Promise<ConflictOutcome> {
   const worktree = join(RUN_DIR, "conflict-worktrees", `pr-${pr}`);
   const transcript = join(RUN_DIR, "transcripts", `pr-${pr}-conflict.jsonl`);
-  const stderrLog = join(RUN_DIR, "transcripts", `pr-${pr}-conflict.stderr.log`);
+  const stderrLog = join(
+    RUN_DIR,
+    "transcripts",
+    `pr-${pr}-conflict.stderr.log`,
+  );
 
   await withGitLock(async () => {
     await removeWorktree(worktree, exec);
     await exec("git", ["worktree", "prune"]);
     await exec("git", ["fetch", "origin"]);
-    await exec("git", ["worktree", "add", worktree, "-B", headRef, `origin/${headRef}`]);
+    await exec("git", [
+      "worktree",
+      "add",
+      worktree,
+      "-B",
+      headRef,
+      `origin/${headRef}`,
+    ]);
     // A conflicting rebase exits non-zero and stops in progress for the
     // Worker; swallow that so setting up the conflict never throws.
-    await exec("git", ["-C", worktree, "rebase", "origin/HEAD"]).catch(() => {});
+    await exec("git", ["-C", worktree, "rebase", "origin/HEAD"]).catch(
+      () => {},
+    );
   });
 
   try {
@@ -484,7 +534,14 @@ export async function dispatchConflictWorker(
     // The branch ref, not HEAD: mid-rebase HEAD is detached on the commit
     // being replayed, while the branch only moves on completion.
     const rebased = await withGitLock(() =>
-      exec("git", ["-C", worktree, "merge-base", "--is-ancestor", "origin/HEAD", headRef]).then(
+      exec("git", [
+        "-C",
+        worktree,
+        "merge-base",
+        "--is-ancestor",
+        "origin/HEAD",
+        headRef,
+      ]).then(
         () => true,
         () => false,
       ),


### PR DESCRIPTION
Introduce biome: lint and format gate

Adds `@biomejs/biome` as a dev dependency with a committed, default-leaning `biome.json` (kept close to `biome init` defaults — space/2-width indentation and double quotes to match the codebase's existing style rather than fighting it, plus VCS-ignore integration). Wires a `lint` package script (`biome check .`) that runs both lint rules and formatting and exits non-zero on violations.

Applies the one-time reformat/autofix pass across `src/` so the gate starts green: line-width wrapping, import organization, a couple of safe lint autofixes (literal-key access instead of bracket access in `config.ts`, dropping a redundant `continue`). No behavioral changes — verified `typecheck`, `build`, and the full test suite (235 tests) all still pass.

Closes #16