### PR TITLE
refactor(types): move the Worker outcome record beside the failure taxonomy

### DIFF
--- a/src/act.test.ts
+++ b/src/act.test.ts
@@ -13,8 +13,9 @@ import {
   CONFLICT_UNRESOLVED_MARKER,
   RELEASE_MARKER,
   VOID_MARKER,
+  type WorkerOutcome,
 } from "./types.js";
-import type { ConflictOutcome, WorkerOutcome } from "./worker.js";
+import type { ConflictOutcome } from "./worker.js";
 
 function recordingExec(): { exec: Exec; calls: string[][] } {
   const calls: string[][] = [];

--- a/src/act.ts
+++ b/src/act.ts
@@ -12,12 +12,8 @@ import {
   updatePrBranch,
   voidAttempt,
 } from "./tracker.js";
-import type { Action } from "./types.js";
-import {
-  type ConflictOutcome,
-  pushAgentBranch,
-  type WorkerOutcome,
-} from "./worker.js";
+import type { Action, WorkerOutcome } from "./types.js";
+import { type ConflictOutcome, pushAgentBranch } from "./worker.js";
 
 /**
  * Dispatch one Worker against one claimed ticket; the caller binds the

--- a/src/classify.test.ts
+++ b/src/classify.test.ts
@@ -5,7 +5,7 @@ import {
   parseResultEvent,
   reclassifyCorrelatedFailures,
 } from "./classify.js";
-import type { WorkerOutcome } from "./worker.js";
+import type { WorkerOutcome } from "./types.js";
 
 describe("classifyInfrastructure", () => {
   it("classifies a usage-limit death", () => {

--- a/src/classify.ts
+++ b/src/classify.ts
@@ -1,5 +1,4 @@
-import type { InfraReason } from "./types.js";
-import type { WorkerOutcome } from "./worker.js";
+import type { InfraReason, WorkerOutcome } from "./types.js";
 
 /**
  * Failure classification (CONTEXT.md "Infrastructure failure"): pure

--- a/src/pr.test.ts
+++ b/src/pr.test.ts
@@ -9,7 +9,7 @@ import {
   workerFinalMessage,
 } from "./pr.js";
 import type { Exec } from "./tracker.js";
-import type { WorkerOutcome } from "./worker.js";
+import type { WorkerOutcome } from "./types.js";
 
 const event = (fields: Record<string, unknown>) => JSON.stringify(fields);
 

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -1,10 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { createDraftPr, type Exec, realExec } from "./tracker.js";
-import {
-  branchCommitSubjects,
-  pushAgentBranch,
-  type WorkerOutcome,
-} from "./worker.js";
+import type { WorkerOutcome } from "./types.js";
+import { branchCommitSubjects, pushAgentBranch } from "./worker.js";
 
 /**
  * PR opening: a successful Attempt's branch becomes a draft PR that closes

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,48 @@ export const INFRA_DESCRIPTIONS: Record<InfraReason, string> = {
   correlated: "several Workers failed the same way within one Tick",
 };
 
+/** One finished Attempt, as observed by the Orchestrator. */
+export interface WorkerOutcome {
+  ticket: number;
+  /** Attempt number the dispatch ran as, echoed from the config. */
+  attempt: number;
+  /** Agent-prefixed branch the Worker committed to; retained after cleanup. */
+  branch: string;
+  /** Commit the branch was cut from; `base..branch` is the Attempt's work. */
+  base: string;
+  /** Transcript file path, for post-mortems. */
+  transcript: string;
+  /** Model the attempt ran on, echoed into the attempt record on failure. */
+  model: string;
+  exitCode: number | null;
+  /** Commits on the branch beyond the base it was cut from. */
+  newCommits: number;
+  /**
+   * Which ticket-failure trigger fired, or undefined when none did (success,
+   * or an infrastructure failure): nonzero-exit, no-commits, timeout, stall,
+   * budget. Mutually exclusive with `infra`.
+   */
+  failure: FailureReason | undefined;
+  /**
+   * The infrastructure class a failed Worker's output evidenced, or
+   * undefined. An infra death voids the Attempt instead of burning it
+   * (CONTEXT.md "Infrastructure failure").
+   */
+  infra: InfraReason | undefined;
+  /** Attempt spend in USD, from the transcript's result event when one survived. */
+  costUsd: number | undefined;
+  /** Agentic turns taken, from the transcript's result event when one survived. */
+  turns: number | undefined;
+  /**
+   * The Attempt spent past the cost cap. An alarm, not a failure: a finished
+   * Attempt keeps its work and its PR — the overrun is surfaced so an
+   * oversized ticket reaches the operator's eye, not the bin.
+   */
+  costOverrun: boolean;
+  /** The success predicate: no failure trigger fired, ticket or infrastructure. */
+  ok: boolean;
+}
+
 /**
  * Hidden HTML marker on a comment that voids the preceding claim: the
  * Attempt died to the environment, so it counts as nothing. Unlike a release

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -10,7 +10,7 @@ import { type Exec, realExec } from "./tracker.js";
 import {
   AGENT_BRANCH_PREFIX,
   type FailureReason,
-  type InfraReason,
+  type WorkerOutcome,
 } from "./types.js";
 
 /**
@@ -65,48 +65,6 @@ function claudeArgs(prompt: string, model: string, maxTurns: number): string[] {
     "--verbose",
     "--dangerously-skip-permissions",
   ];
-}
-
-/** One finished Attempt, as observed by the Orchestrator. */
-export interface WorkerOutcome {
-  ticket: number;
-  /** Attempt number the dispatch ran as, echoed from the config. */
-  attempt: number;
-  /** Agent-prefixed branch the Worker committed to; retained after cleanup. */
-  branch: string;
-  /** Commit the branch was cut from; `base..branch` is the Attempt's work. */
-  base: string;
-  /** Transcript file path, for post-mortems. */
-  transcript: string;
-  /** Model the attempt ran on, echoed into the attempt record on failure. */
-  model: string;
-  exitCode: number | null;
-  /** Commits on the branch beyond the base it was cut from. */
-  newCommits: number;
-  /**
-   * Which ticket-failure trigger fired, or undefined when none did (success,
-   * or an infrastructure failure): nonzero-exit, no-commits, timeout, stall,
-   * budget. Mutually exclusive with `infra`.
-   */
-  failure: FailureReason | undefined;
-  /**
-   * The infrastructure class a failed Worker's output evidenced, or
-   * undefined. An infra death voids the Attempt instead of burning it
-   * (CONTEXT.md "Infrastructure failure").
-   */
-  infra: InfraReason | undefined;
-  /** Attempt spend in USD, from the transcript's result event when one survived. */
-  costUsd: number | undefined;
-  /** Agentic turns taken, from the transcript's result event when one survived. */
-  turns: number | undefined;
-  /**
-   * The Attempt spent past the cost cap. An alarm, not a failure: a finished
-   * Attempt keeps its work and its PR — the overrun is surfaced so an
-   * oversized ticket reaches the operator's eye, not the bin.
-   */
-  costOverrun: boolean;
-  /** The success predicate: no failure trigger fired, ticket or infrastructure. */
-  ok: boolean;
 }
 
 /** What the Worker process is started with. */


### PR DESCRIPTION
## Summary

Moves `WorkerOutcome` from `src/worker.ts` (the Worker adapter) into `src/types.ts` (the shared types module), placing it beside the `FailureReason`/`InfraReason` failure taxonomy that types its `failure`/`infra` fields.

- `src/classify.ts` now imports `InfraReason` and `WorkerOutcome` from `./types.js` only, dropping its type-only import from `./worker.js` and closing the import cycle between failure classification and the Worker adapter.
- `src/pr.ts` and `src/act.ts` (the effects executor) now take `WorkerOutcome` from `./types.js`, keeping only their value imports (`branchCommitSubjects`, `pushAgentBranch`, `ConflictOutcome`) from `./worker.js`.
- `src/worker.ts` drops the now-unused `InfraReason` import and imports `WorkerOutcome` from `./types.js` for its `dispatchWorker` return type.
- Test files (`act.test.ts`, `classify.test.ts`, `pr.test.ts`) updated to import `WorkerOutcome` from `./types.js` — import paths only, no assertion changes.

Pure relocation: doc comments preserved verbatim, no logic touched.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 267/267 passing
- [x] `pnpm build` — clean
- [x] `pnpm smoke` — passing
- [x] `/code-review` (Standards + Spec axes) — no findings on either axis

Closes #34