### PR TITLE
Install and release-process docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,38 @@ while open tickets remain:
   wait for PRs to merge; on merge → close ticket → recompute the dispatchable set
 ```
 
+## Install
+
+Requires Node >=24.
+
+```
+npx border-collie <tick|run>
+```
+
+or install it globally:
+
+```
+npm install -g border-collie
+```
+
+## Release process
+
+Releases are tag-driven (see `.github/workflows/release.yml`):
+
+1. Bump the version and tag it: `npm version <patch|minor|major>`.
+2. Push the tag: `git push --follow-tags`.
+3. Pushing a `v*` tag runs the release workflow: the same lint/typecheck/test/build/smoke gates as CI, a guard that the tag matches `package.json`'s version, a publish to npm over OIDC trusted publishing (no npm token stored in the repo), and a GitHub Release with generated notes.
+
+To rehearse a release without publishing, run the release workflow manually from the Actions tab (`workflow_dispatch`) — it runs the same gates and a `pnpm publish --dry-run` instead of a real publish.
+
+### One-time bootstrap
+
+Trusted publishing has to be bound to an npm package that already exists, so the very first release can't go through the workflow:
+
+1. Publish the first version manually from a local machine: `pnpm publish`.
+2. On npmjs.com, open the package's settings and add a trusted publisher: GitHub Actions, this repo, and the release workflow's filename (`release.yml`).
+3. Renaming the release workflow file afterwards breaks this binding — npm matches on the exact filename. Re-register the trusted publisher with the new filename if you rename it.
+
 ## Status
 
 Design phase. See [docs/handoff-ticket-fleet-orchestrator.md](docs/handoff-ticket-fleet-orchestrator.md) for the design context this project started from, including the decisions already taken and the open questions still to settle.


### PR DESCRIPTION
Documents install paths (npx/global npm, Node >=24) and the tag-driven release process (`npm version`, tag push, dry-run rehearsal via `workflow_dispatch`, and the one-time bootstrap of manual first publish + trusted-publisher binding, including the rename-breaks-binding caveat).

Closes #20.

## Summary
- Adds `## Install` to README: `npx border-collie <tick|run>`, `npm install -g border-collie`, and the Node >=24 requirement.
- Adds `## Release process` to README: bump with `npm version`, push the tag, what `.github/workflows/release.yml` then runs (gates, version guard, OIDC-based npm publish, GitHub Release), and how to rehearse with the `workflow_dispatch` dry-run.
- Adds `### One-time bootstrap` under it: the required manual first `pnpm publish`, registering the trusted publisher on npmjs.com bound to `release.yml`, and the warning that renaming that workflow file breaks the binding.

## Test plan
- [x] `pnpm run lint` passes
- [x] Reviewed against `.github/workflows/release.yml` and `package.json` for factual accuracy
- [x] Two-axis code review (Standards + Spec) run; no hard violations, all three acceptance criteria met