### PR TITLE
refactor(tick): route rendered output through an injected log callback

### DIFF
--- a/src/act.ts
+++ b/src/act.ts
@@ -91,7 +91,7 @@ export async function act(
   openPr: OpenPr,
   dispatchConflict: DispatchConflictWorker,
   exec: Exec = realExec,
-  log: (line: string) => void = console.log,
+  log: (line: string) => void,
 ): Promise<ActReport> {
   const workers: Promise<SpawnResult>[] = [];
   const conflicts: Promise<ConflictOutcome>[] = [];

--- a/src/cli-context.ts
+++ b/src/cli-context.ts
@@ -45,11 +45,14 @@ function nodeProcessAdapter(): StricliProcess {
 
 /** The real context: today's collaborators, wired exactly as the entry point wired them before. */
 export function buildRealContext(): Context {
+  const cliProcess = nodeProcessAdapter();
   return {
-    process: nodeProcessAdapter(),
+    process: cliProcess,
     loadConfig: (flags) => resolveConfig(loadConfigFile(process.cwd()), flags),
     tick: (config, dryRun, dispatchPaused) =>
-      tickOnce(config, dryRun, dispatchPaused),
+      tickOnce(config, dryRun, dispatchPaused, (line) =>
+        cliProcess.stdout.write(`${line}\n`),
+      ),
     probe: (model) => probeEnvironment(model),
     now: () => Date.now(),
     sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),

--- a/src/tick.ts
+++ b/src/tick.ts
@@ -12,6 +12,7 @@ export async function tickOnce(
   config: ResolvedConfig,
   dryRun: boolean,
   dispatchPaused = false,
+  log: (line: string) => void,
 ): Promise<{ world: WorldSnapshot; actions: Action[]; infraFailures: number }> {
   const world = await readScope(config.scope);
   const actions = plan(world, {
@@ -19,7 +20,7 @@ export async function tickOnce(
     maxOpenPrs: config.maxOpenPrs,
     dispatchPaused,
   });
-  console.log(renderPlan(config, world, actions, { dryRun, dispatchPaused }));
+  log(renderPlan(config, world, actions, { dryRun, dispatchPaused }));
   let infraFailures = 0;
   if (!dryRun) {
     const titles = new Map(world.tickets.map((t) => [t.number, t.title]));
@@ -46,6 +47,8 @@ export async function tickOnce(
           stallMs: config.stallMinutes * 60_000,
           maxTurns: config.maxTurns,
         }),
+      undefined,
+      log,
     );
     infraFailures = report.infraFailures;
   }


### PR DESCRIPTION
Committed. Final message is the PR description below.

refactor(tick): route rendered output through an injected log callback

## Summary

The Tick and the effects executor wrote their rendered plan and progress lines straight to the process's stdout. Anything calling the Tick as a library — a second delivery mechanism, or a test — couldn't capture, redirect, or suppress that output, and it escaped the test suite entirely.

Both now take an injected log callback instead:

- `tickOnce` (`src/tick.ts`) gains a `log: (line: string) => void` parameter and calls it instead of `console.log(renderPlan(...))`; it threads the same callback through to `act`.
- `act` (`src/act.ts`) drops its `console.log` default for the `log` parameter, so it can no longer fall back to writing the process directly — every caller must supply one.
- The CLI's composition root (`src/cli-context.ts`) supplies the callback, bound to the same process handle every other CLI write already goes through (`buildRealContext` now hoists one `nodeProcessAdapter()` instance and shares it between `Context.process` and the tick's log binding).

This brings the Tick and the effects executor in line with the run loop, which has taken an injected log from the start.

## Behaviour

Rendered output is unchanged, byte for byte — `` `${line}\n` `` reproduces exactly what `console.log` emitted for the same string. Verified with a real dry-run tick against this repo's own issues (`pnpm dev tick --dry-run --parent 32`), confirming the plan still renders through the new wiring.

## Testing

No new test seam was needed. `act.test.ts` already passes an explicit log collector at every call site and asserts on captured lines, which already proves the callback carries what the direct write carried — the run loop's test is the prior art for this. The Tick gains no test of its own; this is a stated, accepted risk (testing it would mean mocking four collaborators to assert wiring, not behaviour), with a real dry-run tick as the compensating manual check before merge.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (267 passed)
- [x] `pnpm build`
- [x] `pnpm run smoke`
- [x] Manual dry-run tick against a real repo scope, confirming rendered output still appears

Closes #33