### PR TITLE
chore(lint): enforce layer boundaries

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -53,6 +53,10 @@
                   {
                     "group": ["../cli/**"],
                     "message": "core is the pure layer and must not depend on the delivery layer. Move CLI-facing wiring or formatting into cli, not core."
+                  },
+                  {
+                    "group": ["../main.js"],
+                    "message": "main is the composition-root entry point; it depends on cli, and nothing depends on it. Whatever you need from main belongs in core already — this shouldn't be an import at all."
                   }
                 ]
               }
@@ -77,6 +81,10 @@
                   {
                     "group": ["../cli/**"],
                     "message": "adapters may depend on core only. cli's context module is the composition root that wires adapters together — depend on core here, and let cli reach into this adapter instead."
+                  },
+                  {
+                    "group": ["../main.js"],
+                    "message": "main is the composition-root entry point; it depends on cli, and nothing depends on it. An adapter has no legitimate reason to reach into main."
                   }
                 ]
               }
@@ -97,6 +105,30 @@
                   {
                     "group": ["../cli/**"],
                     "message": "app may depend on core and adapters only, not cli. cli calls into app, not the reverse — expose this from app and have the cli command handler call it."
+                  },
+                  {
+                    "group": ["../main.js"],
+                    "message": "main is the composition-root entry point; it depends on cli, and nothing depends on it. app has no legitimate reason to reach into main."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "includes": ["src/cli/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "patterns": [
+                  {
+                    "group": ["../main.js"],
+                    "message": "main is the composition-root entry point; it depends on cli, and nothing depends on it. cli has no legitimate reason to reach into main."
                   }
                 ]
               }

--- a/biome.json
+++ b/biome.json
@@ -31,5 +31,99 @@
         "organizeImports": "on"
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["src/core/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "patterns": [
+                  {
+                    "group": ["../adapters/**"],
+                    "message": "core is the pure layer and must have no I/O. Inject the adapter's result as a parameter instead of importing the adapter, or move this logic to app if it genuinely needs to orchestrate an adapter call."
+                  },
+                  {
+                    "group": ["../app/**"],
+                    "message": "core is the pure layer; app depends on core, not the reverse. If app needs this logic, keep it in core and have app import it — do not import app from core."
+                  },
+                  {
+                    "group": ["../cli/**"],
+                    "message": "core is the pure layer and must not depend on the delivery layer. Move CLI-facing wiring or formatting into cli, not core."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "includes": ["src/adapters/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "patterns": [
+                  {
+                    "group": ["../app/**"],
+                    "message": "adapters may depend on core only. app composes adapters together, not the reverse — move this composition into app instead of importing it from an adapter."
+                  },
+                  {
+                    "group": ["../cli/**"],
+                    "message": "adapters may depend on core only. cli's context module is the composition root that wires adapters together — depend on core here, and let cli reach into this adapter instead."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "includes": ["src/app/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "patterns": [
+                  {
+                    "group": ["../cli/**"],
+                    "message": "app may depend on core and adapters only, not cli. cli calls into app, not the reverse — expose this from app and have the cli command handler call it."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "includes": ["src/main.ts"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "patterns": [
+                  {
+                    "group": ["./core/**", "./adapters/**", "./app/**"],
+                    "message": "main may depend on cli only, so it stays a thin composition-root entry point. Route this through cli/app.ts (or cli/context.ts for wiring adapters) instead of importing it directly here."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- Add Biome `noRestrictedImports` overrides scoped to `src/core/**`, `src/adapters/**`, `src/app/**`, `src/cli/**` and `src/main.ts` that encode the full permitted dependency matrix from #32: `core -> core only`, `adapters -> core`, `app -> core, adapters`, `cli -> core, app, adapters`, `main -> cli`, and the closing edge that nothing depends on `main`.
- Each restriction's message states the rule and the alternative (e.g. inject the adapter's result instead of importing it, or move the logic to the layer that's actually allowed to depend on it), so a lint failure is in-loop feedback rather than a bare import name.
- Overrides are scoped under `src/`, so the flat `*.test.ts` files (and the future mirror test tree from #37) are unaffected — a test may still construct a fake adapter for a pure module.
- No new dependencies; no source files changed.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 267/267 passing
- [x] `pnpm build` — clean
- [x] `pnpm smoke` — passes
- [x] Deliberately added a cross-grain import (`core` importing from `adapters`) — confirmed it fails `lint` with the rule's message, then reverted
- [x] Deliberately added imports of `main.ts` from `core`/`adapters`/`app`/`cli` — confirmed each fails `lint`, then reverted

Closes #38