### PR TITLE
refactor(config): extract configuration file reading from resolution

### DIFF
--- a/src/cli-context.ts
+++ b/src/cli-context.ts
@@ -1,10 +1,6 @@
 import type { CommandContext, StricliProcess } from "@stricli/core";
-import {
-  type Flags,
-  loadConfigFile,
-  type ResolvedConfig,
-  resolveConfig,
-} from "./config.js";
+import { type Flags, type ResolvedConfig, resolveConfig } from "./config.js";
+import { loadConfigFile } from "./config-file.js";
 import { tickOnce } from "./tick.js";
 import type { Action, WorldSnapshot } from "./types.js";
 import { probeEnvironment } from "./worker.js";

--- a/src/config-file.ts
+++ b/src/config-file.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { CONFIG_FILE, ConfigError } from "./config.js";
+
+/** Read the config file from the target repo root; absent file is fine. */
+export function loadConfigFile(repoDir: string): unknown {
+  let raw: string;
+  try {
+    raw = readFileSync(join(repoDir, CONFIG_FILE), "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new ConfigError(`${CONFIG_FILE} is not valid JSON`);
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,3 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-
 /** File name looked up at the target repo's root. */
 export const CONFIG_FILE = "border-collie.json";
 
@@ -172,20 +169,4 @@ export function modelForAttempt(
   attempt: number,
 ): string {
   return attempt >= 2 ? config.retryModel : config.model;
-}
-
-/** Read the config file from the target repo root; absent file is fine. */
-export function loadConfigFile(repoDir: string): unknown {
-  let raw: string;
-  try {
-    raw = readFileSync(join(repoDir, CONFIG_FILE), "utf8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
-    throw error;
-  }
-  try {
-    return JSON.parse(raw);
-  } catch {
-    throw new ConfigError(`${CONFIG_FILE} is not valid JSON`);
-  }
 }


### PR DESCRIPTION
Committed. Here's the PR description:

refactor(config): extract configuration file reading from resolution

## Summary
- Configuration handling mixed a pure half (defaults, flag precedence, validation, the attempt-to-model retry ladder) with a single filesystem read. Move `loadConfigFile` out of `src/config.ts` into a new `src/config-file.ts`, so configuration resolution has no filesystem dependency.
- `src/cli-context.ts` (the CLI's composition root) now imports `loadConfigFile` from `./config-file.js` instead of `./config.js`, but composes `resolveConfig(loadConfigFile(...), flags)` exactly as before.
- No behavioural change: `loadConfigFile`'s body, error handling, and `CONFIG_FILE`/`ConfigError` are unchanged; `config-file.ts` imports both back from `config.ts`.
- No new test coverage added for the extracted read, per scope (it had none before either).

Part of #32 (sub-issue #35).

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (267 tests pass, no assertion changes)
- [x] `pnpm build`
- [x] `pnpm smoke`

Closes #35