### PR TITLE
Release workflow: tag-driven npm publish with OIDC provenance and dry-run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,22 +10,4 @@ permissions:
 
 jobs:
   gate:
-    name: ${{ matrix.script }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        script: [lint, typecheck, test, build, smoke]
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: pnpm/action-setup@v6
-
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
-
-      - run: pnpm run ${{ matrix.script }}
+    uses: ./.github/workflows/gates.yml

--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -1,0 +1,26 @@
+name: Gates
+
+on:
+  workflow_call:
+
+jobs:
+  gate:
+    name: ${{ matrix.script }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        script: [lint, typecheck, test, build, smoke]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm run ${{ matrix.script }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    uses: ./.github/workflows/gates.yml
+
+  guard-version:
+    name: Guard tag matches manifest version
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Compare tag to package.json version
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          manifest_version="$(jq -r .version package.json)"
+          if [ "$tag_version" != "$manifest_version" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match package.json version $manifest_version"
+            exit 1
+          fi
+          echo "tag $GITHUB_REF_NAME matches package.json version $manifest_version"
+
+  publish:
+    name: Publish
+    needs: [gate, guard-version]
+    if: |
+      always() &&
+      needs.gate.result == 'success' &&
+      (needs.guard-version.result == 'success' || needs.guard-version.result == 'skipped')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Update npm for trusted publishing (OIDC)
+        run: npm install -g npm@latest
+
+      - run: pnpm run build
+
+      - name: Publish (dry run)
+        if: github.event_name == 'workflow_dispatch'
+        run: pnpm publish --dry-run --no-git-checks
+
+      - name: Publish
+        if: github.event_name == 'push'
+        run: pnpm publish --no-git-checks
+
+  release:
+    name: Create GitHub Release
+    needs: publish
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --generate-notes


### PR DESCRIPTION
Add a tag-driven release workflow (`.github/workflows/release.yml`) that publishes to npm via OIDC trusted publishing when the maintainer pushes a `v*` tag, plus a `workflow_dispatch` dry-run mode to rehearse the whole path safely.

- Extracted the CI gate matrix into a reusable `.github/workflows/gates.yml` (`workflow_call`) so `ci.yml` and `release.yml` both invoke the exact same lint/typecheck/test/build/smoke jobs — no duplicated, driftable gate definitions.
- `guard-version` job fails the run before publishing whenever the pushed tag (`vX.Y.Z`) doesn't match `package.json`'s `version`.
- `publish` job runs only after `gate` succeeds and `guard-version` succeeds-or-was-skipped. It uses `pnpm publish` (which shells out to the system `npm` CLI), with `id-token: write` scoped to just this job for OIDC trusted publishing — no npm token secret anywhere. `npm install -g npm@latest` ensures the CLI is new enough (>=11.5.1) to speak OIDC; `--no-git-checks` is needed because a tag checkout is detached HEAD. Provenance comes from the existing `publishConfig.provenance: true` in `package.json`.
- On `workflow_dispatch`, the same job runs `pnpm publish --dry-run --no-git-checks` instead — no tag required, nothing published.
- `release` job (tag pushes only, after a successful `publish`) creates a GitHub Release via `gh release create --generate-notes`, with `contents: write` scoped to just that job.
- Top-level workflow permissions stay `contents: read`; only the two jobs that need more get it, job-scoped.

Closes #19.

Verified locally: `pnpm run lint`, `typecheck`, `test`, `build`, and `smoke` all pass; workflow YAML validated with `actionlint`.