### PR TITLE
CI workflow: gate PRs and main on lint, typecheck, test, build, smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   gate:
     name: ${{ matrix.script }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  gate:
+    name: ${{ matrix.script }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        script: [lint, typecheck, test, build, smoke]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm run ${{ matrix.script }}


### PR DESCRIPTION
Add a CI workflow (`.github/workflows/ci.yml`) that gates every pull request and every push to `main` on lint, typecheck, test, build, and the pack smoke script.

- Triggers on `pull_request` and `push` to `main`.
- Runs on Node 24 via `actions/setup-node`, with pnpm provisioned by `pnpm/action-setup` reading the version straight from `package.json`'s `packageManager` field — no version duplicated in workflow config.
- Five gates run as independent matrix jobs (`lint`, `typecheck`, `test`, `build`, `smoke`), each invoking the existing package script (`pnpm run <script>`) so a red gate reports on its own check and a contributor can reproduce it locally with the identical command. `fail-fast: false` so one failing gate doesn't hide the others.
- Workflow token permissions scoped to `contents: read` (no job needs to write anything).

Closes #18.

Verified locally: `pnpm run lint`, `typecheck`, `test`, `build`, and `smoke` all pass on this branch, matching exactly what each CI job will run.