### PR TITLE
feat(logging): structured log events with a pretty, leveled console

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -57,6 +57,10 @@
                   {
                     "group": ["../main.js"],
                     "message": "main is the composition-root entry point; it depends on cli, and nothing depends on it. Whatever you need from main belongs in core already — this shouldn't be an import at all."
+                  },
+                  {
+                    "group": ["tslog"],
+                    "message": "the logging library is constructed only in the composition root (cli/context.ts). core sees only the injected Log function from core/log.ts."
                   }
                 ]
               }
@@ -85,6 +89,10 @@
                   {
                     "group": ["../main.js"],
                     "message": "main is the composition-root entry point; it depends on cli, and nothing depends on it. An adapter has no legitimate reason to reach into main."
+                  },
+                  {
+                    "group": ["tslog"],
+                    "message": "the logging library is constructed only in the composition root (cli/context.ts). An adapter that needs to narrate takes the injected Log function from core/log.ts instead."
                   }
                 ]
               }
@@ -109,6 +117,10 @@
                   {
                     "group": ["../main.js"],
                     "message": "main is the composition-root entry point; it depends on cli, and nothing depends on it. app has no legitimate reason to reach into main."
+                  },
+                  {
+                    "group": ["tslog"],
+                    "message": "the logging library is constructed only in the composition root (cli/context.ts). app sees only the injected Log function from core/log.ts, exactly like every other effect."
                   }
                 ]
               }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "packageManager": "pnpm@11.14.0",
   "dependencies": {
-    "@stricli/core": "^1.3.0"
+    "@stricli/core": "^1.3.0",
+    "tslog": "5.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@stricli/core':
         specifier: ^1.3.0
         version: 1.3.0
+      tslog:
+        specifier: 5.1.0
+        version: 5.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.5
@@ -712,6 +715,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tslog@5.1.0:
+    resolution: {integrity: sha512-g77ALovust2HNBX/63ePEJwetIeX0Vi/dlzqBO+ZAg+aERB54KMmaz/khNPxhFpaxKQ6RQj65sK6vIhj1SJgjQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   tsx@4.23.1:
     resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
     engines: {node: '>=18.0.0'}
@@ -1293,6 +1301,8 @@ snapshots:
 
   tslib@2.8.1:
     optional: true
+
+  tslog@5.1.0: {}
 
   tsx@4.23.1:
     dependencies:

--- a/src/app/act.ts
+++ b/src/app/act.ts
@@ -317,7 +317,16 @@ export async function act(
   if (rejectedConflict) throw rejectedConflict.reason;
   for (const result of settled) {
     if (result.status === "fulfilled" && result.value.prFailure !== undefined) {
-      throw result.value.prFailure;
+      const { outcome: failedOutcome, prFailure } = result.value;
+      const reason =
+        prFailure instanceof Error ? prFailure.message : String(prFailure);
+      log({
+        kind: "pr-open-failed",
+        level: "error",
+        msg: `PR opening failed for #${failedOutcome.ticket} after a successful Attempt: ${reason}`,
+        ticket: failedOutcome.ticket,
+      });
+      throw prFailure;
     }
   }
   return {

--- a/src/app/act.ts
+++ b/src/app/act.ts
@@ -12,6 +12,7 @@ import {
 } from "../adapters/tracker.js";
 import { type ConflictOutcome, pushAgentBranch } from "../adapters/worker.js";
 import { reclassifyCorrelatedFailures } from "../core/classify.js";
+import type { Log } from "../core/log.js";
 import type { Action, WorkerOutcome } from "../core/types.js";
 
 /**
@@ -64,7 +65,7 @@ export interface ActDeps {
   openPr: OpenPr;
   dispatchConflict: DispatchConflictWorker;
   exec: Exec;
-  log: (line: string) => void;
+  log: Log;
 }
 
 function describeConflict(outcome: ConflictOutcome): string {
@@ -104,39 +105,70 @@ export async function act(
     switch (action.type) {
       case "claim":
         await claimTicket(action.ticket, exec);
-        log(`claimed #${action.ticket}`);
+        log({
+          kind: "claim",
+          level: "info",
+          msg: `claimed #${action.ticket}`,
+          ticket: action.ticket,
+        });
         break;
       case "release":
         await releaseTicket(action.ticket, action.assignees, exec);
-        log(`released #${action.ticket} (orphaned claim)`);
+        log({
+          kind: "release",
+          level: "info",
+          msg: `released #${action.ticket} (orphaned claim)`,
+          ticket: action.ticket,
+        });
         break;
       case "escalate":
         await escalateTicket(action.ticket, action.failures, exec);
-        log(
-          `escalated #${action.ticket} to ready-for-human (attempts exhausted)`,
-        );
+        log({
+          kind: "escalate",
+          level: "warn",
+          msg: `escalated #${action.ticket} to ready-for-human (attempts exhausted)`,
+          ticket: action.ticket,
+        });
         break;
       case "close":
         await closeTicket(action.ticket, action.prUrl, exec);
-        log(`closed #${action.ticket} (merged: ${action.prUrl})`);
+        log({
+          kind: "close",
+          level: "info",
+          msg: `closed #${action.ticket} (merged: ${action.prUrl})`,
+          ticket: action.ticket,
+          prUrl: action.prUrl,
+        });
         break;
       case "update-branch":
         await updatePrBranch(action.pr, exec);
-        log(
-          `updated PR #${action.pr} branch (mechanical rebase onto the base)`,
-        );
+        log({
+          kind: "update-branch",
+          level: "info",
+          msg: `updated PR #${action.pr} branch (mechanical rebase onto the base)`,
+          pr: action.pr,
+        });
         break;
       case "mark-ready":
         await markPrReady(action.pr, exec);
-        log(`marked PR #${action.pr} ready for review`);
+        log({
+          kind: "mark-ready",
+          level: "info",
+          msg: `marked PR #${action.pr} ready for review`,
+          pr: action.pr,
+        });
         break;
       case "conflict-worker":
         conflicts.push(
           dispatchConflict(action.pr, action.ticket, action.headRef),
         );
-        log(
-          `dispatched conflict Worker for PR #${action.pr} (ticket #${action.ticket})`,
-        );
+        log({
+          kind: "conflict-dispatch",
+          level: "info",
+          msg: `dispatched conflict Worker for PR #${action.pr} (ticket #${action.ticket})`,
+          pr: action.pr,
+          ticket: action.ticket,
+        });
         break;
       case "spawn":
         workers.push(
@@ -151,7 +183,13 @@ export async function act(
             },
           ),
         );
-        log(`spawned Worker for #${action.ticket} (attempt ${action.attempt})`);
+        log({
+          kind: "spawn",
+          level: "info",
+          msg: `spawned Worker for #${action.ticket} (attempt ${action.attempt})`,
+          ticket: action.ticket,
+          attempt: action.attempt,
+        });
         break;
     }
   }
@@ -171,13 +209,30 @@ export async function act(
     fulfilled.map((spawn) => spawn.outcome),
   ).map((outcome, i) => ({ outcome, prUrl: fulfilled[i]?.prUrl }));
   for (const { outcome, prUrl } of outcomes) {
-    log(describeOutcome(outcome));
-    if (prUrl !== undefined)
-      log(`opened draft PR for #${outcome.ticket}: ${prUrl}`);
+    log({
+      kind: "worker-outcome",
+      level: outcome.infra !== undefined ? "warn" : "info",
+      msg: describeOutcome(outcome),
+      outcome,
+    });
+    if (prUrl !== undefined) {
+      log({
+        kind: "pr-opened",
+        level: "info",
+        msg: `opened draft PR for #${outcome.ticket}: ${prUrl}`,
+        ticket: outcome.ticket,
+        prUrl,
+      });
+    }
     if (outcome.costOverrun && outcome.costUsd !== undefined) {
-      log(
-        `cost overrun on #${outcome.ticket}: attempt ${outcome.attempt} spent $${outcome.costUsd.toFixed(2)} — the ticket may be cut too big for one Worker`,
-      );
+      log({
+        kind: "cost-overrun",
+        level: "warn",
+        msg: `cost overrun on #${outcome.ticket}: attempt ${outcome.attempt} spent $${outcome.costUsd.toFixed(2)} — the ticket may be cut too big for one Worker`,
+        ticket: outcome.ticket,
+        attempt: outcome.attempt,
+        costUsd: outcome.costUsd,
+      });
     }
     if (outcome.infra !== undefined) {
       await voidAttempt(
@@ -190,9 +245,14 @@ export async function act(
         },
         exec,
       );
-      log(
-        `voided attempt ${outcome.attempt} of #${outcome.ticket} (${outcome.infra}); claim held`,
-      );
+      log({
+        kind: "attempt-voided",
+        level: "warn",
+        msg: `voided attempt ${outcome.attempt} of #${outcome.ticket} (${outcome.infra}); claim held`,
+        ticket: outcome.ticket,
+        attempt: outcome.attempt,
+        reason: outcome.infra,
+      });
     } else if (outcome.failure) {
       await releaseFailedTicket(
         outcome.ticket,
@@ -205,9 +265,14 @@ export async function act(
         },
         exec,
       );
-      log(
-        `released #${outcome.ticket} with the attempt record (failed attempt ${outcome.attempt})`,
-      );
+      log({
+        kind: "attempt-released",
+        level: "info",
+        msg: `released #${outcome.ticket} with the attempt record (failed attempt ${outcome.attempt})`,
+        ticket: outcome.ticket,
+        attempt: outcome.attempt,
+        reason: outcome.failure,
+      });
     }
   }
   // Conflict Workers settle alongside the dispatch Workers: a resolved merge is
@@ -218,13 +283,29 @@ export async function act(
   for (const result of settledConflicts) {
     if (result.status !== "fulfilled") continue;
     const outcome = result.value;
-    log(describeConflict(outcome));
+    log({
+      kind: "conflict-outcome",
+      level: outcome.resolved ? "info" : "warn",
+      msg: describeConflict(outcome),
+      pr: outcome.pr,
+      resolved: outcome.resolved,
+    });
     if (outcome.resolved) {
       await pushAgentBranch(outcome.headRef, exec);
-      log(`pushed the resolved rebase for PR #${outcome.pr}`);
+      log({
+        kind: "conflict-pushed",
+        level: "info",
+        msg: `pushed the resolved rebase for PR #${outcome.pr}`,
+        pr: outcome.pr,
+      });
     } else {
       await commentConflictUnresolved(outcome.pr, exec);
-      log(`asked for human resolution on PR #${outcome.pr}`);
+      log({
+        kind: "conflict-unresolved",
+        level: "warn",
+        msg: `asked for human resolution on PR #${outcome.pr}`,
+        pr: outcome.pr,
+      });
     }
   }
 

--- a/src/app/run.ts
+++ b/src/app/run.ts
@@ -4,6 +4,7 @@ import {
   probeDue,
   tripBreaker,
 } from "../core/breaker.js";
+import type { Log } from "../core/log.js";
 import { dispatchableSet } from "../core/plan.js";
 import { renderComplete, renderStuck } from "../core/render.js";
 import type { Action, Ticket, WorldSnapshot } from "../core/types.js";
@@ -73,7 +74,7 @@ export interface RunDeps {
   probe: () => Promise<boolean>;
   now: () => number;
   sleep: (ms: number) => Promise<void>;
-  log: (line: string) => void;
+  log: Log;
 }
 
 export async function run(
@@ -85,14 +86,21 @@ export async function run(
     if (breaker !== undefined && probeDue(breaker, deps.now())) {
       if (await deps.probe()) {
         breaker = undefined;
-        deps.log(
-          "circuit breaker closed: the environment recovered — dispatch resumes.",
-        );
+        deps.log({
+          kind: "breaker-closed",
+          level: "info",
+          msg: "circuit breaker closed: the environment recovered — dispatch resumes.",
+        });
       } else {
         breaker = tripBreaker(breaker, deps.now());
-        deps.log(
-          `circuit breaker still open: the probe failed — next probe in ${Math.round(breakerCooldownMs(breaker.trips) / 60_000)}m.`,
-        );
+        const nextProbeMs = breakerCooldownMs(breaker.trips);
+        deps.log({
+          kind: "breaker-still-open",
+          level: "warn",
+          msg: `circuit breaker still open: the probe failed — next probe in ${Math.round(nextProbeMs / 60_000)}m.`,
+          trips: breaker.trips,
+          nextProbeMs,
+        });
       }
     }
     const { world, actions, infraFailures } = await deps.tick(
@@ -100,20 +108,38 @@ export async function run(
     );
     if (infraFailures > 0) {
       breaker = tripBreaker(breaker, deps.now());
-      deps.log(
-        `circuit breaker open: ${infraFailures} infrastructure failure${infraFailures === 1 ? "" : "s"} this Tick — dispatch paused, claims held, probing in ${Math.round(breakerCooldownMs(breaker.trips) / 60_000)}m.`,
-      );
+      const nextProbeMs = breakerCooldownMs(breaker.trips);
+      deps.log({
+        kind: "breaker-open",
+        level: "warn",
+        msg: `circuit breaker open: ${infraFailures} infrastructure failure${infraFailures === 1 ? "" : "s"} this Tick — dispatch paused, claims held, probing in ${Math.round(nextProbeMs / 60_000)}m.`,
+        infraFailures,
+        nextProbeMs,
+      });
     }
     const status = runStatus(world, actions, breaker !== undefined);
     if (status.state === "complete") {
-      deps.log(renderComplete(world.tickets));
+      deps.log({
+        kind: "complete-report",
+        level: "info",
+        msg: renderComplete(world.tickets),
+      });
       return "complete";
     }
     if (status.state === "stuck") {
-      deps.log(renderStuck(world));
+      deps.log({
+        kind: "stuck-report",
+        level: "warn",
+        msg: renderStuck(world),
+      });
       return "stuck";
     }
-    deps.log(`Next Tick in ${pollSeconds}s.`);
+    deps.log({
+      kind: "next-tick",
+      level: "info",
+      msg: `Next Tick in ${pollSeconds}s.`,
+      pollSeconds,
+    });
     await deps.sleep(pollSeconds * 1000);
   }
 }

--- a/src/app/tick.ts
+++ b/src/app/tick.ts
@@ -2,6 +2,7 @@ import { openPrForOutcome } from "../adapters/pr.js";
 import { readScope, realExec } from "../adapters/tracker.js";
 import { dispatchConflictWorker, dispatchWorker } from "../adapters/worker.js";
 import { modelForAttempt, type ResolvedConfig } from "../core/config.js";
+import type { Log } from "../core/log.js";
 import { plan } from "../core/plan.js";
 import { renderPlan } from "../core/render.js";
 import type { Action, WorldSnapshot } from "../core/types.js";
@@ -12,7 +13,7 @@ export async function tickOnce(
   config: ResolvedConfig,
   dryRun: boolean,
   dispatchPaused = false,
-  log: (line: string) => void,
+  log: Log,
 ): Promise<{ world: WorldSnapshot; actions: Action[]; infraFailures: number }> {
   const world = await readScope(config.scope);
   const actions = plan(world, {
@@ -20,7 +21,11 @@ export async function tickOnce(
     maxOpenPrs: config.maxOpenPrs,
     dispatchPaused,
   });
-  log(renderPlan(config, world, actions, { dryRun, dispatchPaused }));
+  log({
+    kind: "plan-report",
+    level: "info",
+    msg: renderPlan(config, world, actions, { dryRun, dispatchPaused }),
+  });
   let infraFailures = 0;
   if (!dryRun) {
     const titles = new Map(world.tickets.map((t) => [t.number, t.title]));

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -1,4 +1,5 @@
 import type { CommandContext, StricliProcess } from "@stricli/core";
+import { Logger } from "tslog";
 import { loadConfigFile } from "../adapters/config-file.js";
 import { probeEnvironment } from "../adapters/worker.js";
 import { tickOnce } from "../app/tick.js";
@@ -7,6 +8,7 @@ import {
   type ResolvedConfig,
   resolveConfig,
 } from "../core/config.js";
+import type { Log } from "../core/log.js";
 import type { Action, WorldSnapshot } from "../core/types.js";
 
 /** Every effect a command handler needs, injected so handlers never import them directly. */
@@ -25,6 +27,8 @@ export interface Context extends CommandContext {
   readonly probe: (model: string) => Promise<boolean>;
   readonly now: () => number;
   readonly sleep: (ms: number) => Promise<void>;
+  /** The single logging seam narration travels through; see src/core/log.ts. */
+  readonly log: Log;
 }
 
 /**
@@ -47,18 +51,31 @@ function nodeProcessAdapter(): StricliProcess {
   };
 }
 
+/**
+ * Console sink for the Orchestrator's narration: pretty, colored, leveled,
+ * timestamped, at a minimum level of `info`. Code-position and stack capture
+ * are disabled — this is domain narration, not application debugging. Color
+ * (and `NO_COLOR`/`FORCE_COLOR`) and TTY detection are handled by tslog
+ * itself. Constructed only here: `core` and `app` never import the library,
+ * they only see the `Log` function type.
+ */
+function buildLog(): Log {
+  const logger = new Logger({ minLevel: "INFO", stack: { capture: "off" } });
+  return (event) => logger[event.level](event.msg);
+}
+
 /** The real context: today's collaborators, wired exactly as the entry point wired them before. */
 export function buildRealContext(): Context {
   const cliProcess = nodeProcessAdapter();
+  const log = buildLog();
   return {
     process: cliProcess,
     loadConfig: (flags) => resolveConfig(loadConfigFile(process.cwd()), flags),
     tick: (config, dryRun, dispatchPaused) =>
-      tickOnce(config, dryRun, dispatchPaused, (line) =>
-        cliProcess.stdout.write(`${line}\n`),
-      ),
+      tickOnce(config, dryRun, dispatchPaused, log),
     probe: (model) => probeEnvironment(model),
     now: () => Date.now(),
     sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    log,
   };
 }

--- a/src/cli/run-command.ts
+++ b/src/cli/run-command.ts
@@ -22,7 +22,7 @@ async function runHandler(
     probe: () => this.probe(config.model),
     now: this.now,
     sleep: this.sleep,
-    log: (line) => this.process.stdout.write(`${line}\n`),
+    log: this.log,
   });
   if (outcome === "stuck") {
     this.process.exitCode = 1;

--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -1,0 +1,62 @@
+import type { FailureReason, InfraReason, WorkerOutcome } from "./types.js";
+
+/**
+ * Level answers "does a human need to do something?", not "did something
+ * fail?" — a Ticket failure that will be retried is `info`, not a warning
+ * that reads as an alarm. Only these four are used; the console sink's
+ * additional levels above and below are deliberately left unused.
+ */
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+interface LogEventBase {
+  level: LogLevel;
+  /** Human sentence composed at the call site, where the domain meaning lives. */
+  msg: string;
+}
+
+/**
+ * One line the Orchestrator narrates, travelling through the single logging
+ * function injected into the run loop and the act phase's effects executor.
+ * The kind plus its per-kind fields exist so a sink can render or query the
+ * event structurally; the console sink (wired in the composition root) reads
+ * only `level` and `msg`.
+ */
+export type LogEvent = LogEventBase &
+  (
+    | { kind: "claim"; ticket: number }
+    | { kind: "release"; ticket: number }
+    | { kind: "escalate"; ticket: number }
+    | { kind: "close"; ticket: number; prUrl: string }
+    | { kind: "update-branch"; pr: number }
+    | { kind: "mark-ready"; pr: number }
+    | { kind: "conflict-dispatch"; pr: number; ticket: number }
+    | { kind: "spawn"; ticket: number; attempt: number }
+    | { kind: "worker-outcome"; outcome: WorkerOutcome }
+    | { kind: "pr-opened"; ticket: number; prUrl: string }
+    | { kind: "cost-overrun"; ticket: number; attempt: number; costUsd: number }
+    | {
+        kind: "attempt-voided";
+        ticket: number;
+        attempt: number;
+        reason: InfraReason;
+      }
+    | {
+        kind: "attempt-released";
+        ticket: number;
+        attempt: number;
+        reason: FailureReason;
+      }
+    | { kind: "conflict-outcome"; pr: number; resolved: boolean }
+    | { kind: "conflict-pushed"; pr: number }
+    | { kind: "conflict-unresolved"; pr: number }
+    | { kind: "breaker-closed" }
+    | { kind: "breaker-still-open"; trips: number; nextProbeMs: number }
+    | { kind: "breaker-open"; infraFailures: number; nextProbeMs: number }
+    | { kind: "next-tick"; pollSeconds: number }
+    | { kind: "plan-report" }
+    | { kind: "stuck-report" }
+    | { kind: "complete-report" }
+  );
+
+/** The single logging seam injected into the run loop and the act phase's effects executor. */
+export type Log = (event: LogEvent) => void;

--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -33,6 +33,7 @@ export type LogEvent = LogEventBase &
     | { kind: "spawn"; ticket: number; attempt: number }
     | { kind: "worker-outcome"; outcome: WorkerOutcome }
     | { kind: "pr-opened"; ticket: number; prUrl: string }
+    | { kind: "pr-open-failed"; ticket: number }
     | { kind: "cost-overrun"; ticket: number; attempt: number; costUsd: number }
     | {
         kind: "attempt-voided";

--- a/tests/app/act.test.ts
+++ b/tests/app/act.test.ts
@@ -7,6 +7,7 @@ import {
   type DispatchWorker,
   type OpenPr,
 } from "../../src/app/act.js";
+import type { LogEvent } from "../../src/core/log.js";
 import {
   type AttemptFailure,
   attemptMarker,
@@ -24,6 +25,19 @@ function recordingExec(): { exec: Exec; calls: string[][] } {
     return "";
   };
   return { exec, calls };
+}
+
+/** Records emitted events; `msgs()` mirrors the old narration-line assertions. */
+function recordingLog(): {
+  log: (event: LogEvent) => void;
+  events: LogEvent[];
+} {
+  const events: LogEvent[] = [];
+  return { log: (event) => events.push(event), events };
+}
+
+function msgs(events: LogEvent[]): string[] {
+  return events.map((e) => e.msg);
 }
 
 const noDispatch: DispatchWorker = async (ticket) => {
@@ -86,7 +100,7 @@ describe("act", () => {
   it("executes releases and claims in plan order via the tracker", async () => {
     const { exec, calls } = recordingExec();
     const { openPr } = recordingOpenPr();
-    const lines: string[] = [];
+    const { log, events } = recordingLog();
 
     await act(
       [
@@ -98,7 +112,7 @@ describe("act", () => {
         openPr,
         dispatchConflict: noConflict,
         exec,
-        log: (line) => lines.push(line),
+        log,
       },
     );
 
@@ -122,13 +136,18 @@ describe("act", () => {
         expect.stringContaining(CLAIM_MARKER),
       ],
     ]);
-    expect(lines).toEqual(["released #4 (orphaned claim)", "claimed #9"]);
+    expect(events.map((e) => e.kind)).toEqual(["release", "claim"]);
+    expect(events.every((e) => e.level === "info")).toBe(true);
+    expect(msgs(events)).toEqual([
+      "released #4 (orphaned claim)",
+      "claimed #9",
+    ]);
   });
 
   it("closes a merged-but-open ticket via the tracker, linking the PR", async () => {
     const { exec, calls } = recordingExec();
     const { openPr } = recordingOpenPr();
-    const lines: string[] = [];
+    const { log, events } = recordingLog();
 
     await act(
       [{ type: "close", ticket: 6, prUrl: "https://github.com/o/r/pull/60" }],
@@ -137,7 +156,7 @@ describe("act", () => {
         openPr,
         dispatchConflict: noConflict,
         exec,
-        log: (line) => lines.push(line),
+        log,
       },
     );
 
@@ -151,8 +170,14 @@ describe("act", () => {
         expect.stringContaining("https://github.com/o/r/pull/60"),
       ],
     ]);
-    expect(lines).toEqual([
-      "closed #6 (merged: https://github.com/o/r/pull/60)",
+    expect(events).toEqual([
+      {
+        kind: "close",
+        level: "info",
+        msg: "closed #6 (merged: https://github.com/o/r/pull/60)",
+        ticket: 6,
+        prUrl: "https://github.com/o/r/pull/60",
+      },
     ]);
   });
 
@@ -174,7 +199,7 @@ describe("act", () => {
   it("runs spawned Workers concurrently, opens a PR per success, and reports each outcome", async () => {
     const { exec } = recordingExec();
     const { openPr, opened } = recordingOpenPr();
-    const lines: string[] = [];
+    const { log, events } = recordingLog();
     const dispatched: number[] = [];
     let bothInFlight!: () => void;
     const gate = new Promise<void>((resolve) => {
@@ -207,13 +232,35 @@ describe("act", () => {
         openPr,
         dispatchConflict: noConflict,
         exec,
-        log: (line) => lines.push(line),
+        log,
       },
     );
 
     expect(dispatched).toEqual([2, 4]);
     expect(opened).toEqual([2]); // only the success becomes a PR
-    expect(lines).toEqual([
+    expect(events.map((e) => e.kind)).toEqual([
+      "claim",
+      "spawn",
+      "claim",
+      "spawn",
+      "worker-outcome",
+      "pr-opened",
+      "worker-outcome",
+      "attempt-released",
+    ]);
+    // Success and a Ticket failure that will be retried are both info — the
+    // retry ladder working as designed must not read as an alarm.
+    expect(events.map((e) => e.level)).toEqual([
+      "info",
+      "info",
+      "info",
+      "info",
+      "info",
+      "info",
+      "info",
+      "info",
+    ]);
+    expect(msgs(events)).toEqual([
       "claimed #2",
       "spawned Worker for #2 (attempt 1)",
       "claimed #4",
@@ -292,9 +339,53 @@ describe("act", () => {
     expect(calls).toEqual([]);
   });
 
-  it("escalates: forensic comment, then the ready-for-agent → ready-for-human label swap", async () => {
+  it("assigns worker-outcome levels per the level table: success and a retried Ticket failure are info, an infrastructure failure is warn", async () => {
+    const cases: { outcome: WorkerOutcome; level: "info" | "warn" }[] = [
+      { outcome: outcome(2), level: "info" },
+      {
+        outcome: outcome(4, {
+          exitCode: 1,
+          newCommits: 0,
+          failure: "nonzero-exit",
+          ok: false,
+        }),
+        level: "info",
+      },
+      {
+        outcome: outcome(6, {
+          exitCode: 1,
+          newCommits: 0,
+          infra: "network",
+          ok: false,
+        }),
+        level: "warn",
+      },
+    ];
+
+    for (const { outcome: scriptedOutcome, level } of cases) {
+      const { exec } = recordingExec();
+      const { log, events } = recordingLog();
+      const dispatch: DispatchWorker = async () => scriptedOutcome;
+
+      await act(
+        [{ type: "spawn", ticket: scriptedOutcome.ticket, attempt: 1 }],
+        {
+          dispatch,
+          openPr: recordingOpenPr().openPr,
+          dispatchConflict: noConflict,
+          exec,
+          log,
+        },
+      );
+
+      const workerOutcome = events.find((e) => e.kind === "worker-outcome");
+      expect(workerOutcome?.level).toBe(level);
+    }
+  });
+
+  it("escalates: forensic comment, then the ready-for-agent → ready-for-human label swap, logged at warn", async () => {
     const { exec, calls } = recordingExec();
-    const lines: string[] = [];
+    const { log, events } = recordingLog();
     const failures: AttemptFailure[] = [
       {
         attempt: 1,
@@ -310,7 +401,7 @@ describe("act", () => {
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
       exec,
-      log: (line) => lines.push(line),
+      log,
     });
 
     expect(calls).toEqual([
@@ -333,15 +424,20 @@ describe("act", () => {
         "ready-for-human",
       ],
     ]);
-    expect(lines).toEqual([
-      "escalated #5 to ready-for-human (attempts exhausted)",
+    expect(events).toEqual([
+      {
+        kind: "escalate",
+        level: "warn",
+        msg: "escalated #5 to ready-for-human (attempts exhausted)",
+        ticket: 5,
+      },
     ]);
   });
 
-  it("flags a cost overrun on a finished attempt while still opening its PR", async () => {
+  it("flags a cost overrun on a finished attempt while still opening its PR, logged at warn", async () => {
     const { exec, calls } = recordingExec();
     const { openPr, opened } = recordingOpenPr();
-    const lines: string[] = [];
+    const { log, events } = recordingLog();
     const dispatch: DispatchWorker = async () =>
       outcome(7, { costUsd: 25.5, turns: 80, costOverrun: true });
 
@@ -350,19 +446,21 @@ describe("act", () => {
       openPr,
       dispatchConflict: noConflict,
       exec,
-      log: (line) => lines.push(line),
+      log,
     });
 
     expect(opened).toEqual([7]); // the work is kept — discarding refunds nothing
     expect(calls).toEqual([]); // no tracker writes: not a failure
-    expect(lines).toContain(
+    const costOverrun = events.find((e) => e.kind === "cost-overrun");
+    expect(costOverrun?.level).toBe("warn");
+    expect(costOverrun?.msg).toBe(
       "cost overrun on #7: attempt 1 spent $25.50 — the ticket may be cut too big for one Worker",
     );
   });
 
-  it("voids an infrastructure-classified attempt: comment only, claim held, counted in the report", async () => {
+  it("voids an infrastructure-classified attempt: comment only, claim held, counted in the report, logged at warn", async () => {
     const { exec, calls } = recordingExec();
-    const lines: string[] = [];
+    const { log, events } = recordingLog();
     const dispatch: DispatchWorker = async () =>
       outcome(7, {
         exitCode: 1,
@@ -376,7 +474,7 @@ describe("act", () => {
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
       exec,
-      log: (line) => lines.push(line),
+      log,
     });
 
     expect(calls).toEqual([
@@ -390,12 +488,16 @@ describe("act", () => {
       ],
     ]);
     expect(report).toEqual({ infraFailures: 1 });
-    expect(lines).toContain("voided attempt 1 of #7 (usage-limit); claim held");
+    const voided = events.find((e) => e.kind === "attempt-voided");
+    expect(voided?.level).toBe("warn");
+    expect(voided?.msg).toBe(
+      "voided attempt 1 of #7 (usage-limit); claim held",
+    );
   });
 
   it("reclassifies several Workers failing the same way in one Tick as correlated infrastructure", async () => {
     const { exec, calls } = recordingExec();
-    const lines: string[] = [];
+    const { log, events } = recordingLog();
     const dispatch: DispatchWorker = async (ticket) =>
       outcome(ticket, {
         exitCode: 1,
@@ -414,7 +516,7 @@ describe("act", () => {
         openPr: recordingOpenPr().openPr,
         dispatchConflict: noConflict,
         exec,
-        log: (line) => lines.push(line),
+        log,
       },
     );
 
@@ -425,7 +527,9 @@ describe("act", () => {
     ]);
     expect(calls.every((c) => c[5]?.includes(VOID_MARKER))).toBe(true);
     expect(report).toEqual({ infraFailures: 2 });
-    expect(lines.join("\n")).toContain("correlated");
+    const workerOutcomes = events.filter((e) => e.kind === "worker-outcome");
+    expect(workerOutcomes.every((e) => e.level === "warn")).toBe(true);
+    expect(msgs(events).join("\n")).toContain("correlated");
   });
 
   it("reports zero infrastructure failures for a clean Tick", async () => {
@@ -446,7 +550,7 @@ describe("act", () => {
   it("still reports finished Workers when a sibling dispatch throws, then rethrows", async () => {
     const { exec } = recordingExec();
     const { openPr } = recordingOpenPr();
-    const lines: string[] = [];
+    const { log, events } = recordingLog();
     const dispatch: DispatchWorker = async (ticket) => {
       if (ticket === 4) throw new Error("git exploded");
       return outcome(ticket);
@@ -463,19 +567,19 @@ describe("act", () => {
           openPr,
           dispatchConflict: noConflict,
           exec,
-          log: (line) => lines.push(line),
+          log,
         },
       ),
     ).rejects.toThrow("git exploded");
 
-    expect(lines).toContain(
+    expect(msgs(events)).toContain(
       "Worker for #2 succeeded: 2 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
     );
   });
 
   it("still reports the Worker's outcome when PR opening fails, then rethrows", async () => {
     const { exec } = recordingExec();
-    const lines: string[] = [];
+    const { log, events } = recordingLog();
     const dispatch: DispatchWorker = async (ticket) => outcome(ticket);
     const openPr: OpenPr = async () => {
       throw new Error("gh pr create exploded");
@@ -487,11 +591,11 @@ describe("act", () => {
         openPr,
         dispatchConflict: noConflict,
         exec,
-        log: (line) => lines.push(line),
+        log,
       }),
     ).rejects.toThrow("gh pr create exploded");
 
-    expect(lines).toContain(
+    expect(msgs(events)).toContain(
       "Worker for #2 succeeded: 2 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
     );
   });
@@ -500,41 +604,53 @@ describe("act", () => {
 describe("act: PR upkeep", () => {
   it("mechanically updates a behind PR's branch via the tracker", async () => {
     const { exec, calls } = recordingExec();
-    const lines: string[] = [];
+    const { log, events } = recordingLog();
 
     await act([{ type: "update-branch", pr: 30, ticket: 3 }], {
       dispatch: noDispatch,
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
       exec,
-      log: (line) => lines.push(line),
+      log,
     });
 
     expect(calls).toEqual([["gh", "pr", "update-branch", "30", "--rebase"]]);
-    expect(lines).toEqual([
-      "updated PR #30 branch (mechanical rebase onto the base)",
+    expect(events).toEqual([
+      {
+        kind: "update-branch",
+        level: "info",
+        msg: "updated PR #30 branch (mechanical rebase onto the base)",
+        pr: 30,
+      },
     ]);
   });
 
   it("flips a green draft PR to ready for review via the tracker", async () => {
     const { exec, calls } = recordingExec();
-    const lines: string[] = [];
+    const { log, events } = recordingLog();
 
     await act([{ type: "mark-ready", pr: 30, ticket: 3 }], {
       dispatch: noDispatch,
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
       exec,
-      log: (line) => lines.push(line),
+      log,
     });
 
     expect(calls).toEqual([["gh", "pr", "ready", "30"]]);
-    expect(lines).toEqual(["marked PR #30 ready for review"]);
+    expect(events).toEqual([
+      {
+        kind: "mark-ready",
+        level: "info",
+        msg: "marked PR #30 ready for review",
+        pr: 30,
+      },
+    ]);
   });
 
   it("pushes the branch when the conflict Worker resolves the merge", async () => {
     const { exec, calls } = recordingExec();
-    const lines: string[] = [];
+    const { log, events } = recordingLog();
     const dispatchConflict: DispatchConflictWorker = async (
       pr,
       ticket,
@@ -555,23 +671,29 @@ describe("act: PR upkeep", () => {
         openPr: recordingOpenPr().openPr,
         dispatchConflict,
         exec,
-        log: (line) => lines.push(line),
+        log,
       },
     );
 
     expect(calls).toEqual([
       ["git", "push", "--force", "origin", "border-collie/ticket-3-attempt-1"],
     ]);
-    expect(lines).toEqual([
+    expect(events.map((e) => e.kind)).toEqual([
+      "conflict-dispatch",
+      "conflict-outcome",
+      "conflict-pushed",
+    ]);
+    expect(events.every((e) => e.level === "info")).toBe(true);
+    expect(msgs(events)).toEqual([
       "dispatched conflict Worker for PR #30 (ticket #3)",
       "Conflict Worker for PR #30 resolved the conflicts on border-collie/ticket-3-attempt-1 (transcript: .border-collie/transcripts/pr-30-conflict.jsonl)",
       "pushed the resolved rebase for PR #30",
     ]);
   });
 
-  it("asks for human resolution when the conflict Worker gives up (no push)", async () => {
+  it("asks for human resolution when the conflict Worker gives up (no push), logged at warn", async () => {
     const { exec, calls } = recordingExec();
-    const lines: string[] = [];
+    const { log, events } = recordingLog();
     const dispatchConflict: DispatchConflictWorker = async (
       pr,
       ticket,
@@ -592,7 +714,7 @@ describe("act: PR upkeep", () => {
         openPr: recordingOpenPr().openPr,
         dispatchConflict,
         exec,
-        log: (line) => lines.push(line),
+        log,
       },
     );
 
@@ -606,7 +728,13 @@ describe("act: PR upkeep", () => {
         expect.stringContaining(CONFLICT_UNRESOLVED_MARKER),
       ],
     ]);
-    expect(lines).toEqual([
+    expect(events.map((e) => e.kind)).toEqual([
+      "conflict-dispatch",
+      "conflict-outcome",
+      "conflict-unresolved",
+    ]);
+    expect(events.map((e) => e.level)).toEqual(["info", "warn", "warn"]);
+    expect(msgs(events)).toEqual([
       "dispatched conflict Worker for PR #30 (ticket #3)",
       "Conflict Worker for PR #30 could not resolve the conflicts (exit 1) on border-collie/ticket-3-attempt-1 (transcript: .border-collie/transcripts/pr-30-conflict.jsonl)",
       "asked for human resolution on PR #30",
@@ -615,7 +743,7 @@ describe("act: PR upkeep", () => {
 
   it("runs conflict Workers concurrently with dispatch Workers and reports both", async () => {
     const { exec } = recordingExec();
-    const lines: string[] = [];
+    const { log, events } = recordingLog();
     const inFlight: string[] = [];
     let bothInFlight!: () => void;
     const gate = new Promise<void>((resolve) => {
@@ -653,20 +781,20 @@ describe("act: PR upkeep", () => {
         openPr: recordingOpenPr().openPr,
         dispatchConflict,
         exec,
-        log: (line) => lines.push(line),
+        log,
       },
     );
 
     expect(inFlight.sort()).toEqual(["conflict-40", "worker-2"]);
-    expect(lines).toContain("pushed the resolved rebase for PR #40");
-    expect(lines).toContain(
+    expect(msgs(events)).toContain("pushed the resolved rebase for PR #40");
+    expect(msgs(events)).toContain(
       "Worker for #2 succeeded: 2 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
     );
   });
 
   it("reports settled Workers before rethrowing a conflict Worker's infrastructure failure", async () => {
     const { exec } = recordingExec();
-    const lines: string[] = [];
+    const { log, events } = recordingLog();
     const dispatch: DispatchWorker = async (ticket) => outcome(ticket);
     const dispatchConflict: DispatchConflictWorker = async () => {
       throw new Error("claude ENOENT");
@@ -688,12 +816,12 @@ describe("act: PR upkeep", () => {
           openPr: recordingOpenPr().openPr,
           dispatchConflict,
           exec,
-          log: (line) => lines.push(line),
+          log,
         },
       ),
     ).rejects.toThrow("claude ENOENT");
 
-    expect(lines).toContain(
+    expect(msgs(events)).toContain(
       "Worker for #2 succeeded: 2 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
     );
   });

--- a/tests/app/act.test.ts
+++ b/tests/app/act.test.ts
@@ -577,7 +577,7 @@ describe("act", () => {
     );
   });
 
-  it("still reports the Worker's outcome when PR opening fails, then rethrows", async () => {
+  it("still reports the Worker's outcome when PR opening fails, then rethrows, logging the failure at error", async () => {
     const { exec } = recordingExec();
     const { log, events } = recordingLog();
     const dispatch: DispatchWorker = async (ticket) => outcome(ticket);
@@ -597,6 +597,11 @@ describe("act", () => {
 
     expect(msgs(events)).toContain(
       "Worker for #2 succeeded: 2 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
+    );
+    const prOpenFailed = events.find((e) => e.kind === "pr-open-failed");
+    expect(prOpenFailed?.level).toBe("error");
+    expect(prOpenFailed?.msg).toBe(
+      "PR opening failed for #2 after a successful Attempt: gh pr create exploded",
     );
   });
 });

--- a/tests/app/run.test.ts
+++ b/tests/app/run.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { type RunDeps, run, runStatus } from "../../src/app/run.js";
 import { BREAKER_BASE_COOLDOWN_MS } from "../../src/core/breaker.js";
+import type { LogEvent } from "../../src/core/log.js";
 import type {
   Action,
   MergedAgentPr,
@@ -138,14 +139,14 @@ function scriptedDeps(
   pausedFlags: boolean[];
   probes: number;
   sleeps: number[];
-  lines: string[];
+  events: LogEvent[];
 } {
   const state = {
     ticks: 0,
     pausedFlags: [] as boolean[],
     probes: 0,
     sleeps: [] as number[],
-    lines: [] as string[],
+    events: [] as LogEvent[],
     deps: {} as RunDeps,
   };
   let nowMs = 0;
@@ -170,8 +171,8 @@ function scriptedDeps(
       state.sleeps.push(ms);
       nowMs += opts.msPerSleep ?? ms;
     },
-    log: (line) => {
-      state.lines.push(line);
+    log: (event) => {
+      state.events.push(event);
     },
   };
   return state;
@@ -206,10 +207,10 @@ describe("run", () => {
 
     expect(outcome).toBe("complete");
     expect(state.sleeps).toEqual([]);
-    expect(state.lines.some((line) => line.includes("Complete"))).toBe(true);
+    expect(state.events.some((e) => e.kind === "complete-report")).toBe(true);
   });
 
-  it("logs a Complete summary report naming every ticket in Scope", async () => {
+  it("logs a Complete summary report naming every ticket in Scope, at info", async () => {
     const state = scriptedDeps([
       {
         world: world([
@@ -227,9 +228,10 @@ describe("run", () => {
 
     await run(30, state.deps);
 
-    const report = state.lines.join("\n");
-    expect(report).toContain("#2 — Walking skeleton");
-    expect(report).toContain("#7 — Hard one");
+    const report = state.events.find((e) => e.kind === "complete-report");
+    expect(report?.level).toBe("info");
+    expect(report?.msg).toContain("#2 — Walking skeleton");
+    expect(report?.msg).toContain("#7 — Hard one");
   });
 
   it("trips the breaker on infrastructure failure, ticks paused, and resumes when the probe passes", async () => {
@@ -258,8 +260,13 @@ describe("run", () => {
     expect(outcome).toBe("complete");
     expect(state.pausedFlags).toEqual([false, true, false]);
     expect(state.probes).toBe(1);
-    expect(state.lines.join("\n")).toContain("circuit breaker open");
-    expect(state.lines.join("\n")).toContain("dispatch resumes");
+    // Infrastructure failure is healthy-but-degraded, warn — not an alarm.
+    const open = state.events.find((e) => e.kind === "breaker-open");
+    expect(open?.level).toBe("warn");
+    expect(open).toMatchObject({ infraFailures: 1 });
+    // Recovery is the loop working again, info.
+    const closed = state.events.find((e) => e.kind === "breaker-closed");
+    expect(closed?.level).toBe("info");
   });
 
   it("re-trips on a failed probe and waits the doubled cooldown before probing again", async () => {
@@ -283,9 +290,12 @@ describe("run", () => {
     // t2; passes at t3 — so exactly two probes and three paused ticks.
     expect(state.probes).toBe(2);
     expect(state.pausedFlags).toEqual([false, true, true, false]);
+    const stillOpen = state.events.find((e) => e.kind === "breaker-still-open");
+    expect(stillOpen?.level).toBe("warn");
+    expect(stillOpen).toMatchObject({ trips: 2 });
   });
 
-  it("exits stuck with a report naming the open tickets", async () => {
+  it("exits stuck with a report naming the open tickets, at warn", async () => {
     const state = scriptedDeps([
       {
         world: world([
@@ -303,8 +313,26 @@ describe("run", () => {
 
     expect(outcome).toBe("stuck");
     expect(state.sleeps).toEqual([]);
-    expect(state.lines.join("\n")).toContain("Stuck");
-    expect(state.lines.join("\n")).toContain("#7");
+    const report = state.events.find((e) => e.kind === "stuck-report");
+    expect(report?.level).toBe("warn");
+    expect(report?.msg).toContain("#7");
+  });
+
+  it("logs the poll wait at info between ticks", async () => {
+    const inFlight = world(
+      [ticket({ number: 2, assignees: ["operator"], hasAgentClaim: true })],
+      [2],
+    );
+    const state = scriptedDeps([
+      { world: inFlight, actions: [] },
+      { world: world([ticket({ number: 2, state: "closed" })]), actions: [] },
+    ]);
+
+    await run(45, state.deps);
+
+    const nextTick = state.events.find((e) => e.kind === "next-tick");
+    expect(nextTick?.level).toBe("info");
+    expect(nextTick).toMatchObject({ pollSeconds: 45 });
   });
 
   it("resumes from tracker truth when re-run after a human fixes a Stuck state", async () => {

--- a/tests/cli/app.test.ts
+++ b/tests/cli/app.test.ts
@@ -7,6 +7,7 @@ import {
   type Flags,
   type ResolvedConfig,
 } from "../../src/core/config.js";
+import type { LogEvent } from "../../src/core/log.js";
 import type { Ticket, WorldSnapshot } from "../../src/core/types.js";
 
 function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
@@ -55,6 +56,7 @@ interface FakeContext {
     dispatchPaused: boolean | undefined;
   }[];
   probeCalls: string[];
+  events: LogEvent[];
 }
 
 function fakeContext(
@@ -72,6 +74,7 @@ function fakeContext(
     dispatchPaused: boolean | undefined;
   }[] = [];
   const probeCalls: string[] = [];
+  const events: LogEvent[] = [];
   const tickResults = overrides.tickResults ?? [{ world: CLOSED_WORLD }];
 
   const context: Context = {
@@ -103,6 +106,9 @@ function fakeContext(
     },
     now: () => 0,
     sleep: async () => {},
+    log: (event) => {
+      events.push(event);
+    },
   };
 
   return {
@@ -112,6 +118,7 @@ function fakeContext(
     loadConfigCalls,
     tickCalls,
     probeCalls,
+    events,
   };
 }
 

--- a/tests/cli/app.test.ts
+++ b/tests/cli/app.test.ts
@@ -252,20 +252,22 @@ describe("exit-code contract", () => {
     expect(fake.stdout()).toContain("Infrastructure failure detected");
   });
 
-  it("run exits 0 on Complete", async () => {
+  it("run exits 0 on Complete, narrating it through the injected log", async () => {
     const fake = fakeContext({ tickResults: [{ world: CLOSED_WORLD }] });
 
     await runCli(["run", "--parent", "1"], fake.context);
 
     expect(fake.context.process.exitCode).toBeFalsy();
+    expect(fake.events.some((e) => e.kind === "complete-report")).toBe(true);
   });
 
-  it("run exits 1 on Stuck", async () => {
+  it("run exits 1 on Stuck, narrating it through the injected log", async () => {
     const fake = fakeContext({ tickResults: [{ world: STUCK_WORLD }] });
 
     await runCli(["run", "--parent", "1"], fake.context);
 
     expect(fake.context.process.exitCode).toBe(1);
+    expect(fake.events.some((e) => e.kind === "stuck-report")).toBe(true);
   });
 
   it("a config error prints a one-line message and exits 1", async () => {


### PR DESCRIPTION
## Summary

- Add a `LogEvent`/`Log` type to `core` (`src/core/log.ts`): every event carries a `kind`, a `level` (`debug`/`info`/`warn`/`error`), a composed `msg`, and per-kind structured fields. Only `core`/`app` see this type; the logging library itself stays out of both.
- Convert the run loop (`src/app/run.ts`) and the act phase's effects executor (`src/app/act.ts`) — plus `tickOnce`'s plan-report line — from narrating raw strings through their injected `log` to emitting structured `LogEvent`s. Levels follow the table in #47: claim/release/spawn/close/mark-ready/branch-update/Worker-succeeded/**Worker-failed-an-Attempt**/next-Tick/Complete are `info`; Escalation, Conflict-Worker-unresolved, Infrastructure-failure, circuit-breaker-open, cost-overrun, and Stuck are `warn`.
- Wire `tslog@5.1.0` (pinned exact, not a caret range) as the console sink, constructed only in the composition root (`src/cli/context.ts`): pretty, colored, leveled, timestamped, minimum level `info`, code-position/stack capture disabled. Color suppression and `NO_COLOR`/`FORCE_COLOR` are handled by the library itself (verified manually under a real TTY, piped, and with `NO_COLOR=1`); both narration and reports stay on stdout (tslog's default level→console-method mapping is `console.log` for every level).
- Add a `Context.log: Log` field, built once alongside the console logger, so `run`'s own narration (breaker, next-Tick, reports) and `tick`'s narration (plan, act) travel through the same injected seam instead of two independently-constructed stdout writers.
- Add a `biome.json` `noRestrictedImports` rule blocking `tslog` from `core`, `adapters`, and `app`, mirroring the existing layer-boundary rules — verified it actually fires by temporarily adding a violating import and reverting.
- Closed the one gap the level table left unimplemented: PR opening that fails after a successful Attempt is one of the table's named `error` examples, and `act()` already rethrows on that path — it now logs an `error` event first.
- Rewrote `tests/app/run.test.ts` and `tests/app/act.test.ts` to assert on event kinds and levels (including the level table's easy-to-get-wrong assignments: a retried Ticket failure at `info`, Escalation/Infrastructure-failure/cost-overrun/Conflict-Worker-unresolved at `warn`) instead of matching substrings of narration prose.

Deliberately out of scope (later tickets in the set): the durable JSON log file (#50), per-Worker sub-logger correlation (#51), the report data/text split (#52), debug-level instrumentation and the verbosity flag (#53), and the Worker heartbeat (#54). The standalone `tick` command's own "Infrastructure failure detected" notice (`src/cli/tick-command.ts`) is left as a plain stdout write — it predates this change and sits outside the run loop and effects executor, which is what this ticket's acceptance criteria scope the seam change to.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 269/269 passing
- [x] `pnpm build` — clean
- [x] Manually verified `tslog` wiring end-to-end against the real composition root: leveled/colored/timestamped output on a real TTY, color suppressed when piped and under `NO_COLOR=1`, `debug` filtered below the `info` floor, `warn`/`error` land on stdout (not stderr)
- [x] Ran `tick --dry-run` against this repo's own live Scope through the real CLI entry point to confirm the wired-up pipeline renders correctly end to end
- [x] Confirmed `tslog` does not appear anywhere in the test suite (`grep -rn tslog tests/`)
- [x] Reviewed via `/code-review` (Standards + Spec axes): fixed the missing `error`-level event and dead test scaffolding it surfaced; the remaining findings (call-site verbosity inherent to the discriminated-union design, and the type declaring `debug`/`error` ahead of later tickets using them) were judged intentional

Closes #49.