### PR TITLE
refactor(act): take an injected dependency record

### DIFF
--- a/src/app/act.ts
+++ b/src/app/act.ts
@@ -5,7 +5,6 @@ import {
   type Exec,
   escalateTicket,
   markPrReady,
-  realExec,
   releaseFailedTicket,
   releaseTicket,
   updatePrBranch,
@@ -59,6 +58,15 @@ export interface ActReport {
   infraFailures: number;
 }
 
+/** The act phase's effects, injectable for tests, matching the run loop's pattern. */
+export interface ActDeps {
+  dispatch: DispatchWorker;
+  openPr: OpenPr;
+  dispatchConflict: DispatchConflictWorker;
+  exec: Exec;
+  log: (line: string) => void;
+}
+
 function describeConflict(outcome: ConflictOutcome): string {
   const where = `on ${outcome.headRef} (transcript: ${outcome.transcript})`;
   return outcome.resolved
@@ -87,12 +95,9 @@ function describeConflict(outcome: ConflictOutcome): string {
  */
 export async function act(
   actions: Action[],
-  dispatch: DispatchWorker,
-  openPr: OpenPr,
-  dispatchConflict: DispatchConflictWorker,
-  exec: Exec = realExec,
-  log: (line: string) => void,
+  deps: ActDeps,
 ): Promise<ActReport> {
+  const { dispatch, openPr, dispatchConflict, exec, log } = deps;
   const workers: Promise<SpawnResult>[] = [];
   const conflicts: Promise<ConflictOutcome>[] = [];
   for (const action of actions) {

--- a/src/app/tick.ts
+++ b/src/app/tick.ts
@@ -1,5 +1,5 @@
 import { openPrForOutcome } from "../adapters/pr.js";
-import { readScope } from "../adapters/tracker.js";
+import { readScope, realExec } from "../adapters/tracker.js";
 import { dispatchConflictWorker, dispatchWorker } from "../adapters/worker.js";
 import { modelForAttempt, type ResolvedConfig } from "../core/config.js";
 import { plan } from "../core/plan.js";
@@ -24,9 +24,8 @@ export async function tickOnce(
   let infraFailures = 0;
   if (!dryRun) {
     const titles = new Map(world.tickets.map((t) => [t.number, t.title]));
-    const report = await act(
-      actions,
-      (ticket, attempt) =>
+    const report = await act(actions, {
+      dispatch: (ticket, attempt) =>
         dispatchWorker(ticket, {
           model: modelForAttempt(config, attempt),
           attempt,
@@ -35,21 +34,21 @@ export async function tickOnce(
           maxTurns: config.maxTurns,
           maxCostUsd: config.maxCostUsd,
         }),
-      (outcome) =>
+      openPr: (outcome) =>
         openPrForOutcome(
           outcome,
           titles.get(outcome.ticket) ?? `Ticket #${outcome.ticket}`,
         ),
-      (pr, ticket, headRef) =>
+      dispatchConflict: (pr, ticket, headRef) =>
         dispatchConflictWorker(pr, ticket, headRef, {
           model: config.model,
           timeoutMs: config.timeoutMinutes * 60_000,
           stallMs: config.stallMinutes * 60_000,
           maxTurns: config.maxTurns,
         }),
-      undefined,
+      exec: realExec,
       log,
-    );
+    });
     infraFailures = report.infraFailures;
   }
   return { world, actions, infraFailures };

--- a/tests/app/act.test.ts
+++ b/tests/app/act.test.ts
@@ -93,11 +93,13 @@ describe("act", () => {
         { type: "release", ticket: 4, assignees: ["operator"] },
         { type: "claim", ticket: 9 },
       ],
-      noDispatch,
-      openPr,
-      noConflict,
-      exec,
-      (line) => lines.push(line),
+      {
+        dispatch: noDispatch,
+        openPr,
+        dispatchConflict: noConflict,
+        exec,
+        log: (line) => lines.push(line),
+      },
     );
 
     expect(calls).toEqual([
@@ -130,11 +132,13 @@ describe("act", () => {
 
     await act(
       [{ type: "close", ticket: 6, prUrl: "https://github.com/o/r/pull/60" }],
-      noDispatch,
-      openPr,
-      noConflict,
-      exec,
-      (line) => lines.push(line),
+      {
+        dispatch: noDispatch,
+        openPr,
+        dispatchConflict: noConflict,
+        exec,
+        log: (line) => lines.push(line),
+      },
     );
 
     expect(calls).toEqual([
@@ -156,7 +160,13 @@ describe("act", () => {
     const { exec, calls } = recordingExec();
     const { openPr } = recordingOpenPr();
 
-    await act([], noDispatch, openPr, noConflict, exec, () => {});
+    await act([], {
+      dispatch: noDispatch,
+      openPr,
+      dispatchConflict: noConflict,
+      exec,
+      log: () => {},
+    });
 
     expect(calls).toEqual([]);
   });
@@ -192,11 +202,13 @@ describe("act", () => {
         { type: "claim", ticket: 4 },
         { type: "spawn", ticket: 4, attempt: 1 },
       ],
-      dispatch,
-      openPr,
-      noConflict,
-      exec,
-      (line) => lines.push(line),
+      {
+        dispatch,
+        openPr,
+        dispatchConflict: noConflict,
+        exec,
+        log: (line) => lines.push(line),
+      },
     );
 
     expect(dispatched).toEqual([2, 4]);
@@ -221,14 +233,13 @@ describe("act", () => {
       return outcome(ticket);
     };
 
-    await act(
-      [{ type: "spawn", ticket: 7, attempt: 2 }],
+    await act([{ type: "spawn", ticket: 7, attempt: 2 }], {
       dispatch,
-      recordingOpenPr().openPr,
-      noConflict,
+      openPr: recordingOpenPr().openPr,
+      dispatchConflict: noConflict,
       exec,
-      () => {},
-    );
+      log: () => {},
+    });
 
     expect(attempts).toEqual([[7, 2]]);
   });
@@ -238,14 +249,13 @@ describe("act", () => {
     const dispatch: DispatchWorker = async () =>
       outcome(7, { attempt: 2, exitCode: null, failure: "stall", ok: false });
 
-    await act(
-      [{ type: "spawn", ticket: 7, attempt: 2 }],
+    await act([{ type: "spawn", ticket: 7, attempt: 2 }], {
       dispatch,
-      recordingOpenPr().openPr,
-      noConflict,
+      openPr: recordingOpenPr().openPr,
+      dispatchConflict: noConflict,
       exec,
-      () => {},
-    );
+      log: () => {},
+    });
 
     const record: AttemptFailure = {
       attempt: 2,
@@ -271,14 +281,13 @@ describe("act", () => {
     const { exec, calls } = recordingExec();
     const dispatch: DispatchWorker = async () => outcome(7);
 
-    await act(
-      [{ type: "spawn", ticket: 7, attempt: 1 }],
+    await act([{ type: "spawn", ticket: 7, attempt: 1 }], {
       dispatch,
-      recordingOpenPr().openPr,
-      noConflict,
+      openPr: recordingOpenPr().openPr,
+      dispatchConflict: noConflict,
       exec,
-      () => {},
-    );
+      log: () => {},
+    });
 
     expect(calls).toEqual([]);
   });
@@ -296,14 +305,13 @@ describe("act", () => {
       },
     ];
 
-    await act(
-      [{ type: "escalate", ticket: 5, failures }],
-      noDispatch,
-      recordingOpenPr().openPr,
-      noConflict,
+    await act([{ type: "escalate", ticket: 5, failures }], {
+      dispatch: noDispatch,
+      openPr: recordingOpenPr().openPr,
+      dispatchConflict: noConflict,
       exec,
-      (line) => lines.push(line),
-    );
+      log: (line) => lines.push(line),
+    });
 
     expect(calls).toEqual([
       [
@@ -337,14 +345,13 @@ describe("act", () => {
     const dispatch: DispatchWorker = async () =>
       outcome(7, { costUsd: 25.5, turns: 80, costOverrun: true });
 
-    await act(
-      [{ type: "spawn", ticket: 7, attempt: 1 }],
+    await act([{ type: "spawn", ticket: 7, attempt: 1 }], {
       dispatch,
       openPr,
-      noConflict,
+      dispatchConflict: noConflict,
       exec,
-      (line) => lines.push(line),
-    );
+      log: (line) => lines.push(line),
+    });
 
     expect(opened).toEqual([7]); // the work is kept — discarding refunds nothing
     expect(calls).toEqual([]); // no tracker writes: not a failure
@@ -364,14 +371,13 @@ describe("act", () => {
         ok: false,
       });
 
-    const report = await act(
-      [{ type: "spawn", ticket: 7, attempt: 1 }],
+    const report = await act([{ type: "spawn", ticket: 7, attempt: 1 }], {
       dispatch,
-      recordingOpenPr().openPr,
-      noConflict,
+      openPr: recordingOpenPr().openPr,
+      dispatchConflict: noConflict,
       exec,
-      (line) => lines.push(line),
-    );
+      log: (line) => lines.push(line),
+    });
 
     expect(calls).toEqual([
       [
@@ -403,11 +409,13 @@ describe("act", () => {
         { type: "spawn", ticket: 2, attempt: 1 },
         { type: "spawn", ticket: 4, attempt: 1 },
       ],
-      dispatch,
-      recordingOpenPr().openPr,
-      noConflict,
-      exec,
-      (line) => lines.push(line),
+      {
+        dispatch,
+        openPr: recordingOpenPr().openPr,
+        dispatchConflict: noConflict,
+        exec,
+        log: (line) => lines.push(line),
+      },
     );
 
     // Both attempts voided, none released: no assignee ever removed.
@@ -424,14 +432,13 @@ describe("act", () => {
     const { exec } = recordingExec();
     const dispatch: DispatchWorker = async (ticket) => outcome(ticket);
 
-    const report = await act(
-      [{ type: "spawn", ticket: 2, attempt: 1 }],
+    const report = await act([{ type: "spawn", ticket: 2, attempt: 1 }], {
       dispatch,
-      recordingOpenPr().openPr,
-      noConflict,
+      openPr: recordingOpenPr().openPr,
+      dispatchConflict: noConflict,
       exec,
-      () => {},
-    );
+      log: () => {},
+    });
 
     expect(report).toEqual({ infraFailures: 0 });
   });
@@ -451,11 +458,13 @@ describe("act", () => {
           { type: "spawn", ticket: 2, attempt: 1 },
           { type: "spawn", ticket: 4, attempt: 1 },
         ],
-        dispatch,
-        openPr,
-        noConflict,
-        exec,
-        (line) => lines.push(line),
+        {
+          dispatch,
+          openPr,
+          dispatchConflict: noConflict,
+          exec,
+          log: (line) => lines.push(line),
+        },
       ),
     ).rejects.toThrow("git exploded");
 
@@ -473,14 +482,13 @@ describe("act", () => {
     };
 
     await expect(
-      act(
-        [{ type: "spawn", ticket: 2, attempt: 1 }],
+      act([{ type: "spawn", ticket: 2, attempt: 1 }], {
         dispatch,
         openPr,
-        noConflict,
+        dispatchConflict: noConflict,
         exec,
-        (line) => lines.push(line),
-      ),
+        log: (line) => lines.push(line),
+      }),
     ).rejects.toThrow("gh pr create exploded");
 
     expect(lines).toContain(
@@ -494,14 +502,13 @@ describe("act: PR upkeep", () => {
     const { exec, calls } = recordingExec();
     const lines: string[] = [];
 
-    await act(
-      [{ type: "update-branch", pr: 30, ticket: 3 }],
-      noDispatch,
-      recordingOpenPr().openPr,
-      noConflict,
+    await act([{ type: "update-branch", pr: 30, ticket: 3 }], {
+      dispatch: noDispatch,
+      openPr: recordingOpenPr().openPr,
+      dispatchConflict: noConflict,
       exec,
-      (line) => lines.push(line),
-    );
+      log: (line) => lines.push(line),
+    });
 
     expect(calls).toEqual([["gh", "pr", "update-branch", "30", "--rebase"]]);
     expect(lines).toEqual([
@@ -513,14 +520,13 @@ describe("act: PR upkeep", () => {
     const { exec, calls } = recordingExec();
     const lines: string[] = [];
 
-    await act(
-      [{ type: "mark-ready", pr: 30, ticket: 3 }],
-      noDispatch,
-      recordingOpenPr().openPr,
-      noConflict,
+    await act([{ type: "mark-ready", pr: 30, ticket: 3 }], {
+      dispatch: noDispatch,
+      openPr: recordingOpenPr().openPr,
+      dispatchConflict: noConflict,
       exec,
-      (line) => lines.push(line),
-    );
+      log: (line) => lines.push(line),
+    });
 
     expect(calls).toEqual([["gh", "pr", "ready", "30"]]);
     expect(lines).toEqual(["marked PR #30 ready for review"]);
@@ -544,11 +550,13 @@ describe("act: PR upkeep", () => {
           headRef: "border-collie/ticket-3-attempt-1",
         },
       ],
-      noDispatch,
-      recordingOpenPr().openPr,
-      dispatchConflict,
-      exec,
-      (line) => lines.push(line),
+      {
+        dispatch: noDispatch,
+        openPr: recordingOpenPr().openPr,
+        dispatchConflict,
+        exec,
+        log: (line) => lines.push(line),
+      },
     );
 
     expect(calls).toEqual([
@@ -579,11 +587,13 @@ describe("act: PR upkeep", () => {
           headRef: "border-collie/ticket-3-attempt-1",
         },
       ],
-      noDispatch,
-      recordingOpenPr().openPr,
-      dispatchConflict,
-      exec,
-      (line) => lines.push(line),
+      {
+        dispatch: noDispatch,
+        openPr: recordingOpenPr().openPr,
+        dispatchConflict,
+        exec,
+        log: (line) => lines.push(line),
+      },
     );
 
     expect(calls).toEqual([
@@ -638,11 +648,13 @@ describe("act: PR upkeep", () => {
         },
         { type: "spawn", ticket: 2, attempt: 1 },
       ],
-      dispatch,
-      recordingOpenPr().openPr,
-      dispatchConflict,
-      exec,
-      (line) => lines.push(line),
+      {
+        dispatch,
+        openPr: recordingOpenPr().openPr,
+        dispatchConflict,
+        exec,
+        log: (line) => lines.push(line),
+      },
     );
 
     expect(inFlight.sort()).toEqual(["conflict-40", "worker-2"]);
@@ -671,11 +683,13 @@ describe("act: PR upkeep", () => {
           },
           { type: "spawn", ticket: 2, attempt: 1 },
         ],
-        dispatch,
-        recordingOpenPr().openPr,
-        dispatchConflict,
-        exec,
-        (line) => lines.push(line),
+        {
+          dispatch,
+          openPr: recordingOpenPr().openPr,
+          dispatchConflict,
+          exec,
+          log: (line) => lines.push(line),
+        },
       ),
     ).rejects.toThrow("claude ENOENT");
 


### PR DESCRIPTION
refactor(act): take an injected dependency record

## Summary

Converts the act phase's effects executor from six positional parameters to a single injected `ActDeps` record, matching the shape `RunDeps` already uses in the run loop and the pattern ADR 0005 describes. Later tickets in this set (clock, interval scheduler, changed logging function) can now add a collaborator by naming a field instead of appending another positional argument to a call that was already hard to read.

Pure prefactor — no behavior change. Console output, exit codes, and tracker writes are identical to before.

## Changes

- `src/app/act.ts`: `act(actions, dispatch, openPr, dispatchConflict, exec, log)` → `act(actions, deps: ActDeps)`, where `ActDeps` bundles `dispatch`, `openPr`, `dispatchConflict`, `exec`, and `log` as required function-type fields, mirroring `RunDeps`.
- `src/app/tick.ts`: updated to compose and pass the `ActDeps` record, including `exec: realExec` explicitly (previously relied on `act`'s default parameter).
- `tests/app/act.test.ts`: every call site updated to the record form; no assertions changed.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` — 267 tests pass, no assertions changed
- [x] Reviewed via `/code-review` (Standards + Spec axes); one spec-consistency nit found and fixed (`exec` was optional with a default, inconsistent with `RunDeps`' all-required shape — now required)

Closes #48.