### PR TITLE
test: move tests to a mirror tree

### DIFF
--- a/tests/adapters/pr.test.ts
+++ b/tests/adapters/pr.test.ts
@@ -7,9 +7,9 @@ import {
   openPrForOutcome,
   type ReadFile,
   workerFinalMessage,
-} from "./adapters/pr.js";
-import type { Exec } from "./adapters/tracker.js";
-import type { WorkerOutcome } from "./core/types.js";
+} from "../../src/adapters/pr.js";
+import type { Exec } from "../../src/adapters/tracker.js";
+import type { WorkerOutcome } from "../../src/core/types.js";
 
 const event = (fields: Record<string, unknown>) => JSON.stringify(fields);
 

--- a/tests/adapters/tracker.test.ts
+++ b/tests/adapters/tracker.test.ts
@@ -12,7 +12,7 @@ import {
   releaseTicket,
   updatePrBranch,
   voidAttempt,
-} from "./adapters/tracker.js";
+} from "../../src/adapters/tracker.js";
 import {
   type AttemptFailure,
   attemptMarker,
@@ -20,7 +20,7 @@ import {
   CONFLICT_UNRESOLVED_MARKER,
   RELEASE_MARKER,
   VOID_MARKER,
-} from "./core/types.js";
+} from "../../src/core/types.js";
 
 const FAILURE: AttemptFailure = {
   attempt: 1,

--- a/tests/adapters/worker.test.ts
+++ b/tests/adapters/worker.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import type { Exec } from "./adapters/tracker.js";
+import type { Exec } from "../../src/adapters/tracker.js";
 import {
   branchCommitSubjects,
   type ConflictWorkerConfig,
@@ -17,7 +17,7 @@ import {
   type WorkerProcessExit,
   type WorkerProcessRequest,
   workerPrompt,
-} from "./adapters/worker.js";
+} from "../../src/adapters/worker.js";
 
 const WORKTREE = ".border-collie/worktrees/ticket-4";
 const BRANCH = "border-collie/ticket-4-attempt-1";

--- a/tests/app/act.test.ts
+++ b/tests/app/act.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
-import type { Exec } from "./adapters/tracker.js";
-import type { ConflictOutcome } from "./adapters/worker.js";
+import type { Exec } from "../../src/adapters/tracker.js";
+import type { ConflictOutcome } from "../../src/adapters/worker.js";
 import {
   act,
   type DispatchConflictWorker,
   type DispatchWorker,
   type OpenPr,
-} from "./app/act.js";
+} from "../../src/app/act.js";
 import {
   type AttemptFailure,
   attemptMarker,
@@ -15,7 +15,7 @@ import {
   RELEASE_MARKER,
   VOID_MARKER,
   type WorkerOutcome,
-} from "./core/types.js";
+} from "../../src/core/types.js";
 
 function recordingExec(): { exec: Exec; calls: string[][] } {
   const calls: string[][] = [];

--- a/tests/app/run.test.ts
+++ b/tests/app/run.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { type RunDeps, run, runStatus } from "./app/run.js";
-import { BREAKER_BASE_COOLDOWN_MS } from "./core/breaker.js";
+import { type RunDeps, run, runStatus } from "../../src/app/run.js";
+import { BREAKER_BASE_COOLDOWN_MS } from "../../src/core/breaker.js";
 import type {
   Action,
   MergedAgentPr,
   OpenAgentPr,
   Ticket,
   WorldSnapshot,
-} from "./core/types.js";
+} from "../../src/core/types.js";
 
 function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
   return {

--- a/tests/cli/app.test.ts
+++ b/tests/cli/app.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { runCli } from "./cli/app.js";
-import type { Context } from "./cli/context.js";
-import { VERSION } from "./cli/version.js";
-import { ConfigError, type Flags, type ResolvedConfig } from "./core/config.js";
-import type { Ticket, WorldSnapshot } from "./core/types.js";
+import { runCli } from "../../src/cli/app.js";
+import type { Context } from "../../src/cli/context.js";
+import { VERSION } from "../../src/cli/version.js";
+import {
+  ConfigError,
+  type Flags,
+  type ResolvedConfig,
+} from "../../src/core/config.js";
+import type { Ticket, WorldSnapshot } from "../../src/core/types.js";
 
 function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
   return {

--- a/tests/core/breaker.test.ts
+++ b/tests/core/breaker.test.ts
@@ -5,7 +5,7 @@ import {
   breakerCooldownMs,
   probeDue,
   tripBreaker,
-} from "./core/breaker.js";
+} from "../../src/core/breaker.js";
 
 describe("tripBreaker", () => {
   it("opens a closed breaker with one trip", () => {

--- a/tests/core/classify.test.ts
+++ b/tests/core/classify.test.ts
@@ -4,8 +4,8 @@ import {
   lastResultLine,
   parseResultEvent,
   reclassifyCorrelatedFailures,
-} from "./core/classify.js";
-import type { WorkerOutcome } from "./core/types.js";
+} from "../../src/core/classify.js";
+import type { WorkerOutcome } from "../../src/core/types.js";
 
 describe("classifyInfrastructure", () => {
   it("classifies a usage-limit death", () => {

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { ConfigError, modelForAttempt, resolveConfig } from "./core/config.js";
+import {
+  ConfigError,
+  modelForAttempt,
+  resolveConfig,
+} from "../../src/core/config.js";
 
 describe("resolveConfig", () => {
   it("takes the scope parent and max_workers from the config file", () => {

--- a/tests/core/plan.test.ts
+++ b/tests/core/plan.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { plan } from "./core/plan.js";
+import { plan } from "../../src/core/plan.js";
 import type {
   AttemptFailure,
   MergedAgentPr,
   OpenAgentPr,
   Ticket,
   WorldSnapshot,
-} from "./core/types.js";
+} from "../../src/core/types.js";
 
 function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
   return {

--- a/tests/core/render.test.ts
+++ b/tests/core/render.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from "vitest";
-import type { ResolvedConfig } from "./core/config.js";
-import { plan } from "./core/plan.js";
-import { renderComplete, renderPlan, renderStuck } from "./core/render.js";
-import type { OpenAgentPr, Ticket, WorldSnapshot } from "./core/types.js";
+import type { ResolvedConfig } from "../../src/core/config.js";
+import { plan } from "../../src/core/plan.js";
+import {
+  renderComplete,
+  renderPlan,
+  renderStuck,
+} from "../../src/core/render.js";
+import type {
+  OpenAgentPr,
+  Ticket,
+  WorldSnapshot,
+} from "../../src/core/types.js";
 
 function ticket(
   overrides: Partial<Ticket> & { number: number; title: string },

--- a/tests/core/types.test.ts
+++ b/tests/core/types.test.ts
@@ -4,7 +4,7 @@ import {
   attemptMarker,
   parseAttemptMarker,
   ticketFromAgentBranch,
-} from "./core/types.js";
+} from "../../src/core/types.js";
 
 const FAILURE: AttemptFailure = {
   attempt: 1,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/**/*.test.ts"]
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "lib": ["ES2023"],
     "types": ["node"],
     "outDir": "dist",
-    "rootDir": "src",
     "declaration": true,
     "sourceMap": true,
     "strict": true,
@@ -16,5 +15,5 @@
     "verbatimModuleSyntax": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }


### PR DESCRIPTION
Committed clean. Final message is the PR description below.

test: move tests to a mirror tree

Moves the test modules out of the source root into a mirror tree, one folder per layer, so a source folder lists only source.

- `src/*.test.ts` → `tests/{core,adapters,app,cli}/*.test.ts`, matching each test to its subject's layer (`src/cli-app.test.ts` becomes `tests/cli/app.test.ts`, mirroring `src/cli/app.ts`)
- Test imports updated to plain relative paths (`../../src/<layer>/<module>.js`) — no aliases, no subpath imports
- `tsconfig.json` (base): drops `rootDir`, includes both `src` and `tests`, so `typecheck` covers the whole tree
- `tsconfig.build.json`: gains its own `rootDir: "src"` and `include: ["src"]`, replacing the now-redundant `exclude: ["src/**/*.test.ts"]`
- No vitest config added — default test discovery is depth-agnostic

Verified the type-check coverage claim directly: introduced a deliberate type error into a moved test file, confirmed `pnpm typecheck` failed on it, then reverted.

No test assertions changed — diffs are import-path-only. `lint`, `typecheck`, `test` (267 passing), `build`, and `smoke` all pass.

Closes #37