### PR TITLE
feat(render): reports as structured events

### DIFF
--- a/src/app/run.ts
+++ b/src/app/run.ts
@@ -6,7 +6,7 @@ import {
 } from "../core/breaker.js";
 import type { Log } from "../core/log.js";
 import { dispatchableSet } from "../core/plan.js";
-import { renderComplete, renderStuck } from "../core/render.js";
+import { buildCompleteReport, buildStuckReport } from "../core/render.js";
 import type { Action, Ticket, WorldSnapshot } from "../core/types.js";
 
 /**
@@ -119,18 +119,22 @@ export async function run(
     }
     const status = runStatus(world, actions, breaker !== undefined);
     if (status.state === "complete") {
+      const completeReport = buildCompleteReport(world.tickets);
       deps.log({
         kind: "complete-report",
         level: "info",
-        msg: renderComplete(world.tickets),
+        msg: "run complete",
+        report: completeReport,
       });
       return "complete";
     }
     if (status.state === "stuck") {
+      const stuckReport = buildStuckReport(world);
       deps.log({
         kind: "stuck-report",
         level: "warn",
-        msg: renderStuck(world),
+        msg: "run stuck",
+        report: stuckReport,
       });
       return "stuck";
     }

--- a/src/app/tick.ts
+++ b/src/app/tick.ts
@@ -4,7 +4,7 @@ import { dispatchConflictWorker, dispatchWorker } from "../adapters/worker.js";
 import { modelForAttempt, type ResolvedConfig } from "../core/config.js";
 import type { Log } from "../core/log.js";
 import { plan } from "../core/plan.js";
-import { renderPlan } from "../core/render.js";
+import { buildPlanReport } from "../core/render.js";
 import type { Action, WorldSnapshot } from "../core/types.js";
 import { act } from "./act.js";
 
@@ -21,10 +21,15 @@ export async function tickOnce(
     maxOpenPrs: config.maxOpenPrs,
     dispatchPaused,
   });
+  const planReport = buildPlanReport(config, world, actions, {
+    dryRun,
+    dispatchPaused,
+  });
   log({
     kind: "plan-report",
     level: "info",
-    msg: renderPlan(config, world, actions, { dryRun, dispatchPaused }),
+    msg: "dispatch plan",
+    report: planReport,
   });
   let infraFailures = 0;
   if (!dryRun) {

--- a/src/cli/console-report.ts
+++ b/src/cli/console-report.ts
@@ -1,0 +1,26 @@
+import type { LogEvent } from "../core/log.js";
+import {
+  renderCompleteReport,
+  renderPlanReport,
+  renderStuckReport,
+} from "../core/render.js";
+
+/**
+ * The console formatter's dispatch on a report event's kind: the familiar
+ * unadorned text block, with no level or timestamp prefix bolted onto a
+ * table. Null for every other kind, which the leveled console logger renders
+ * instead. Kept free of the logging library so the dispatch itself is
+ * testable without it.
+ */
+export function reportBlockText(event: LogEvent): string | null {
+  switch (event.kind) {
+    case "plan-report":
+      return renderPlanReport(event.report);
+    case "stuck-report":
+      return renderStuckReport(event.report);
+    case "complete-report":
+      return renderCompleteReport(event.report);
+    default:
+      return null;
+  }
+}

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -10,6 +10,7 @@ import {
 } from "../core/config.js";
 import type { Log } from "../core/log.js";
 import type { Action, WorldSnapshot } from "../core/types.js";
+import { reportBlockText } from "./console-report.js";
 
 /** Every effect a command handler needs, injected so handlers never import them directly. */
 export interface Context extends CommandContext {
@@ -58,16 +59,28 @@ function nodeProcessAdapter(): StricliProcess {
  * (and `NO_COLOR`/`FORCE_COLOR`) and TTY detection are handled by tslog
  * itself. Constructed only here: `core` and `app` never import the library,
  * they only see the `Log` function type.
+ *
+ * The three report kinds bypass tslog entirely: they print as the familiar
+ * unadorned block straight to the process's stdout, byte-identical to before
+ * structured logging existed — a report is read as a table, not narration,
+ * and a level/timestamp prefix would be bolted onto it.
  */
-function buildLog(): Log {
+function buildLog(cliProcess: StricliProcess): Log {
   const logger = new Logger({ minLevel: "INFO", stack: { capture: "off" } });
-  return (event) => logger[event.level](event.msg);
+  return (event) => {
+    const block = reportBlockText(event);
+    if (block !== null) {
+      cliProcess.stdout.write(`${block}\n`);
+      return;
+    }
+    logger[event.level](event.msg);
+  };
 }
 
 /** The real context: today's collaborators, wired exactly as the entry point wired them before. */
 export function buildRealContext(): Context {
   const cliProcess = nodeProcessAdapter();
-  const log = buildLog();
+  const log = buildLog(cliProcess);
   return {
     process: cliProcess,
     loadConfig: (flags) => resolveConfig(loadConfigFile(process.cwd()), flags),

--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -1,3 +1,4 @@
+import type { CompleteReport, PlanReport, StuckReport } from "./render.js";
 import type { FailureReason, InfraReason, WorkerOutcome } from "./types.js";
 
 /**
@@ -18,8 +19,9 @@ interface LogEventBase {
  * One line the Orchestrator narrates, travelling through the single logging
  * function injected into the run loop and the act phase's effects executor.
  * The kind plus its per-kind fields exist so a sink can render or query the
- * event structurally; the console sink (wired in the composition root) reads
- * only `level` and `msg`.
+ * event structurally. The console sink (wired in the composition root) reads
+ * `level` and `msg` for narration; for the three report kinds it instead
+ * renders `report` as the familiar unadorned block, dispatching on `kind`.
  */
 export type LogEvent = LogEventBase &
   (
@@ -54,9 +56,9 @@ export type LogEvent = LogEventBase &
     | { kind: "breaker-still-open"; trips: number; nextProbeMs: number }
     | { kind: "breaker-open"; infraFailures: number; nextProbeMs: number }
     | { kind: "next-tick"; pollSeconds: number }
-    | { kind: "plan-report" }
-    | { kind: "stuck-report" }
-    | { kind: "complete-report" }
+    | { kind: "plan-report"; report: PlanReport }
+    | { kind: "stuck-report"; report: StuckReport }
+    | { kind: "complete-report"; report: CompleteReport }
   );
 
 /** The single logging seam injected into the run loop and the act phase's effects executor. */

--- a/src/core/render.ts
+++ b/src/core/render.ts
@@ -8,8 +8,83 @@ import {
   type WorldSnapshot,
 } from "./types.js";
 
-/** Render the dispatch plan as human-readable lines. Pure. */
-export function renderPlan(
+// ---------------------------------------------------------------------------
+// Dispatch plan report
+// ---------------------------------------------------------------------------
+
+/** Why dispatch is paused this Tick, or absent when it isn't. */
+export type PlanPausedReason =
+  | { kind: "breaker" }
+  | { kind: "max-open-prs"; openCount: number };
+
+/** One planned action, resolved to exactly the fields its console line needs. */
+export type PlanActionLine =
+  | { type: "claim"; ticket: number; title: string }
+  | { type: "release"; ticket: number; title: string }
+  | {
+      type: "spawn";
+      ticket: number;
+      title: string;
+      model: string;
+      attempt: number;
+    }
+  | { type: "escalate"; ticket: number; title: string }
+  | { type: "close"; ticket: number; title: string; prUrl: string }
+  | { type: "update-branch"; pr: number; title: string }
+  | { type: "conflict-worker"; pr: number; title: string }
+  | { type: "mark-ready"; pr: number; title: string };
+
+export interface PlanReport {
+  scopeLabel: string;
+  totalTickets: number;
+  openTickets: number;
+  /** Dispatchable ticket numbers, in the order they'd claim. */
+  dispatchable: number[];
+  paused: PlanPausedReason | null;
+  maxWorkers: number;
+  maxOpenPrs: number;
+  actions: PlanActionLine[];
+  dryRun: boolean;
+}
+
+function toPlanActionLine(
+  action: Action,
+  title: string,
+  config: ResolvedConfig,
+): PlanActionLine {
+  switch (action.type) {
+    case "claim":
+      return { type: "claim", ticket: action.ticket, title };
+    case "release":
+      return { type: "release", ticket: action.ticket, title };
+    case "spawn":
+      return {
+        type: "spawn",
+        ticket: action.ticket,
+        title,
+        model: modelForAttempt(config, action.attempt),
+        attempt: action.attempt,
+      };
+    case "escalate":
+      return { type: "escalate", ticket: action.ticket, title };
+    case "close":
+      return {
+        type: "close",
+        ticket: action.ticket,
+        title,
+        prUrl: action.prUrl,
+      };
+    case "update-branch":
+      return { type: "update-branch", pr: action.pr, title };
+    case "conflict-worker":
+      return { type: "conflict-worker", pr: action.pr, title };
+    case "mark-ready":
+      return { type: "mark-ready", pr: action.pr, title };
+  }
+}
+
+/** Build the dispatch plan report's data. Pure. */
+export function buildPlanReport(
   config: ResolvedConfig,
   world: WorldSnapshot,
   actions: Action[],
@@ -17,156 +92,244 @@ export function renderPlan(
     dryRun,
     dispatchPaused = false,
   }: { dryRun: boolean; dispatchPaused?: boolean },
-): string {
+): PlanReport {
   const { scope, maxWorkers, maxOpenPrs } = config;
-  const lines: string[] = [];
-  const open = world.tickets.filter((t) => t.state === "open").length;
   const scopeLabel =
     scope.kind === "parent"
       ? `sub-issues of #${scope.parent}`
       : "repo-wide (--all)";
-  lines.push(
-    `Scope: ${scopeLabel} — ${world.tickets.length} tickets (${open} open)`,
-  );
+  const dispatchable = dispatchableSet(world).map((ticket) => ticket.number);
 
-  const dispatchable = dispatchableSet(world);
-  if (dispatchable.length === 0) {
-    lines.push("Dispatchable: none");
-  } else {
-    lines.push(
-      `Dispatchable: ${dispatchable.map((t) => `#${t.number}`).join(", ")}`,
-    );
-  }
+  let paused: PlanPausedReason | null = null;
   if (dispatchPaused) {
-    lines.push(
-      "Dispatch paused: circuit breaker open (infrastructure failure), claims held",
-    );
+    paused = { kind: "breaker" };
   } else if (
     dispatchable.length > 0 &&
     world.openAgentPrs.length >= maxOpenPrs
   ) {
-    lines.push(
-      `Dispatch paused: ${world.openAgentPrs.length} open agent PRs at max_open_prs (${maxOpenPrs})`,
-    );
+    paused = { kind: "max-open-prs", openCount: world.openAgentPrs.length };
   }
 
   const titles = new Map(world.tickets.map((t) => [t.number, t.title]));
-  if (actions.length === 0) {
+  const actionLines = actions.map((action) =>
+    toPlanActionLine(action, titles.get(action.ticket) ?? "", config),
+  );
+
+  return {
+    scopeLabel,
+    totalTickets: world.tickets.length,
+    openTickets: world.tickets.filter((t) => t.state === "open").length,
+    dispatchable,
+    paused,
+    maxWorkers,
+    maxOpenPrs,
+    actions: actionLines,
+    dryRun,
+  };
+}
+
+function renderPlanActionLine(line: PlanActionLine): string {
+  switch (line.type) {
+    case "claim":
+      return `  claim #${line.ticket} — ${line.title}`;
+    case "release":
+      return `  release #${line.ticket} — ${line.title} (orphaned agent claim)`;
+    case "spawn":
+      return `  spawn Worker for #${line.ticket} — ${line.title} (model ${line.model}, attempt ${line.attempt})`;
+    case "escalate":
+      return `  escalate #${line.ticket} — ${line.title} (attempts exhausted → ready-for-human)`;
+    case "close":
+      return `  close #${line.ticket} — ${line.title} (merged: ${line.prUrl})`;
+    case "update-branch":
+      return `  update PR #${line.pr} — ${line.title} (behind base, mechanical rebase)`;
+    case "conflict-worker":
+      return `  conflict Worker for PR #${line.pr} — ${line.title} (resolve merge conflicts)`;
+    case "mark-ready":
+      return `  mark PR #${line.pr} ready — ${line.title} (CI green)`;
+  }
+}
+
+/** Render the dispatch plan report as the familiar unadorned text block. Pure. */
+export function renderPlanReport(report: PlanReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `Scope: ${report.scopeLabel} — ${report.totalTickets} tickets (${report.openTickets} open)`,
+  );
+
+  lines.push(
+    report.dispatchable.length === 0
+      ? "Dispatchable: none"
+      : `Dispatchable: ${report.dispatchable.map((n) => `#${n}`).join(", ")}`,
+  );
+
+  if (report.paused?.kind === "breaker") {
     lines.push(
-      `Plan (max_workers=${maxWorkers}, max_open_prs=${maxOpenPrs}): nothing to do`,
+      "Dispatch paused: circuit breaker open (infrastructure failure), claims held",
     );
-  } else {
-    lines.push(`Plan (max_workers=${maxWorkers}, max_open_prs=${maxOpenPrs}):`);
-    for (const action of actions) {
-      const title = titles.get(action.ticket) ?? "";
-      switch (action.type) {
-        case "claim":
-          lines.push(`  claim #${action.ticket} — ${title}`);
-          break;
-        case "release":
-          lines.push(
-            `  release #${action.ticket} — ${title} (orphaned agent claim)`,
-          );
-          break;
-        case "spawn":
-          lines.push(
-            `  spawn Worker for #${action.ticket} — ${title} (model ${modelForAttempt(
-              config,
-              action.attempt,
-            )}, attempt ${action.attempt})`,
-          );
-          break;
-        case "escalate":
-          lines.push(
-            `  escalate #${action.ticket} — ${title} (attempts exhausted → ready-for-human)`,
-          );
-          break;
-        case "close":
-          lines.push(
-            `  close #${action.ticket} — ${title} (merged: ${action.prUrl})`,
-          );
-          break;
-        case "update-branch":
-          lines.push(
-            `  update PR #${action.pr} — ${title} (behind base, mechanical rebase)`,
-          );
-          break;
-        case "conflict-worker":
-          lines.push(
-            `  conflict Worker for PR #${action.pr} — ${title} (resolve merge conflicts)`,
-          );
-          break;
-        case "mark-ready":
-          lines.push(`  mark PR #${action.pr} ready — ${title} (CI green)`);
-          break;
-      }
-    }
+  } else if (report.paused?.kind === "max-open-prs") {
+    lines.push(
+      `Dispatch paused: ${report.paused.openCount} open agent PRs at max_open_prs (${report.maxOpenPrs})`,
+    );
   }
 
-  if (dryRun) lines.push("Dry run: no writes performed.");
+  if (report.actions.length === 0) {
+    lines.push(
+      `Plan (max_workers=${report.maxWorkers}, max_open_prs=${report.maxOpenPrs}): nothing to do`,
+    );
+  } else {
+    lines.push(
+      `Plan (max_workers=${report.maxWorkers}, max_open_prs=${report.maxOpenPrs}):`,
+    );
+    lines.push(...report.actions.map(renderPlanActionLine));
+  }
+
+  if (report.dryRun) lines.push("Dry run: no writes performed.");
   return lines.join("\n");
 }
 
+// ---------------------------------------------------------------------------
+// Stuck report
+// ---------------------------------------------------------------------------
+
 /**
- * Why this open ticket cannot move without a human. Any assignee at a Stuck
- * exit is a human claim: agent claims are either orphans (released before the
- * exit) or backed by a PR (which keeps the run polling).
+ * Why one open ticket cannot move without a human, as structured data — "what
+ * blocked what" is answerable without parsing a rendered block.
  */
-function stuckReason(ticket: Ticket, inScope: Set<number>): string {
-  const reasons: string[] = [];
+export type StuckReasonDetail =
+  | { kind: "human-claim"; assignees: string[] }
+  | { kind: "ready-for-human" }
+  | { kind: "not-ready-for-agent" }
+  | { kind: "blocked-by"; blockers: { ticket: number; inScope: boolean }[] }
+  | { kind: "blocked-count"; count: number };
+
+export interface StuckTicketReport {
+  ticket: number;
+  title: string;
+  reasons: StuckReasonDetail[];
+}
+
+export interface StuckReport {
+  tickets: StuckTicketReport[];
+}
+
+/**
+ * Any assignee at a Stuck exit is a human claim: agent claims are either
+ * orphans (released before the exit) or backed by a PR (which keeps the run
+ * polling).
+ */
+function stuckReasons(
+  ticket: Ticket,
+  inScope: Set<number>,
+): StuckReasonDetail[] {
+  const reasons: StuckReasonDetail[] = [];
   if (ticket.assignees.length > 0) {
-    reasons.push(
-      `claimed by ${ticket.assignees.join(", ")} — a human claim, hands off`,
-    );
+    reasons.push({ kind: "human-claim", assignees: ticket.assignees });
   }
   if (ticket.labels.includes(READY_FOR_HUMAN)) {
-    reasons.push(`labelled ${READY_FOR_HUMAN}`);
+    reasons.push({ kind: "ready-for-human" });
   } else if (!ticket.labels.includes(READY_FOR_AGENT)) {
-    reasons.push(`not labelled ${READY_FOR_AGENT}`);
+    reasons.push({ kind: "not-ready-for-agent" });
   }
   if (ticket.openBlockers > 0) {
     // Blockers outside Scope are flagged: their tickets get no line of their
     // own in this report. The count is the fallback for an unread list.
     reasons.push(
       ticket.blockedBy.length > 0
-        ? `blocked by ${ticket.blockedBy
-            .map((n) => (inScope.has(n) ? `#${n}` : `#${n} (outside Scope)`))
-            .join(", ")}`
-        : `${ticket.openBlockers} open blocker${ticket.openBlockers === 1 ? "" : "s"}`,
+        ? {
+            kind: "blocked-by",
+            blockers: ticket.blockedBy.map((n) => ({
+              ticket: n,
+              inScope: inScope.has(n),
+            })),
+          }
+        : { kind: "blocked-count", count: ticket.openBlockers },
     );
   }
-  return reasons.join("; ") || "no path forward found";
+  return reasons;
 }
 
-/** Render the Stuck exit report: each remaining open ticket and exactly what it is stuck on. Pure. */
-export function renderStuck(world: WorldSnapshot): string {
+/** Build the Stuck exit report's data: each remaining open ticket and exactly what it is stuck on. Pure. */
+export function buildStuckReport(world: WorldSnapshot): StuckReport {
   const inScope = new Set(world.tickets.map((t) => t.number));
+  return {
+    tickets: world.tickets
+      .filter((ticket) => ticket.state === "open")
+      .map((ticket) => ({
+        ticket: ticket.number,
+        title: ticket.title,
+        reasons: stuckReasons(ticket, inScope),
+      })),
+  };
+}
+
+function renderStuckReasonText(reason: StuckReasonDetail): string {
+  switch (reason.kind) {
+    case "human-claim":
+      return `claimed by ${reason.assignees.join(", ")} — a human claim, hands off`;
+    case "ready-for-human":
+      return `labelled ${READY_FOR_HUMAN}`;
+    case "not-ready-for-agent":
+      return `not labelled ${READY_FOR_AGENT}`;
+    case "blocked-by":
+      return `blocked by ${reason.blockers
+        .map((b) =>
+          b.inScope ? `#${b.ticket}` : `#${b.ticket} (outside Scope)`,
+        )
+        .join(", ")}`;
+    case "blocked-count":
+      return `${reason.count} open blocker${reason.count === 1 ? "" : "s"}`;
+  }
+}
+
+/** Render the Stuck exit report as the familiar unadorned text block. Pure. */
+export function renderStuckReport(report: StuckReport): string {
   return [
     "Run Stuck: open tickets remain, but every path forward runs through a human.",
-    ...world.tickets
-      .filter((ticket) => ticket.state === "open")
-      .map(
-        (ticket) =>
-          `  #${ticket.number} — ${ticket.title} (${stuckReason(ticket, inScope)})`,
-      ),
+    ...report.tickets.map((ticket) => {
+      const reasonText =
+        ticket.reasons.map(renderStuckReasonText).join("; ") ||
+        "no path forward found";
+      return `  #${ticket.ticket} — ${ticket.title} (${reasonText})`;
+    }),
   ].join("\n");
 }
 
-/**
- * Render the Complete exit report: every ticket in Scope, closed. A closed
- * ticket still labelled ready-for-human went through Escalation and was
- * finished by a human — worth naming, as those are the tickets the fleet
- * could not do alone. Pure.
- */
-export function renderComplete(tickets: Ticket[]): string {
-  const count = `${tickets.length} ticket${tickets.length === 1 ? "" : "s"}`;
+// ---------------------------------------------------------------------------
+// Complete report
+// ---------------------------------------------------------------------------
+
+export interface CompleteTicketReport {
+  ticket: number;
+  title: string;
+  /** Closed after going through Escalation and being finished by a human. */
+  escalated: boolean;
+}
+
+export interface CompleteReport {
+  tickets: CompleteTicketReport[];
+}
+
+/** Build the Complete exit report's data: every ticket in Scope, closed. Pure. */
+export function buildCompleteReport(tickets: Ticket[]): CompleteReport {
+  return {
+    tickets: tickets.map((ticket) => ({
+      ticket: ticket.number,
+      title: ticket.title,
+      escalated: ticket.labels.includes(READY_FOR_HUMAN),
+    })),
+  };
+}
+
+/** Render the Complete exit report as the familiar unadorned text block. Pure. */
+export function renderCompleteReport(report: CompleteReport): string {
+  const count = `${report.tickets.length} ticket${report.tickets.length === 1 ? "" : "s"}`;
   return [
     `Run Complete: every ticket in Scope is closed (${count}).`,
-    ...tickets.map((ticket) => {
-      const escalated = ticket.labels.includes(READY_FOR_HUMAN)
+    ...report.tickets.map((ticket) => {
+      const escalated = ticket.escalated
         ? " (closed by a human after Escalation)"
         : "";
-      return `  #${ticket.number} — ${ticket.title}${escalated}`;
+      return `  #${ticket.ticket} — ${ticket.title}${escalated}`;
     }),
   ].join("\n");
 }

--- a/tests/app/run.test.ts
+++ b/tests/app/run.test.ts
@@ -228,10 +228,15 @@ describe("run", () => {
 
     await run(30, state.deps);
 
-    const report = state.events.find((e) => e.kind === "complete-report");
+    const report = state.events.find(
+      (e): e is Extract<LogEvent, { kind: "complete-report" }> =>
+        e.kind === "complete-report",
+    );
     expect(report?.level).toBe("info");
-    expect(report?.msg).toContain("#2 — Walking skeleton");
-    expect(report?.msg).toContain("#7 — Hard one");
+    expect(report?.report.tickets).toEqual([
+      { ticket: 2, title: "Walking skeleton", escalated: false },
+      { ticket: 7, title: "Hard one", escalated: true },
+    ]);
   });
 
   it("trips the breaker on infrastructure failure, ticks paused, and resumes when the probe passes", async () => {
@@ -313,9 +318,12 @@ describe("run", () => {
 
     expect(outcome).toBe("stuck");
     expect(state.sleeps).toEqual([]);
-    const report = state.events.find((e) => e.kind === "stuck-report");
+    const report = state.events.find(
+      (e): e is Extract<LogEvent, { kind: "stuck-report" }> =>
+        e.kind === "stuck-report",
+    );
     expect(report?.level).toBe("warn");
-    expect(report?.msg).toContain("#7");
+    expect(report?.report.tickets.map((t) => t.ticket)).toEqual([7]);
   });
 
   it("logs the poll wait at info between ticks", async () => {

--- a/tests/cli/console-report.test.ts
+++ b/tests/cli/console-report.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { reportBlockText } from "../../src/cli/console-report.js";
+import type { LogEvent } from "../../src/core/log.js";
+import type {
+  CompleteReport,
+  PlanReport,
+  StuckReport,
+} from "../../src/core/render.js";
+import {
+  renderCompleteReport,
+  renderPlanReport,
+  renderStuckReport,
+} from "../../src/core/render.js";
+
+const PLAN_REPORT: PlanReport = {
+  scopeLabel: "sub-issues of #1",
+  totalTickets: 1,
+  openTickets: 1,
+  dispatchable: [2],
+  paused: null,
+  maxWorkers: 3,
+  maxOpenPrs: 5,
+  actions: [{ type: "claim", ticket: 2, title: "Walking skeleton" }],
+  dryRun: true,
+};
+
+const STUCK_REPORT: StuckReport = {
+  tickets: [
+    { ticket: 7, title: "Escalated", reasons: [{ kind: "ready-for-human" }] },
+  ],
+};
+
+const COMPLETE_REPORT: CompleteReport = {
+  tickets: [{ ticket: 2, title: "Walking skeleton", escalated: false }],
+};
+
+describe("reportBlockText", () => {
+  it("renders a plan-report event as the plan's unadorned text block", () => {
+    const event: LogEvent = {
+      kind: "plan-report",
+      level: "info",
+      msg: "dispatch plan",
+      report: PLAN_REPORT,
+    };
+
+    expect(reportBlockText(event)).toBe(renderPlanReport(PLAN_REPORT));
+  });
+
+  it("renders a stuck-report event as the Stuck report's unadorned text block", () => {
+    const event: LogEvent = {
+      kind: "stuck-report",
+      level: "warn",
+      msg: "run stuck",
+      report: STUCK_REPORT,
+    };
+
+    expect(reportBlockText(event)).toBe(renderStuckReport(STUCK_REPORT));
+  });
+
+  it("renders a complete-report event as the Complete report's unadorned text block", () => {
+    const event: LogEvent = {
+      kind: "complete-report",
+      level: "info",
+      msg: "run complete",
+      report: COMPLETE_REPORT,
+    };
+
+    expect(reportBlockText(event)).toBe(renderCompleteReport(COMPLETE_REPORT));
+  });
+
+  it("returns null for narration events, leaving them to the leveled console logger", () => {
+    const event: LogEvent = {
+      kind: "next-tick",
+      level: "info",
+      msg: "Next Tick in 30s.",
+      pollSeconds: 30,
+    };
+
+    expect(reportBlockText(event)).toBeNull();
+  });
+});

--- a/tests/core/render.test.ts
+++ b/tests/core/render.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from "vitest";
 import type { ResolvedConfig } from "../../src/core/config.js";
-import { plan } from "../../src/core/plan.js";
 import {
-  renderComplete,
-  renderPlan,
-  renderStuck,
+  buildCompleteReport,
+  buildPlanReport,
+  buildStuckReport,
+  type CompleteReport,
+  type PlanReport,
+  renderCompleteReport,
+  renderPlanReport,
+  renderStuckReport,
+  type StuckReport,
 } from "../../src/core/render.js";
 import type {
+  Action,
   OpenAgentPr,
   Ticket,
   WorldSnapshot,
@@ -57,7 +63,11 @@ function config(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
   };
 }
 
-describe("renderPlan", () => {
+function stuckWorld(tickets: Ticket[]): WorldSnapshot {
+  return { tickets, openAgentPrs: [], mergedAgentPrs: [] };
+}
+
+describe("buildPlanReport", () => {
   const world: WorldSnapshot = {
     tickets: [
       ticket({ number: 2, title: "Walking skeleton" }),
@@ -68,152 +78,188 @@ describe("renderPlan", () => {
     mergedAgentPrs: [],
   };
 
-  it("shows the scope, the dispatchable set, and the planned claims and spawns", () => {
-    const actions = plan(world, { maxWorkers: 3, maxOpenPrs: 5 });
+  it("computes the scope label, ticket totals, the dispatchable set, and carries dryRun", () => {
+    const report = buildPlanReport(config(), world, [], { dryRun: true });
 
-    expect(renderPlan(config(), world, actions, { dryRun: true })).toBe(
-      [
-        "Scope: sub-issues of #1 — 3 tickets (2 open)",
-        "Dispatchable: #2",
-        "Plan (max_workers=3, max_open_prs=5):",
-        "  claim #2 — Walking skeleton",
-        "  spawn Worker for #2 — Walking skeleton (model sonnet, attempt 1)",
-        "Dry run: no writes performed.",
-      ].join("\n"),
-    );
+    expect(report.scopeLabel).toBe("sub-issues of #1");
+    expect(report.totalTickets).toBe(3);
+    expect(report.openTickets).toBe(2);
+    expect(report.dispatchable).toEqual([2]);
+    expect(report.dryRun).toBe(true);
   });
 
-  it("says so when nothing is dispatchable", () => {
+  it("labels repo-wide scope for --all", () => {
     const empty: WorldSnapshot = {
       tickets: [],
       openAgentPrs: [],
       mergedAgentPrs: [],
     };
 
-    expect(
-      renderPlan(config({ scope: { kind: "all" } }), empty, [], {
-        dryRun: true,
-      }),
-    ).toBe(
-      [
-        "Scope: repo-wide (--all) — 0 tickets (0 open)",
-        "Dispatchable: none",
-        "Plan (max_workers=3, max_open_prs=5): nothing to do",
-        "Dry run: no writes performed.",
-      ].join("\n"),
+    const report = buildPlanReport(
+      config({ scope: { kind: "all" } }),
+      empty,
+      [],
+      { dryRun: true },
     );
+
+    expect(report.scopeLabel).toBe("repo-wide (--all)");
   });
 
-  it("shows planned releases and drops the dry-run footer when acting", () => {
-    const orphaned: WorldSnapshot = {
+  it("reports no pause when nothing throttles dispatch", () => {
+    const report = buildPlanReport(config(), world, [], { dryRun: true });
+
+    expect(report.paused).toBeNull();
+  });
+
+  it("reports a breaker pause while the circuit breaker holds dispatch", () => {
+    const report = buildPlanReport(config(), world, [], {
+      dryRun: false,
+      dispatchPaused: true,
+    });
+
+    expect(report.paused).toEqual({ kind: "breaker" });
+  });
+
+  it("reports a max_open_prs pause when dispatchable tickets wait on headroom", () => {
+    const throttled: WorldSnapshot = {
+      ...world,
+      openAgentPrs: [10, 11, 12, 13, 14].map(openPr),
+    };
+
+    const report = buildPlanReport(config(), throttled, [], {
+      dryRun: false,
+    });
+
+    expect(report.paused).toEqual({ kind: "max-open-prs", openCount: 5 });
+  });
+
+  it("does not report a pause when nothing is dispatchable, even at max_open_prs", () => {
+    const noDispatch: WorldSnapshot = {
+      tickets: [ticket({ number: 4, title: "Done already", state: "closed" })],
+      openAgentPrs: [10, 11, 12, 13, 14].map(openPr),
+      mergedAgentPrs: [],
+    };
+
+    const report = buildPlanReport(config(), noDispatch, [], {
+      dryRun: false,
+    });
+
+    expect(report.paused).toBeNull();
+  });
+
+  it("resolves every action kind to a structured line, including the retry-ladder model", () => {
+    const actionWorld: WorldSnapshot = {
       tickets: [
-        ticket({
-          number: 5,
-          title: "Stranded by a crash",
-          assignees: ["operator"],
-          hasAgentClaim: true,
-        }),
+        ticket({ number: 2, title: "Walking skeleton" }),
+        ticket({ number: 3, title: "Stranded" }),
+        ticket({ number: 4, title: "Failed twice" }),
+        ticket({ number: 5, title: "Merged but open" }),
+        ticket({ number: 6, title: "Behind base" }),
+        ticket({ number: 7, title: "Green draft" }),
       ],
       openAgentPrs: [],
       mergedAgentPrs: [],
     };
-    const actions = plan(orphaned, { maxWorkers: 3, maxOpenPrs: 5 });
+    const actions: Action[] = [
+      { type: "claim", ticket: 2 },
+      { type: "release", ticket: 3, assignees: ["operator"] },
+      { type: "spawn", ticket: 2, attempt: 2 },
+      { type: "escalate", ticket: 4, failures: [] },
+      { type: "close", ticket: 5, prUrl: "https://github.com/o/r/pull/50" },
+      { type: "update-branch", pr: 60, ticket: 6 },
+      {
+        type: "conflict-worker",
+        pr: 61,
+        ticket: 6,
+        headRef: "border-collie/ticket-6-attempt-1",
+      },
+      { type: "mark-ready", pr: 70, ticket: 7 },
+    ];
 
-    expect(renderPlan(config(), orphaned, actions, { dryRun: false })).toBe(
-      [
-        "Scope: sub-issues of #1 — 1 tickets (1 open)",
-        "Dispatchable: none",
-        "Plan (max_workers=3, max_open_prs=5):",
-        "  release #5 — Stranded by a crash (orphaned agent claim)",
-      ].join("\n"),
-    );
+    const report = buildPlanReport(config(), actionWorld, actions, {
+      dryRun: true,
+    });
+
+    expect(report.actions).toEqual([
+      { type: "claim", ticket: 2, title: "Walking skeleton" },
+      { type: "release", ticket: 3, title: "Stranded" },
+      {
+        type: "spawn",
+        ticket: 2,
+        title: "Walking skeleton",
+        model: "opus",
+        attempt: 2,
+      },
+      { type: "escalate", ticket: 4, title: "Failed twice" },
+      {
+        type: "close",
+        ticket: 5,
+        title: "Merged but open",
+        prUrl: "https://github.com/o/r/pull/50",
+      },
+      { type: "update-branch", pr: 60, title: "Behind base" },
+      { type: "conflict-worker", pr: 61, title: "Behind base" },
+      { type: "mark-ready", pr: 70, title: "Green draft" },
+    ]);
   });
 
-  it("shows the retry model on second attempts and planned escalations", () => {
-    const laddered: WorldSnapshot = {
-      tickets: [
-        ticket({ number: 6, title: "Failed once", agentClaimCount: 1 }),
-        ticket({ number: 7, title: "Failed twice", agentClaimCount: 2 }),
-      ],
-      openAgentPrs: [],
-      mergedAgentPrs: [],
-    };
-    const actions = plan(laddered, { maxWorkers: 3, maxOpenPrs: 5 });
-
-    expect(renderPlan(config(), laddered, actions, { dryRun: true })).toBe(
-      [
-        "Scope: sub-issues of #1 — 2 tickets (2 open)",
-        "Dispatchable: #6, #7",
-        "Plan (max_workers=3, max_open_prs=5):",
-        "  escalate #7 — Failed twice (attempts exhausted → ready-for-human)",
-        "  claim #6 — Failed once",
-        "  spawn Worker for #6 — Failed once (model opus, attempt 2)",
-        "Dry run: no writes performed.",
-      ].join("\n"),
+  it("falls back to an empty title when a ticket isn't in the world snapshot", () => {
+    const report = buildPlanReport(
+      config(),
+      { tickets: [], openAgentPrs: [], mergedAgentPrs: [] },
+      [{ type: "claim", ticket: 999 }],
+      { dryRun: true },
     );
-  });
 
-  it("shows planned closes with the merged PR", () => {
-    const merged: WorldSnapshot = {
-      tickets: [
-        ticket({
-          number: 6,
+    expect(report.actions).toEqual([{ type: "claim", ticket: 999, title: "" }]);
+  });
+});
+
+describe("renderPlanReport", () => {
+  it("renders the familiar unadorned block: header lines, one line per action kind, the paused notice, the dry-run footer", () => {
+    const report: PlanReport = {
+      scopeLabel: "sub-issues of #1",
+      totalTickets: 5,
+      openTickets: 4,
+      dispatchable: [2, 6],
+      paused: { kind: "max-open-prs", openCount: 5 },
+      maxWorkers: 3,
+      maxOpenPrs: 5,
+      actions: [
+        { type: "claim", ticket: 2, title: "Walking skeleton" },
+        { type: "release", ticket: 3, title: "Stranded" },
+        {
+          type: "spawn",
+          ticket: 2,
+          title: "Walking skeleton",
+          model: "sonnet",
+          attempt: 1,
+        },
+        { type: "escalate", ticket: 7, title: "Failed twice" },
+        {
+          type: "close",
+          ticket: 6,
           title: "Merged but open",
-          assignees: ["operator"],
-          hasAgentClaim: true,
-        }),
+          prUrl: "https://github.com/o/r/pull/60",
+        },
+        { type: "update-branch", pr: 50, title: "Behind base" },
+        { type: "conflict-worker", pr: 60, title: "Conflicted" },
+        { type: "mark-ready", pr: 70, title: "Green draft" },
       ],
-      openAgentPrs: [],
-      mergedAgentPrs: [{ ticket: 6, url: "https://github.com/o/r/pull/60" }],
+      dryRun: true,
     };
-    const actions = plan(merged, { maxWorkers: 3, maxOpenPrs: 5 });
 
-    expect(renderPlan(config(), merged, actions, { dryRun: false })).toBe(
+    expect(renderPlanReport(report)).toBe(
       [
-        "Scope: sub-issues of #1 — 1 tickets (1 open)",
-        "Dispatchable: none",
+        "Scope: sub-issues of #1 — 5 tickets (4 open)",
+        "Dispatchable: #2, #6",
+        "Dispatch paused: 5 open agent PRs at max_open_prs (5)",
         "Plan (max_workers=3, max_open_prs=5):",
+        "  claim #2 — Walking skeleton",
+        "  release #3 — Stranded (orphaned agent claim)",
+        "  spawn Worker for #2 — Walking skeleton (model sonnet, attempt 1)",
+        "  escalate #7 — Failed twice (attempts exhausted → ready-for-human)",
         "  close #6 — Merged but open (merged: https://github.com/o/r/pull/60)",
-      ].join("\n"),
-    );
-  });
-
-  it("renders the PR-upkeep actions with the PR number and the ticket title", () => {
-    const upkeep: WorldSnapshot = {
-      tickets: [
-        ticket({
-          number: 5,
-          title: "Behind base",
-          assignees: ["operator"],
-          hasAgentClaim: true,
-        }),
-        ticket({
-          number: 6,
-          title: "Conflicted",
-          assignees: ["operator"],
-          hasAgentClaim: true,
-        }),
-        ticket({
-          number: 7,
-          title: "Green draft",
-          assignees: ["operator"],
-          hasAgentClaim: true,
-        }),
-      ],
-      openAgentPrs: [
-        { ...openPr(5), behind: true },
-        { ...openPr(6), mergeable: "conflicted" },
-        { ...openPr(7), draft: true },
-      ],
-      mergedAgentPrs: [],
-    };
-    const actions = plan(upkeep, { maxWorkers: 3, maxOpenPrs: 5 });
-
-    expect(renderPlan(config(), upkeep, actions, { dryRun: true })).toBe(
-      [
-        "Scope: sub-issues of #1 — 3 tickets (3 open)",
-        "Dispatchable: none",
-        "Plan (max_workers=3, max_open_prs=5):",
         "  update PR #50 — Behind base (behind base, mechanical rebase)",
         "  conflict Worker for PR #60 — Conflicted (resolve merge conflicts)",
         "  mark PR #70 ready — Green draft (CI green)",
@@ -221,108 +267,178 @@ describe("renderPlan", () => {
       ].join("\n"),
     );
   });
+});
 
-  it("notes paused dispatch when dispatchable tickets wait on max_open_prs headroom", () => {
-    const throttled: WorldSnapshot = {
-      ...world,
-      openAgentPrs: [10, 11, 12, 13, 14].map(openPr),
-    };
-    const actions = plan(throttled, { maxWorkers: 3, maxOpenPrs: 5 });
-
-    expect(renderPlan(config(), throttled, actions, { dryRun: false })).toBe(
-      [
-        "Scope: sub-issues of #1 — 3 tickets (2 open)",
-        "Dispatchable: #2",
-        "Dispatch paused: 5 open agent PRs at max_open_prs (5)",
-        "Plan (max_workers=3, max_open_prs=5): nothing to do",
-      ].join("\n"),
+describe("buildStuckReport", () => {
+  it("includes only open tickets", () => {
+    const report = buildStuckReport(
+      stuckWorld([
+        ticket({ number: 2, title: "Open one" }),
+        ticket({ number: 3, title: "Closed one", state: "closed" }),
+      ]),
     );
+
+    expect(report.tickets.map((t) => t.ticket)).toEqual([2]);
   });
 
-  it("notes the open circuit breaker when dispatch is paused for infrastructure failure", () => {
-    const actions = plan(world, {
-      maxWorkers: 3,
-      maxOpenPrs: 5,
-      dispatchPaused: true,
-    });
-
-    expect(
-      renderPlan(config(), world, actions, {
-        dryRun: false,
-        dispatchPaused: true,
-      }),
-    ).toBe(
-      [
-        "Scope: sub-issues of #1 — 3 tickets (2 open)",
-        "Dispatchable: #2",
-        "Dispatch paused: circuit breaker open (infrastructure failure), claims held",
-        "Plan (max_workers=3, max_open_prs=5): nothing to do",
-      ].join("\n"),
+  it("flags a human claim", () => {
+    const report = buildStuckReport(
+      stuckWorld([
+        ticket({
+          number: 9,
+          title: "A colleague's work",
+          assignees: ["some-human"],
+        }),
+      ]),
     );
+
+    expect(report.tickets[0]?.reasons).toEqual([
+      { kind: "human-claim", assignees: ["some-human"] },
+    ]);
+  });
+
+  it("flags labelled ready-for-human distinctly from a missing ready-for-agent label", () => {
+    const escalated = buildStuckReport(
+      stuckWorld([
+        ticket({ number: 7, title: "Escalated", labels: ["ready-for-human"] }),
+      ]),
+    );
+    const untriaged = buildStuckReport(
+      stuckWorld([
+        ticket({ number: 4, title: "Untriaged", labels: ["needs-triage"] }),
+      ]),
+    );
+
+    expect(escalated.tickets[0]?.reasons).toEqual([
+      { kind: "ready-for-human" },
+    ]);
+    expect(untriaged.tickets[0]?.reasons).toEqual([
+      { kind: "not-ready-for-agent" },
+    ]);
+  });
+
+  it("names each blocker, flagging ones outside Scope", () => {
+    const report = buildStuckReport(
+      stuckWorld([
+        ticket({ number: 7, title: "Escalated", labels: ["ready-for-human"] }),
+        ticket({
+          number: 8,
+          title: "Downstream",
+          openBlockers: 2,
+          blockedBy: [7, 99],
+        }),
+      ]),
+    );
+    const downstream = report.tickets.find((t) => t.ticket === 8);
+
+    expect(downstream?.reasons).toEqual([
+      {
+        kind: "blocked-by",
+        blockers: [
+          { ticket: 7, inScope: true },
+          { ticket: 99, inScope: false },
+        ],
+      },
+    ]);
+  });
+
+  it("falls back to the blocker count when the blocker list is missing", () => {
+    const report = buildStuckReport(
+      stuckWorld([
+        ticket({ number: 8, title: "Blocked blind", openBlockers: 2 }),
+      ]),
+    );
+
+    expect(report.tickets[0]?.reasons).toEqual([
+      { kind: "blocked-count", count: 2 },
+    ]);
+  });
+
+  it("combines multiple reasons for one ticket", () => {
+    const report = buildStuckReport(
+      stuckWorld([
+        ticket({
+          number: 9,
+          title: "Multi",
+          assignees: ["operator"],
+          labels: ["needs-triage"],
+          openBlockers: 1,
+          blockedBy: [5],
+        }),
+      ]),
+    );
+
+    expect(report.tickets[0]?.reasons).toEqual([
+      { kind: "human-claim", assignees: ["operator"] },
+      { kind: "not-ready-for-agent" },
+      { kind: "blocked-by", blockers: [{ ticket: 5, inScope: false }] },
+    ]);
+  });
+
+  it("reports no reasons when nothing is found — the renderer's fallback case", () => {
+    const report = buildStuckReport(
+      stuckWorld([ticket({ number: 10, title: "Mystery" })]),
+    );
+
+    expect(report.tickets[0]?.reasons).toEqual([]);
   });
 });
 
-describe("renderStuck", () => {
-  function stuckWorld(tickets: Ticket[]): WorldSnapshot {
-    return { tickets, openAgentPrs: [], mergedAgentPrs: [] };
-  }
+describe("renderStuckReport", () => {
+  it("renders the familiar unadorned block, joining multiple reasons and falling back for none", () => {
+    const report: StuckReport = {
+      tickets: [
+        {
+          ticket: 7,
+          title: "Escalated",
+          reasons: [{ kind: "ready-for-human" }],
+        },
+        {
+          ticket: 8,
+          title: "Downstream",
+          reasons: [
+            {
+              kind: "blocked-by",
+              blockers: [
+                { ticket: 7, inScope: true },
+                { ticket: 99, inScope: false },
+              ],
+            },
+          ],
+        },
+        {
+          ticket: 9,
+          title: "A colleague's work",
+          reasons: [
+            { kind: "human-claim", assignees: ["some-human"] },
+            { kind: "not-ready-for-agent" },
+          ],
+        },
+        {
+          ticket: 10,
+          title: "Blocked blind",
+          reasons: [{ kind: "blocked-count", count: 2 }],
+        },
+        { ticket: 11, title: "Unexplained", reasons: [] },
+      ],
+    };
 
-  it("names each open ticket and exactly what it is stuck on", () => {
-    const open = [
-      ticket({ number: 7, title: "Escalated", labels: ["ready-for-human"] }),
-      ticket({
-        number: 8,
-        title: "Downstream",
-        openBlockers: 2,
-        blockedBy: [7, 99],
-      }),
-      ticket({
-        number: 9,
-        title: "A colleague's work",
-        assignees: ["some-human"],
-      }),
-    ];
-
-    expect(renderStuck(stuckWorld(open))).toBe(
+    expect(renderStuckReport(report)).toBe(
       [
         "Run Stuck: open tickets remain, but every path forward runs through a human.",
         "  #7 — Escalated (labelled ready-for-human)",
         "  #8 — Downstream (blocked by #7, #99 (outside Scope))",
-        "  #9 — A colleague's work (claimed by some-human — a human claim, hands off)",
-      ].join("\n"),
-    );
-  });
-
-  it("falls back to the blocker count when the blocker list is missing", () => {
-    const open = [
-      ticket({ number: 8, title: "Blocked blind", openBlockers: 2 }),
-    ];
-
-    expect(renderStuck(stuckWorld(open))).toBe(
-      [
-        "Run Stuck: open tickets remain, but every path forward runs through a human.",
-        "  #8 — Blocked blind (2 open blockers)",
-      ].join("\n"),
-    );
-  });
-
-  it("notes a missing agent label distinctly from an escalation", () => {
-    const open = [
-      ticket({ number: 4, title: "Untriaged", labels: ["needs-triage"] }),
-    ];
-
-    expect(renderStuck(stuckWorld(open))).toBe(
-      [
-        "Run Stuck: open tickets remain, but every path forward runs through a human.",
-        "  #4 — Untriaged (not labelled ready-for-agent)",
+        "  #9 — A colleague's work (claimed by some-human — a human claim, hands off; not labelled ready-for-agent)",
+        "  #10 — Blocked blind (2 open blockers)",
+        "  #11 — Unexplained (no path forward found)",
       ].join("\n"),
     );
   });
 });
 
-describe("renderComplete", () => {
-  it("summarizes every ticket in Scope, noting human closes after Escalation", () => {
-    const report = renderComplete([
+describe("buildCompleteReport", () => {
+  it("marks a ticket escalated when it carries the ready-for-human label", () => {
+    const report = buildCompleteReport([
       ticket({ number: 2, title: "Walking skeleton", state: "closed" }),
       ticket({
         number: 7,
@@ -332,18 +448,32 @@ describe("renderComplete", () => {
       }),
     ]);
 
-    expect(report).toBe(
+    expect(report.tickets).toEqual([
+      { ticket: 2, title: "Walking skeleton", escalated: false },
+      { ticket: 7, title: "Hard one", escalated: true },
+    ]);
+  });
+
+  it("builds an empty report for an empty Scope", () => {
+    expect(buildCompleteReport([])).toEqual({ tickets: [] });
+  });
+});
+
+describe("renderCompleteReport", () => {
+  it("renders the familiar unadorned block, noting human closes after Escalation", () => {
+    const report: CompleteReport = {
+      tickets: [
+        { ticket: 2, title: "Walking skeleton", escalated: false },
+        { ticket: 7, title: "Hard one", escalated: true },
+      ],
+    };
+
+    expect(renderCompleteReport(report)).toBe(
       [
         "Run Complete: every ticket in Scope is closed (2 tickets).",
         "  #2 — Walking skeleton",
         "  #7 — Hard one (closed by a human after Escalation)",
       ].join("\n"),
-    );
-  });
-
-  it("reports an empty Scope as complete with nothing herded", () => {
-    expect(renderComplete([])).toBe(
-      "Run Complete: every ticket in Scope is closed (0 tickets).",
     );
   });
 });


### PR DESCRIPTION
Committed cleanly. Now the PR description as the final message.

Reports as structured events (#52)

Splits each of the three block reports — the dispatch plan, the Stuck report, and the Complete report — into a pure data builder and a pure text renderer over that data in `core/render.ts`. The three report-kind `LogEvent`s now carry that structured data directly instead of a pre-joined multi-line string: the Stuck report's per-Ticket reasons are a discriminated union (`human-claim`, `ready-for-human`, `not-ready-for-agent`, `blocked-by`, `blocked-count`), so "what blocked what" is answerable without parsing a rendered block.

A new `cli/console-report.ts` dispatches a `LogEvent`'s kind to the matching renderer, kept free of the logging library so the dispatch itself is testable without it. The composition root's `buildLog` uses it to print report blocks raw to stdout, bypassing tslog entirely for these three kinds — so they stay the familiar unadorned block with no level or timestamp prefix, byte-identical to the output from before structured logging existed at all. (Issue #49's uniform tslog pass had regressed reports to print with an INFO/WARN timestamp prefix; that was a deliberate, called-out deferral to this ticket, not a new requirement.) Narration events are unaffected and still flow through the leveled console logger.

`app/tick.ts` and `app/run.ts` now call only the builders, not the renderers — the renderer's only caller is the console formatter, matching "the builder feeds a structured report event; the renderer feeds the console." Each event's `msg` is a short static summary (`"dispatch plan"`, `"run stuck"`, `"run complete"`); the full detail lives in the structured `report` field.

`tests/core/render.test.ts` is rewritten rather than extended: the exhaustive case matrix moves onto the three builders as structure assertions, and exactly one golden text test per renderer is kept as a formatting guard. `tests/app/run.test.ts`'s report assertions now check the structured `report` field instead of substring-matching `msg`. A new `tests/cli/console-report.test.ts` covers the kind-dispatch.

Lint, typecheck, and the full test suite (280 tests) pass. Manually verified against the real composition root that report blocks render unadorned while narration keeps its leveled/timestamped prefix.

Closes #52