### PR TITLE
refactor(cli): extract the tick-pass wiring from the entry point

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,25 +1,14 @@
 #!/usr/bin/env node
 import { parseArgs } from "node:util";
-import { act } from "./act.js";
 import {
   ConfigError,
   type Flags,
   loadConfigFile,
-  modelForAttempt,
-  type ResolvedConfig,
   resolveConfig,
 } from "./config.js";
-import { plan } from "./plan.js";
-import { openPrForOutcome } from "./pr.js";
-import { renderPlan } from "./render.js";
 import { run } from "./run.js";
-import { readScope } from "./tracker.js";
-import type { Action, WorldSnapshot } from "./types.js";
-import {
-  dispatchConflictWorker,
-  dispatchWorker,
-  probeEnvironment,
-} from "./worker.js";
+import { tickOnce } from "./tick.js";
+import { probeEnvironment } from "./worker.js";
 
 const USAGE = `Usage: border-collie <tick|run> [options]
 
@@ -78,51 +67,6 @@ function parseIntFlag(
     throw new ConfigError(`${name} must be an integer, got "${value}"`);
   }
   return Number(value);
-}
-
-/** One full observe → plan → act pass — the single Tick both commands share. */
-async function tickOnce(
-  config: ResolvedConfig,
-  dryRun: boolean,
-  dispatchPaused = false,
-): Promise<{ world: WorldSnapshot; actions: Action[]; infraFailures: number }> {
-  const world = await readScope(config.scope);
-  const actions = plan(world, {
-    maxWorkers: config.maxWorkers,
-    maxOpenPrs: config.maxOpenPrs,
-    dispatchPaused,
-  });
-  console.log(renderPlan(config, world, actions, { dryRun, dispatchPaused }));
-  let infraFailures = 0;
-  if (!dryRun) {
-    const titles = new Map(world.tickets.map((t) => [t.number, t.title]));
-    const report = await act(
-      actions,
-      (ticket, attempt) =>
-        dispatchWorker(ticket, {
-          model: modelForAttempt(config, attempt),
-          attempt,
-          timeoutMs: config.timeoutMinutes * 60_000,
-          stallMs: config.stallMinutes * 60_000,
-          maxTurns: config.maxTurns,
-          maxCostUsd: config.maxCostUsd,
-        }),
-      (outcome) =>
-        openPrForOutcome(
-          outcome,
-          titles.get(outcome.ticket) ?? `Ticket #${outcome.ticket}`,
-        ),
-      (pr, ticket, headRef) =>
-        dispatchConflictWorker(pr, ticket, headRef, {
-          model: config.model,
-          timeoutMs: config.timeoutMinutes * 60_000,
-          stallMs: config.stallMinutes * 60_000,
-          maxTurns: config.maxTurns,
-        }),
-    );
-    infraFailures = report.infraFailures;
-  }
-  return { world, actions, infraFailures };
 }
 
 async function main(argv: string[]): Promise<number> {

--- a/src/tick.ts
+++ b/src/tick.ts
@@ -1,0 +1,53 @@
+import { act } from "./act.js";
+import { modelForAttempt, type ResolvedConfig } from "./config.js";
+import { plan } from "./plan.js";
+import { openPrForOutcome } from "./pr.js";
+import { renderPlan } from "./render.js";
+import { readScope } from "./tracker.js";
+import type { Action, WorldSnapshot } from "./types.js";
+import { dispatchConflictWorker, dispatchWorker } from "./worker.js";
+
+/** One full observe → plan → act pass — the single Tick both commands share. */
+export async function tickOnce(
+  config: ResolvedConfig,
+  dryRun: boolean,
+  dispatchPaused = false,
+): Promise<{ world: WorldSnapshot; actions: Action[]; infraFailures: number }> {
+  const world = await readScope(config.scope);
+  const actions = plan(world, {
+    maxWorkers: config.maxWorkers,
+    maxOpenPrs: config.maxOpenPrs,
+    dispatchPaused,
+  });
+  console.log(renderPlan(config, world, actions, { dryRun, dispatchPaused }));
+  let infraFailures = 0;
+  if (!dryRun) {
+    const titles = new Map(world.tickets.map((t) => [t.number, t.title]));
+    const report = await act(
+      actions,
+      (ticket, attempt) =>
+        dispatchWorker(ticket, {
+          model: modelForAttempt(config, attempt),
+          attempt,
+          timeoutMs: config.timeoutMinutes * 60_000,
+          stallMs: config.stallMinutes * 60_000,
+          maxTurns: config.maxTurns,
+          maxCostUsd: config.maxCostUsd,
+        }),
+      (outcome) =>
+        openPrForOutcome(
+          outcome,
+          titles.get(outcome.ticket) ?? `Ticket #${outcome.ticket}`,
+        ),
+      (pr, ticket, headRef) =>
+        dispatchConflictWorker(pr, ticket, headRef, {
+          model: config.model,
+          timeoutMs: config.timeoutMinutes * 60_000,
+          stallMs: config.stallMinutes * 60_000,
+          maxTurns: config.maxTurns,
+        }),
+    );
+    infraFailures = report.infraFailures;
+  }
+  return { world, actions, infraFailures };
+}


### PR DESCRIPTION
Committed. Final output is the PR description below.

refactor(cli): extract the tick-pass wiring from the entry point

## Summary

- Moves the shared Tick pass (`tickOnce`: observe → plan → act) and its Worker/PR/conflict-Worker collaborator wiring out of `src/cli.ts` into a new `src/tick.ts` module, imported by the entry point.
- `src/cli.ts` now retains only usage text, flag parsing/validation, command routing, and exit-code assignment.
- Pure prefactor for #27 (stricli migration): no operator-visible change of any kind — `tickOnce`'s logic is unchanged, only exported and relocated.

Closes #28

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` (biome) passes
- [x] `pnpm run test` — all 235 tests pass unchanged
- [x] `pnpm run smoke` — builds, packs, installs cold, `border-collie --help` runs successfully
- [x] Two-axis code review (standards + spec) run: no violations, no scope creep, extraction verified logic-identical