### PR TITLE
feat(logging): per-Worker correlation via sub-loggers

### DIFF
--- a/src/app/act.ts
+++ b/src/app/act.ts
@@ -40,17 +40,24 @@ interface SpawnResult {
   prUrl?: string;
   /** PR opening failed after a successful Attempt; reported, then rethrown. */
   prFailure?: unknown;
+  /** This Worker's sub-logger, carried forward so outcome/PR lines inherit its bindings. */
+  log: Log;
+}
+
+/** What one conflict-worker action came to: the outcome, and its sub-logger to carry forward. */
+interface ConflictSpawnResult {
+  outcome: ConflictOutcome;
+  log: Log;
 }
 
 function describeOutcome(outcome: WorkerOutcome): string {
   const commits = `${outcome.newCommits} new commit${outcome.newCommits === 1 ? "" : "s"}`;
   const where = `on ${outcome.branch} (transcript: ${outcome.transcript})`;
-  if (outcome.ok)
-    return `Worker for #${outcome.ticket} succeeded: ${commits} ${where}`;
+  if (outcome.ok) return `Worker succeeded: ${commits} ${where}`;
   if (outcome.infra !== undefined) {
-    return `Worker for #${outcome.ticket} hit an infrastructure failure (${outcome.infra}): attempt ${outcome.attempt} voided, exit ${outcome.exitCode} ${where}`;
+    return `Worker hit an infrastructure failure (${outcome.infra}): attempt ${outcome.attempt} voided, exit ${outcome.exitCode} ${where}`;
   }
-  return `Worker for #${outcome.ticket} failed attempt ${outcome.attempt} (${outcome.failure}): exit ${outcome.exitCode}, ${commits} ${where}`;
+  return `Worker failed attempt ${outcome.attempt} (${outcome.failure}): exit ${outcome.exitCode}, ${commits} ${where}`;
 }
 
 /** What one Tick's act phase reports back to the loop. */
@@ -71,8 +78,8 @@ export interface ActDeps {
 function describeConflict(outcome: ConflictOutcome): string {
   const where = `on ${outcome.headRef} (transcript: ${outcome.transcript})`;
   return outcome.resolved
-    ? `Conflict Worker for PR #${outcome.pr} resolved the conflicts ${where}`
-    : `Conflict Worker for PR #${outcome.pr} could not resolve the conflicts (exit ${outcome.exitCode}) ${where}`;
+    ? `Conflict Worker resolved the conflicts ${where}`
+    : `Conflict Worker could not resolve the conflicts (exit ${outcome.exitCode}) ${where}`;
 }
 
 /**
@@ -100,7 +107,7 @@ export async function act(
 ): Promise<ActReport> {
   const { dispatch, openPr, dispatchConflict, exec, log } = deps;
   const workers: Promise<SpawnResult>[] = [];
-  const conflicts: Promise<ConflictOutcome>[] = [];
+  const conflicts: Promise<ConflictSpawnResult>[] = [];
   for (const action of actions) {
     switch (action.type) {
       case "claim":
@@ -158,39 +165,49 @@ export async function act(
           pr: action.pr,
         });
         break;
-      case "conflict-worker":
+      case "conflict-worker": {
+        const conflictLog = log.child({ pr: action.pr });
         conflicts.push(
-          dispatchConflict(action.pr, action.ticket, action.headRef),
+          dispatchConflict(action.pr, action.ticket, action.headRef).then(
+            (outcome) => ({ outcome, log: conflictLog }),
+          ),
         );
-        log({
+        conflictLog({
           kind: "conflict-dispatch",
           level: "info",
-          msg: `dispatched conflict Worker for PR #${action.pr} (ticket #${action.ticket})`,
-          pr: action.pr,
+          msg: `dispatched conflict Worker (ticket #${action.ticket})`,
           ticket: action.ticket,
         });
         break;
-      case "spawn":
+      }
+      case "spawn": {
+        const workerLog = log.child({
+          ticket: action.ticket,
+          attempt: action.attempt,
+        });
         workers.push(
           dispatch(action.ticket, action.attempt).then(
             async (outcome): Promise<SpawnResult> => {
-              if (!outcome.ok) return { outcome };
+              if (!outcome.ok) return { outcome, log: workerLog };
               try {
-                return { outcome, prUrl: await openPr(outcome) };
+                return {
+                  outcome,
+                  prUrl: await openPr(outcome),
+                  log: workerLog,
+                };
               } catch (error) {
-                return { outcome, prFailure: error };
+                return { outcome, prFailure: error, log: workerLog };
               }
             },
           ),
         );
-        log({
+        workerLog({
           kind: "spawn",
           level: "info",
-          msg: `spawned Worker for #${action.ticket} (attempt ${action.attempt})`,
-          ticket: action.ticket,
-          attempt: action.attempt,
+          msg: `spawned Worker (attempt ${action.attempt})`,
         });
         break;
+      }
     }
   }
 
@@ -204,33 +221,35 @@ export async function act(
   // Reclassify once every Worker has settled: only the full Tick's outcomes
   // can show several Workers dying the same way (an environment problem,
   // not a coincidence of tickets). Zipped straight back onto the spawn
-  // results so each outcome keeps its own PR.
-  const outcomes = reclassifyCorrelatedFailures(
+  // results so each outcome keeps its own PR and sub-logger.
+  const reclassifiedOutcomes = reclassifyCorrelatedFailures(
     fulfilled.map((spawn) => spawn.outcome),
-  ).map((outcome, i) => ({ outcome, prUrl: fulfilled[i]?.prUrl }));
-  for (const { outcome, prUrl } of outcomes) {
-    log({
+  );
+  const outcomes = fulfilled.map((spawn, i) => ({
+    outcome: reclassifiedOutcomes[i] ?? spawn.outcome,
+    prUrl: spawn.prUrl,
+    log: spawn.log,
+  }));
+  for (const { outcome, prUrl, log: workerLog } of outcomes) {
+    workerLog({
       kind: "worker-outcome",
       level: outcome.infra !== undefined ? "warn" : "info",
       msg: describeOutcome(outcome),
       outcome,
     });
     if (prUrl !== undefined) {
-      log({
+      workerLog({
         kind: "pr-opened",
         level: "info",
-        msg: `opened draft PR for #${outcome.ticket}: ${prUrl}`,
-        ticket: outcome.ticket,
+        msg: `opened draft PR: ${prUrl}`,
         prUrl,
       });
     }
     if (outcome.costOverrun && outcome.costUsd !== undefined) {
-      log({
+      workerLog({
         kind: "cost-overrun",
         level: "warn",
-        msg: `cost overrun on #${outcome.ticket}: attempt ${outcome.attempt} spent $${outcome.costUsd.toFixed(2)} — the ticket may be cut too big for one Worker`,
-        ticket: outcome.ticket,
-        attempt: outcome.attempt,
+        msg: `cost overrun: attempt ${outcome.attempt} spent $${outcome.costUsd.toFixed(2)} — the ticket may be cut too big for one Worker`,
         costUsd: outcome.costUsd,
       });
     }
@@ -245,12 +264,10 @@ export async function act(
         },
         exec,
       );
-      log({
+      workerLog({
         kind: "attempt-voided",
         level: "warn",
-        msg: `voided attempt ${outcome.attempt} of #${outcome.ticket} (${outcome.infra}); claim held`,
-        ticket: outcome.ticket,
-        attempt: outcome.attempt,
+        msg: `voided attempt ${outcome.attempt} (${outcome.infra}); claim held`,
         reason: outcome.infra,
       });
     } else if (outcome.failure) {
@@ -265,12 +282,10 @@ export async function act(
         },
         exec,
       );
-      log({
+      workerLog({
         kind: "attempt-released",
         level: "info",
-        msg: `released #${outcome.ticket} with the attempt record (failed attempt ${outcome.attempt})`,
-        ticket: outcome.ticket,
-        attempt: outcome.attempt,
+        msg: `released with the attempt record (failed attempt ${outcome.attempt})`,
         reason: outcome.failure,
       });
     }
@@ -282,29 +297,26 @@ export async function act(
   const settledConflicts = await Promise.allSettled(conflicts);
   for (const result of settledConflicts) {
     if (result.status !== "fulfilled") continue;
-    const outcome = result.value;
-    log({
+    const { outcome, log: conflictLog } = result.value;
+    conflictLog({
       kind: "conflict-outcome",
       level: outcome.resolved ? "info" : "warn",
       msg: describeConflict(outcome),
-      pr: outcome.pr,
       resolved: outcome.resolved,
     });
     if (outcome.resolved) {
       await pushAgentBranch(outcome.headRef, exec);
-      log({
+      conflictLog({
         kind: "conflict-pushed",
         level: "info",
-        msg: `pushed the resolved rebase for PR #${outcome.pr}`,
-        pr: outcome.pr,
+        msg: "pushed the resolved rebase",
       });
     } else {
       await commentConflictUnresolved(outcome.pr, exec);
-      log({
+      conflictLog({
         kind: "conflict-unresolved",
         level: "warn",
-        msg: `asked for human resolution on PR #${outcome.pr}`,
-        pr: outcome.pr,
+        msg: "asked for human resolution",
       });
     }
   }
@@ -317,14 +329,13 @@ export async function act(
   if (rejectedConflict) throw rejectedConflict.reason;
   for (const result of settled) {
     if (result.status === "fulfilled" && result.value.prFailure !== undefined) {
-      const { outcome: failedOutcome, prFailure } = result.value;
+      const { prFailure, log: workerLog } = result.value;
       const reason =
         prFailure instanceof Error ? prFailure.message : String(prFailure);
-      log({
+      workerLog({
         kind: "pr-open-failed",
         level: "error",
-        msg: `PR opening failed for #${failedOutcome.ticket} after a successful Attempt: ${reason}`,
-        ticket: failedOutcome.ticket,
+        msg: `PR opening failed after a successful Attempt: ${reason}`,
       });
       throw prFailure;
     }

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -8,7 +8,7 @@ import {
   type ResolvedConfig,
   resolveConfig,
 } from "../core/config.js";
-import type { Log } from "../core/log.js";
+import type { Log, LogBindings, LogEvent } from "../core/log.js";
 import type { Action, WorldSnapshot } from "../core/types.js";
 import { reportBlockText } from "./console-report.js";
 
@@ -52,6 +52,13 @@ function nodeProcessAdapter(): StricliProcess {
   };
 }
 
+/** The console tag for a Worker's (or Conflict Worker's) sub-logger — what distinguishes its interleaved lines. */
+function tagFor(bindings: LogBindings): string {
+  if (bindings.pr !== undefined) return `PR #${bindings.pr}`;
+  if (bindings.ticket !== undefined) return `#${bindings.ticket}`;
+  return "";
+}
+
 /**
  * Console sink for the Orchestrator's narration: pretty, colored, leveled,
  * timestamped, at a minimum level of `info`. Code-position and stack capture
@@ -63,18 +70,36 @@ function nodeProcessAdapter(): StricliProcess {
  * The three report kinds bypass tslog entirely: they print as the familiar
  * unadorned block straight to the process's stdout, byte-identical to before
  * structured logging existed — a report is read as a table, not narration,
- * and a level/timestamp prefix would be bolted onto it.
+ * and a level/timestamp prefix would be bolted onto it. `child` derives a
+ * tslog sub-logger per dispatched Worker: its `name` tags every console line
+ * so concurrent Workers stay tellable apart, and its `bindings` carry the
+ * Ticket/Attempt (or PR) as real fields once a structured sink exists to
+ * read them.
  */
 function buildLog(cliProcess: StricliProcess): Log {
-  const logger = new Logger({ minLevel: "INFO", stack: { capture: "off" } });
-  return (event) => {
-    const block = reportBlockText(event);
-    if (block !== null) {
-      cliProcess.stdout.write(`${block}\n`);
-      return;
-    }
-    logger[event.level](event.msg);
-  };
+  const rootLogger = new Logger({
+    minLevel: "INFO",
+    stack: { capture: "off" },
+  });
+  function wrap(logger: typeof rootLogger): Log {
+    const log = ((event: LogEvent): void => {
+      const block = reportBlockText(event);
+      if (block !== null) {
+        cliProcess.stdout.write(`${block}\n`);
+        return;
+      }
+      logger[event.level](event.msg);
+    }) as Log;
+    log.child = (bindings) =>
+      wrap(
+        logger.getSubLogger({
+          name: tagFor(bindings),
+          bindings: bindings as Record<string, unknown>,
+        }),
+      );
+    return log;
+  }
+  return wrap(rootLogger);
 }
 
 /** The real context: today's collaborators, wired exactly as the entry point wired them before. */

--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -22,6 +22,10 @@ interface LogEventBase {
  * event structurally. The console sink (wired in the composition root) reads
  * `level` and `msg` for narration; for the three report kinds it instead
  * renders `report` as the familiar unadorned block, dispatching on `kind`.
+ * Worker-lifecycle kinds (`spawn` through `attempt-released`, and the
+ * `conflict-*` kinds) omit the ticket/attempt/pr they'd otherwise repeat on
+ * every call — a dispatched Worker's sub-logger binds those once; see
+ * {@link Log.child}.
  */
 export type LogEvent = LogEventBase &
   (
@@ -31,27 +35,17 @@ export type LogEvent = LogEventBase &
     | { kind: "close"; ticket: number; prUrl: string }
     | { kind: "update-branch"; pr: number }
     | { kind: "mark-ready"; pr: number }
-    | { kind: "conflict-dispatch"; pr: number; ticket: number }
-    | { kind: "spawn"; ticket: number; attempt: number }
+    | { kind: "conflict-dispatch"; ticket: number }
+    | { kind: "spawn" }
     | { kind: "worker-outcome"; outcome: WorkerOutcome }
-    | { kind: "pr-opened"; ticket: number; prUrl: string }
-    | { kind: "pr-open-failed"; ticket: number }
-    | { kind: "cost-overrun"; ticket: number; attempt: number; costUsd: number }
-    | {
-        kind: "attempt-voided";
-        ticket: number;
-        attempt: number;
-        reason: InfraReason;
-      }
-    | {
-        kind: "attempt-released";
-        ticket: number;
-        attempt: number;
-        reason: FailureReason;
-      }
-    | { kind: "conflict-outcome"; pr: number; resolved: boolean }
-    | { kind: "conflict-pushed"; pr: number }
-    | { kind: "conflict-unresolved"; pr: number }
+    | { kind: "pr-opened"; prUrl: string }
+    | { kind: "pr-open-failed" }
+    | { kind: "cost-overrun"; costUsd: number }
+    | { kind: "attempt-voided"; reason: InfraReason }
+    | { kind: "attempt-released"; reason: FailureReason }
+    | { kind: "conflict-outcome"; resolved: boolean }
+    | { kind: "conflict-pushed" }
+    | { kind: "conflict-unresolved" }
     | { kind: "breaker-closed" }
     | { kind: "breaker-still-open"; trips: number; nextProbeMs: number }
     | { kind: "breaker-open"; infraFailures: number; nextProbeMs: number }
@@ -61,5 +55,22 @@ export type LogEvent = LogEventBase &
     | { kind: "complete-report"; report: CompleteReport }
   );
 
-/** The single logging seam injected into the run loop and the act phase's effects executor. */
-export type Log = (event: LogEvent) => void;
+/** Fields a Worker's (or Conflict Worker's) sub-logger binds onto every event it emits. */
+export interface LogBindings {
+  ticket?: number;
+  attempt?: number;
+  pr?: number;
+}
+
+/**
+ * The single logging seam injected into the run loop and the act phase's
+ * effects executor — a function type per ADR 0005, not a named interface,
+ * with `child` attached for deriving a sub-logger scoped to one dispatched
+ * Worker (bound by ticket and attempt) or Conflict Worker (bound by PR):
+ * every event it emits carries those bindings, tagged in the console and
+ * carried as structured fields, without the call site repeating them.
+ * Bindings are inherited by further children.
+ */
+export type Log = ((event: LogEvent) => void) & {
+  child(bindings: LogBindings): Log;
+};

--- a/tests/app/act.test.ts
+++ b/tests/app/act.test.ts
@@ -7,7 +7,7 @@ import {
   type DispatchWorker,
   type OpenPr,
 } from "../../src/app/act.js";
-import type { LogEvent } from "../../src/core/log.js";
+import type { Log, LogBindings, LogEvent } from "../../src/core/log.js";
 import {
   type AttemptFailure,
   attemptMarker,
@@ -27,13 +27,29 @@ function recordingExec(): { exec: Exec; calls: string[][] } {
   return { exec, calls };
 }
 
-/** Records emitted events; `msgs()` mirrors the old narration-line assertions. */
-function recordingLog(): {
-  log: (event: LogEvent) => void;
-  events: LogEvent[];
-} {
+/**
+ * Records emitted events, merging each sub-logger's bindings onto every
+ * event it forwards — exactly what a real sink sees, so assertions can
+ * check the bound ticket/attempt/pr fields directly instead of scraping
+ * rendered text. `msgs()` mirrors the old narration-line assertions.
+ */
+function recordingLog(): { log: Log; events: LogEvent[] } {
   const events: LogEvent[] = [];
-  return { log: (event) => events.push(event), events };
+  function make(bindings: LogBindings): Log {
+    const fn = ((event: LogEvent) => {
+      events.push({ ...bindings, ...event } as LogEvent);
+    }) as Log;
+    fn.child = (childBindings) => make({ ...bindings, ...childBindings });
+    return fn;
+  }
+  return { log: make({}), events };
+}
+
+/** A `Log` that discards everything, for tests uninterested in narration. */
+function noopLog(): Log {
+  const fn = ((_event: LogEvent) => {}) as Log;
+  fn.child = () => fn;
+  return fn;
 }
 
 function msgs(events: LogEvent[]): string[] {
@@ -190,7 +206,7 @@ describe("act", () => {
       openPr,
       dispatchConflict: noConflict,
       exec,
-      log: () => {},
+      log: noopLog(),
     });
 
     expect(calls).toEqual([]);
@@ -262,14 +278,28 @@ describe("act", () => {
     ]);
     expect(msgs(events)).toEqual([
       "claimed #2",
-      "spawned Worker for #2 (attempt 1)",
+      "spawned Worker (attempt 1)",
       "claimed #4",
-      "spawned Worker for #4 (attempt 1)",
-      "Worker for #2 succeeded: 3 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
-      "opened draft PR for #2: https://github.com/o/r/pull/20",
-      "Worker for #4 failed attempt 1 (nonzero-exit): exit 1, 0 new commits on border-collie/ticket-4 (transcript: .border-collie/transcripts/ticket-4.jsonl)",
-      "released #4 with the attempt record (failed attempt 1)",
+      "spawned Worker (attempt 1)",
+      "Worker succeeded: 3 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
+      "opened draft PR: https://github.com/o/r/pull/20",
+      "Worker failed attempt 1 (nonzero-exit): exit 1, 0 new commits on border-collie/ticket-4 (transcript: .border-collie/transcripts/ticket-4.jsonl)",
+      "released with the attempt record (failed attempt 1)",
     ]);
+    // Each Worker's own sub-logger binds its ticket and attempt onto every
+    // line it emits — concurrent Workers stay tellable apart by field, not
+    // by a "#N" buried in prose.
+    const worker2Events = events.filter(
+      (e) => e.kind !== "claim" && (e as { ticket?: number }).ticket === 2,
+    );
+    expect(worker2Events).toHaveLength(3); // spawn, worker-outcome, pr-opened
+    expect(
+      worker2Events.every((e) => (e as { attempt?: number }).attempt === 1),
+    ).toBe(true);
+    const worker4Events = events.filter(
+      (e) => e.kind !== "claim" && (e as { ticket?: number }).ticket === 4,
+    );
+    expect(worker4Events).toHaveLength(3); // spawn, worker-outcome, attempt-released
   });
 
   it("dispatches with the planned attempt number (the retry ladder rung)", async () => {
@@ -285,7 +315,7 @@ describe("act", () => {
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
       exec,
-      log: () => {},
+      log: noopLog(),
     });
 
     expect(attempts).toEqual([[7, 2]]);
@@ -301,7 +331,7 @@ describe("act", () => {
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
       exec,
-      log: () => {},
+      log: noopLog(),
     });
 
     const record: AttemptFailure = {
@@ -333,7 +363,7 @@ describe("act", () => {
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
       exec,
-      log: () => {},
+      log: noopLog(),
     });
 
     expect(calls).toEqual([]);
@@ -454,8 +484,10 @@ describe("act", () => {
     const costOverrun = events.find((e) => e.kind === "cost-overrun");
     expect(costOverrun?.level).toBe("warn");
     expect(costOverrun?.msg).toBe(
-      "cost overrun on #7: attempt 1 spent $25.50 — the ticket may be cut too big for one Worker",
+      "cost overrun: attempt 1 spent $25.50 — the ticket may be cut too big for one Worker",
     );
+    // Bound by the Worker's sub-logger, not repeated per call site.
+    expect(costOverrun).toMatchObject({ ticket: 7, attempt: 1 });
   });
 
   it("voids an infrastructure-classified attempt: comment only, claim held, counted in the report, logged at warn", async () => {
@@ -490,9 +522,9 @@ describe("act", () => {
     expect(report).toEqual({ infraFailures: 1 });
     const voided = events.find((e) => e.kind === "attempt-voided");
     expect(voided?.level).toBe("warn");
-    expect(voided?.msg).toBe(
-      "voided attempt 1 of #7 (usage-limit); claim held",
-    );
+    expect(voided?.msg).toBe("voided attempt 1 (usage-limit); claim held");
+    // Bound by the Worker's sub-logger, not repeated per call site.
+    expect(voided).toMatchObject({ ticket: 7, attempt: 1 });
   });
 
   it("reclassifies several Workers failing the same way in one Tick as correlated infrastructure", async () => {
@@ -541,7 +573,7 @@ describe("act", () => {
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
       exec,
-      log: () => {},
+      log: noopLog(),
     });
 
     expect(report).toEqual({ infraFailures: 0 });
@@ -573,7 +605,7 @@ describe("act", () => {
     ).rejects.toThrow("git exploded");
 
     expect(msgs(events)).toContain(
-      "Worker for #2 succeeded: 2 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
+      "Worker succeeded: 2 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
     );
   });
 
@@ -596,13 +628,15 @@ describe("act", () => {
     ).rejects.toThrow("gh pr create exploded");
 
     expect(msgs(events)).toContain(
-      "Worker for #2 succeeded: 2 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
+      "Worker succeeded: 2 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
     );
     const prOpenFailed = events.find((e) => e.kind === "pr-open-failed");
     expect(prOpenFailed?.level).toBe("error");
     expect(prOpenFailed?.msg).toBe(
-      "PR opening failed for #2 after a successful Attempt: gh pr create exploded",
+      "PR opening failed after a successful Attempt: gh pr create exploded",
     );
+    // Bound by the Worker's sub-logger, not repeated per call site.
+    expect(prOpenFailed).toMatchObject({ ticket: 2, attempt: 1 });
   });
 });
 
@@ -690,10 +724,12 @@ describe("act: PR upkeep", () => {
     ]);
     expect(events.every((e) => e.level === "info")).toBe(true);
     expect(msgs(events)).toEqual([
-      "dispatched conflict Worker for PR #30 (ticket #3)",
-      "Conflict Worker for PR #30 resolved the conflicts on border-collie/ticket-3-attempt-1 (transcript: .border-collie/transcripts/pr-30-conflict.jsonl)",
-      "pushed the resolved rebase for PR #30",
+      "dispatched conflict Worker (ticket #3)",
+      "Conflict Worker resolved the conflicts on border-collie/ticket-3-attempt-1 (transcript: .border-collie/transcripts/pr-30-conflict.jsonl)",
+      "pushed the resolved rebase",
     ]);
+    // Bound by the Conflict Worker's sub-logger, not repeated per call site.
+    expect(events.every((e) => (e as { pr?: number }).pr === 30)).toBe(true);
   });
 
   it("asks for human resolution when the conflict Worker gives up (no push), logged at warn", async () => {
@@ -740,10 +776,12 @@ describe("act: PR upkeep", () => {
     ]);
     expect(events.map((e) => e.level)).toEqual(["info", "warn", "warn"]);
     expect(msgs(events)).toEqual([
-      "dispatched conflict Worker for PR #30 (ticket #3)",
-      "Conflict Worker for PR #30 could not resolve the conflicts (exit 1) on border-collie/ticket-3-attempt-1 (transcript: .border-collie/transcripts/pr-30-conflict.jsonl)",
-      "asked for human resolution on PR #30",
+      "dispatched conflict Worker (ticket #3)",
+      "Conflict Worker could not resolve the conflicts (exit 1) on border-collie/ticket-3-attempt-1 (transcript: .border-collie/transcripts/pr-30-conflict.jsonl)",
+      "asked for human resolution",
     ]);
+    // Bound by the Conflict Worker's sub-logger, not repeated per call site.
+    expect(events.every((e) => (e as { pr?: number }).pr === 30)).toBe(true);
   });
 
   it("runs conflict Workers concurrently with dispatch Workers and reports both", async () => {
@@ -791,9 +829,9 @@ describe("act: PR upkeep", () => {
     );
 
     expect(inFlight.sort()).toEqual(["conflict-40", "worker-2"]);
-    expect(msgs(events)).toContain("pushed the resolved rebase for PR #40");
+    expect(msgs(events)).toContain("pushed the resolved rebase");
     expect(msgs(events)).toContain(
-      "Worker for #2 succeeded: 2 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
+      "Worker succeeded: 2 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
     );
   });
 
@@ -827,7 +865,7 @@ describe("act: PR upkeep", () => {
     ).rejects.toThrow("claude ENOENT");
 
     expect(msgs(events)).toContain(
-      "Worker for #2 succeeded: 2 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
+      "Worker succeeded: 2 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
     );
   });
 });

--- a/tests/app/run.test.ts
+++ b/tests/app/run.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { type RunDeps, run, runStatus } from "../../src/app/run.js";
 import { BREAKER_BASE_COOLDOWN_MS } from "../../src/core/breaker.js";
-import type { LogEvent } from "../../src/core/log.js";
+import type { Log, LogEvent } from "../../src/core/log.js";
 import type {
   Action,
   MergedAgentPr,
@@ -171,11 +171,18 @@ function scriptedDeps(
       state.sleeps.push(ms);
       nowMs += opts.msPerSleep ?? ms;
     },
-    log: (event) => {
-      state.events.push(event);
-    },
+    log: recordingLog(state.events),
   };
   return state;
+}
+
+/** A `Log` recording every event into `events`; the run loop never derives a sub-logger, but the type requires `child`. */
+function recordingLog(events: LogEvent[]): Log {
+  const fn = ((event: LogEvent) => {
+    events.push(event);
+  }) as Log;
+  fn.child = () => recordingLog(events);
+  return fn;
 }
 
 describe("run", () => {

--- a/tests/cli/app.test.ts
+++ b/tests/cli/app.test.ts
@@ -7,8 +7,17 @@ import {
   type Flags,
   type ResolvedConfig,
 } from "../../src/core/config.js";
-import type { LogEvent } from "../../src/core/log.js";
+import type { Log, LogEvent } from "../../src/core/log.js";
 import type { Ticket, WorldSnapshot } from "../../src/core/types.js";
+
+/** A `Log` recording every event into `events`; this fake context never derives a sub-logger, but the type requires `child`. */
+function recordingLog(events: LogEvent[]): Log {
+  const fn = ((event: LogEvent) => {
+    events.push(event);
+  }) as Log;
+  fn.child = () => recordingLog(events);
+  return fn;
+}
 
 function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
   return {
@@ -106,9 +115,7 @@ function fakeContext(
     },
     now: () => 0,
     sleep: async () => {},
-    log: (event) => {
-      events.push(event);
-    },
+    log: recordingLog(events),
   };
 
   return {


### PR DESCRIPTION
Committed. Here's the PR description:

---

feat(logging): per-Worker correlation via sub-loggers (#51)

An operator running the default three concurrent Workers could not tell them apart: narration interleaved, and the only thing distinguishing one Worker's line from another's was a Ticket number buried mid-sentence.

Each dispatched Worker now gets a sub-logger (`Log.child({ ticket, attempt })`) that binds its Ticket and Attempt onto every line it emits. A Conflict Worker gets the same treatment, scoped by PR (`Log.child({ pr })`) rather than Ticket. The console tags each line with the Worker it belongs to (e.g. `#7`, `PR #30`), and the underlying bindings carry Ticket/Attempt as real fields via tslog's `getSubLogger`, ready for a structured JSON sink to read without any call site repeating them.

Bindings are inherited: the sub-logger created at spawn/dispatch time is threaded through the settled-Worker promise chain, so the follow-up lines — PR opened, cost overrun, Attempt voided, Ticket released with its Attempt record, and the Conflict Worker's push/unresolved outcome — all carry the same fields for free.

With the tag and fields present, the `#N` prefix is dropped from Worker-lifecycle prose (`spawn`, `worker-outcome`, `pr-opened`, `pr-open-failed`, `cost-overrun`, `attempt-voided`, `attempt-released`, and the `conflict-*` kinds). It's retained everywhere else — report renderers, and lines like `claim`/`release`/`escalate`/`close`/`update-branch`/`mark-ready` that aren't part of a dispatched Worker's session.

`Log` moves from a bare function type to a function type with an attached `child` method (an intersection type, keeping ADR 0005's "ports as function types, not interfaces"), and `LogEvent`'s Worker-lifecycle variants drop the ticket/attempt/pr fields that are now supplied solely via binding — so a test can only see them by actually exercising the sub-logger, not by trusting a call site that passed them manually.

Tests assert the bound fields on emitted events (via `toMatchObject`/filter checks) rather than scraping rendered console text, per the ticket's testing requirement.

Lint, typecheck, and the full test suite (269 tests) pass.

Closes #51