### PR TITLE
feat(logging): durable per-run JSON log file

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "dev": "tsx src/main.ts",
+    "logs:pretty": "node scripts/logs-pretty.mjs",
     "smoke": "scripts/smoke.sh"
   },
   "devDependencies": {

--- a/scripts/logs-pretty.mjs
+++ b/scripts/logs-pretty.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+//
+// logs-pretty.mjs — replay a durable run log as pretty, level-filtered output.
+//
+// tslog ships a `tslog` bin that does exactly this, but it never runs from
+// `node_modules/.bin` on any package manager. Its entry-point guard compares
+// `import.meta.url` against `process.argv[1]`, and a symlink always sits
+// between the two: under npm the `.bin` entry is itself the symlink, under
+// pnpm the `node_modules/tslog` directory is. Node resolves symlinks for
+// `import.meta.url` and not for `argv[1]`, so the guard is always false and
+// `npx tslog` exits 0 having printed nothing.
+//
+// The rendering here is still tslog's own — this calls the same `runCli` the
+// bin would, through the public `tslog/cli` subpath. Only the entry point is
+// ours, which is the part that was broken. See issue #47.
+//
+// Usage:
+//   pnpm logs:pretty                    # newest log under .border-collie/logs
+//   pnpm logs:pretty <file.jsonl>
+//   cat <file.jsonl> | pnpm logs:pretty
+//
+// Flags are tslog's and pass straight through: `-l`/`--level <name|id>` to
+// filter, `--color`/`--no-color` to override TTY detection.
+//
+//   pnpm logs:pretty --level warn
+
+import { createReadStream, fstatSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { parseCliArgs, runCli } from "tslog/cli";
+
+// Mirrors RUN_DIR in src/adapters/worker.ts. Duplicated rather than imported
+// so this stays a plain node script with no build step; if the run directory
+// ever moves, this fails loudly with the message below rather than silently.
+const LOGS_DIR = join(".border-collie", "logs");
+
+/**
+ * Split argv into tslog's flags and the optional file path. `parseCliArgs`
+ * ignores anything it does not recognize, so it gets the whole array; we only
+ * need to know which bare word is a path, skipping the value `--level` takes.
+ */
+function splitArgs(argv) {
+  const paths = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "-l" || arg === "--level") {
+      i++;
+    } else if (!arg.startsWith("-")) {
+      paths.push(arg);
+    }
+  }
+  return { options: parseCliArgs(argv), path: paths[0] };
+}
+
+/**
+ * The newest log under the run directory — the run you just watched. File
+ * names are ISO start times, so lexical order is chronological order.
+ */
+async function newestLog() {
+  let entries;
+  try {
+    entries = await readdir(LOGS_DIR);
+  } catch {
+    throw new Error(
+      `no ${LOGS_DIR} directory yet — run border-collie first, or pass a file path`,
+    );
+  }
+  const newest = entries
+    .filter((entry) => entry.endsWith(".jsonl"))
+    .sort()
+    .at(-1);
+  if (newest === undefined) {
+    throw new Error(`no .jsonl logs in ${LOGS_DIR} — pass a file path`);
+  }
+  return join(LOGS_DIR, newest);
+}
+
+/**
+ * Whether someone actually fed us bytes: stdin is a pipe or a redirected file.
+ * `isTTY` alone is not enough — under a CI runner or a non-interactive shell
+ * stdin is an empty character device, and reading it would print nothing at
+ * all, which is the exact silent failure this script exists to replace.
+ */
+function stdinIsFed() {
+  try {
+    const stats = fstatSync(0);
+    return stats.isFIFO() || stats.isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** An explicit path wins; then a pipe; then the newest log on disk. */
+async function resolveInput(path) {
+  if (path !== undefined) {
+    return createReadStream(path);
+  }
+  if (stdinIsFed()) {
+    return process.stdin;
+  }
+  const newest = await newestLog();
+  // Named on stderr so stdout stays pipeable, and so an auto-picked file is
+  // never a mystery when it turns out to be the wrong run.
+  process.stderr.write(`logs-pretty: replaying ${newest}\n`);
+  return createReadStream(newest);
+}
+
+const { options, path } = splitArgs(process.argv.slice(2));
+
+try {
+  await runCli(await resolveInput(path), process.stdout, options);
+} catch (error) {
+  process.stderr.write(
+    `logs-pretty: ${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.exitCode = 1;
+}

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -1,7 +1,9 @@
+import { join } from "node:path";
 import type { CommandContext, StricliProcess } from "@stricli/core";
 import { Logger } from "tslog";
+import { fileTransport } from "tslog/transports/file";
 import { loadConfigFile } from "../adapters/config-file.js";
-import { probeEnvironment } from "../adapters/worker.js";
+import { probeEnvironment, RUN_DIR } from "../adapters/worker.js";
 import { tickOnce } from "../app/tick.js";
 import {
   type Flags,
@@ -62,32 +64,76 @@ function tagFor(bindings: LogBindings): string {
 }
 
 /**
- * Console sink for the Orchestrator's narration: pretty, colored, leveled,
- * timestamped, at a minimum level of `info` — lowered to `debug` by the
- * verbosity flag via `setMinLevel`, tslog's supported way to change a
- * logger's level after construction. Code-position and stack capture are
- * disabled — this is domain narration, not application debugging. Color (and
- * `NO_COLOR`/`FORCE_COLOR`) and TTY detection are handled by tslog itself.
- * Constructed only here: `core` and `app` never import the library, they
- * only see the `Log` function type.
+ * Two sinks over one logger, since a durable record needs more detail than a
+ * human wants scrolling past live: `type: "hidden"` suppresses tslog's own
+ * console output (which has no per-sink level of its own) so each sink below
+ * can set its own threshold.
  *
- * The three report kinds bypass tslog entirely: they print as the familiar
- * unadorned block straight to the process's stdout, byte-identical to before
- * structured logging existed — a report is read as a table, not narration,
- * and a level/timestamp prefix would be bolted onto it. `child` derives a
- * tslog sub-logger per dispatched Worker: its `name` tags every console line
- * so concurrent Workers stay tellable apart, and its `bindings` carry the
- * Ticket/Attempt (or PR) as real fields once a structured sink exists to
- * read them.
+ * - **Console**: pretty, colored, leveled, timestamped, minimum level `info`
+ *   — lowered to `debug` by the verbosity flag. tslog's `setMinLevel` isn't
+ *   enough here: it moves the shared floor both sinks read from before their
+ *   own per-transport `minLevel` applies, so lowering it would also let
+ *   below-`info` records reach the file gate unnecessarily. Instead the
+ *   console transport reads its `minLevel` from a closed-over variable the
+ *   flag mutates directly, leaving the file's threshold untouched.
+ *   Code-position and stack capture are disabled — this is domain narration,
+ *   not application debugging. Color (and `NO_COLOR`/`FORCE_COLOR`) and TTY
+ *   detection are handled by tslog itself.
+ * - **File**: the run's durable record, one newline-delimited JSON file per
+ *   process invocation under `<cwd>/<RUN_DIR>/logs`, named by start time.
+ *   Minimum level `debug`, unconditionally — this detail cannot be recovered
+ *   by re-running later. The parent directory is created on first write;
+ *   append mode; a sink failure (permissions, full disk) is contained and
+ *   reported rather than fatal; the buffered tail is flushed on normal exit
+ *   and on crash. Records use tslog's native shape, not its pino-compatible
+ *   preset.
+ *
+ * The root logger binds a run identifier matching the file's name, so every
+ * record — console or file — carries it.
+ *
+ * The three report kinds bypass both sinks entirely: they print as the
+ * familiar unadorned block straight to the process's stdout, byte-identical
+ * to before structured logging existed — a report is read as a table, not
+ * narration, and a level/timestamp prefix would be bolted onto it. `child`
+ * derives a tslog sub-logger per dispatched Worker: its `name` tags every
+ * console line so concurrent Workers stay tellable apart, and its
+ * `bindings` carry the Ticket/Attempt (or PR) as real fields captured by
+ * the file sink, alongside the run id every sub-logger inherits.
+ *
+ * Constructed only here: `core` and `app` never import tslog, they only see
+ * the `Log` function type.
  */
-function buildLog(cliProcess: StricliProcess): {
+function buildLog(
+  cliProcess: StricliProcess,
+  cwd: string,
+): {
   log: Log;
   setVerbose: (verbose: boolean) => void;
 } {
+  const runId = new Date().toISOString().replace(/[:.]/g, "-");
   const rootLogger = new Logger({
-    minLevel: "INFO",
+    type: "hidden",
     stack: { capture: "off" },
+    bindings: { runId },
   });
+  let consoleMinLevel: "INFO" | "DEBUG" = "INFO";
+  rootLogger.attachTransport({
+    name: "console",
+    format: "pretty",
+    get minLevel() {
+      return consoleMinLevel;
+    },
+    write: (_record, line) => {
+      cliProcess.stdout.write(`${line}\n`);
+    },
+  });
+  rootLogger.attachTransport(
+    fileTransport({
+      path: join(cwd, RUN_DIR, "logs", `${runId}.jsonl`),
+      format: "json",
+      minLevel: "DEBUG",
+    }),
+  );
   function wrap(logger: typeof rootLogger): Log {
     const log = ((event: LogEvent): void => {
       const block = reportBlockText(event);
@@ -108,17 +154,19 @@ function buildLog(cliProcess: StricliProcess): {
   }
   return {
     log: wrap(rootLogger),
-    setVerbose: (verbose) => rootLogger.setMinLevel(verbose ? "DEBUG" : "INFO"),
+    setVerbose: (verbose) => {
+      consoleMinLevel = verbose ? "DEBUG" : "INFO";
+    },
   };
 }
 
 /** The real context: today's collaborators, wired exactly as the entry point wired them before. */
-export function buildRealContext(): Context {
+export function buildRealContext(cwd: string = process.cwd()): Context {
   const cliProcess = nodeProcessAdapter();
-  const { log, setVerbose } = buildLog(cliProcess);
+  const { log, setVerbose } = buildLog(cliProcess, cwd);
   return {
     process: cliProcess,
-    loadConfig: (flags) => resolveConfig(loadConfigFile(process.cwd()), flags),
+    loadConfig: (flags) => resolveConfig(loadConfigFile(cwd), flags),
     tick: (config, dryRun, dispatchPaused) =>
       tickOnce(config, dryRun, dispatchPaused, log),
     probe: (model) => probeEnvironment(model),

--- a/tests/cli/context.test.ts
+++ b/tests/cli/context.test.ts
@@ -1,0 +1,42 @@
+import { existsSync, mkdtempSync, readdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { buildRealContext } from "../../src/cli/context.js";
+
+/**
+ * The one integration test in the set: builds the real composition root
+ * (real tslog instance, real filesystem) against a temporary directory and
+ * proves the durable file sink actually exists, rather than trusting the
+ * injected-collector unit tests that stand in for it everywhere else.
+ */
+describe("buildRealContext's durable log file", () => {
+  it("creates a log file under <cwd>/.border-collie/logs containing a debug record", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "border-collie-context-test-"));
+
+    const context = buildRealContext(dir);
+    context.log({
+      kind: "claim",
+      level: "debug",
+      ticket: 1,
+      msg: "claimed #1",
+    });
+
+    const logsDir = join(dir, ".border-collie", "logs");
+    await vi.waitFor(() => {
+      expect(existsSync(logsDir)).toBe(true);
+    });
+    const [fileName] = readdirSync(logsDir);
+    expect(fileName).toBeDefined();
+    const logPath = join(logsDir, String(fileName));
+
+    await vi.waitFor(() => {
+      const contents = readFileSync(logPath, "utf8").trim();
+      expect(contents.length).toBeGreaterThan(0);
+    });
+
+    const line = readFileSync(logPath, "utf8").trim().split("\n")[0];
+    const record = JSON.parse(String(line));
+    expect(record).toMatchObject({ message: "claimed #1", level: "DEBUG" });
+  });
+});


### PR DESCRIPTION
Adds the durable per-run JSON log file from #50: every process invocation now writes its own newline-delimited JSON record under `.border-collie/logs`, alongside the existing transcripts and worktrees, so a run's decision record survives past terminal scrollback.

The composition root (`src/cli/context.ts`) attaches two sinks to one `tslog` logger instead of relying on its built-in console output: a pretty console transport at `info` (unchanged from before) and a JSON file transport at `debug`, unconditionally. Because tslog gates on the root logger's own minimum level before any sink ever sees a record, the root logger switches to `type: "hidden"` so each sink can carry its own threshold independently — the file being verbose can't make live watching unreadable. The root logger binds a run identifier that matches the log file's name, so every record — console or file — carries it. The file's parent directory is created lazily on first write, failures are contained and reported rather than fatal, and the buffered tail is flushed on normal exit and on crash — all handled by tslog's own `fileTransport`, not hand-rolled here.

`buildRealContext` now takes an optional `cwd` (defaulting to `process.cwd()`), which is what makes this ticket's new integration test possible: it builds the real composition root against a temporary directory and asserts a log file appears containing a `debug` record, rather than relying on the injected-collector fakes every other test in the suite uses.

## The replay criterion, and the bug behind it

One acceptance criterion — "the library's bundled replay CLI renders the produced file as pretty, level-filtered output" — surfaced a real external bug rather than a gap in this implementation. `npx tslog` / `pnpm exec tslog` silently renders nothing against the produced file: no output, exit 0, no error.

An earlier comment on #50 scoped this to pnpm's symlinked `node_modules`. That was wrong, and a cold `npm install tslog@5.1.0` into a flat, non-symlinked tree fails identically. The guard is `import.meta.url === file://${process.argv[1]}`, and a symlink always sits between the invoked path and the resolved one — under npm the `.bin` entry is itself the symlink, under pnpm the `node_modules/tslog` directory is. Node resolves symlinks for `import.meta.url` and not for `argv[1]`, so the guard is always false on Unix regardless of package manager. Corrected on #50 and on #47.

The decision is recorded on #47: the record shape stays tslog's **native** layout, unchanged. The pino-preset fallback named in that issue was written for "the formatter can't read our records", and the formatter reads them fine — it is the bin's entry point that is broken, not the format.

So this PR adds `pnpm logs:pretty` (`scripts/logs-pretty.mjs`), which calls the same `runCli` the bin would through tslog's public `tslog/cli` subpath. The rendering stays the library's own; only the entry point is ours, so it works on every package manager rather than papering over one layout.

```
pnpm logs:pretty                    # newest log under .border-collie/logs
pnpm logs:pretty <file.jsonl>
cat <file.jsonl> | pnpm logs:pretty
pnpm logs:pretty --level warn       # -l/--level, --color/--no-color pass through
```

With no arguments it replays the newest log, naming the file on stderr so stdout stays pipeable. It prefers a genuinely fed stdin (a pipe or redirected file) over the newest-file default, but does not treat a bare non-TTY stdin as input — under CI that would read an empty character device and print nothing, reproducing the very silent-failure mode this replaces.

Verified end to end against a real produced file: `border-collie tick --dry-run` writes a log, and `pnpm logs:pretty` renders it as pretty, timestamped, level-tagged output carrying the bound run id, with `--level` filtering working.

Raising this upstream is tracked separately in #62.

Lint, typecheck, and the full test suite (294 tests) pass.

Closes #50
