### PR TITLE
feat(worker): heartbeat while Workers are in flight

### DIFF
--- a/src/adapters/worker.ts
+++ b/src/adapters/worker.ts
@@ -81,6 +81,12 @@ export interface WorkerProcessRequest {
   timeoutMs: number;
   /** Stall window; the process is killed when stdout goes quiet this long. */
   stallMs: number;
+  /**
+   * Called on every chunk of stdout the process emits — the same
+   * observation that re-arms the stall watchdog, surfaced for the fleet
+   * heartbeat. No new process seam: this rides the existing one.
+   */
+  onActivity?: () => void;
 }
 
 /** How the Worker process ended: on its own, or killed by which watchdog. */
@@ -147,6 +153,7 @@ export const realSpawnWorkerProcess: SpawnWorkerProcess = (request) =>
     };
     rearmStallWatchdog();
     child.stdout.on("data", rearmStallWatchdog);
+    child.stdout.on("data", () => request.onActivity?.());
 
     const end = () => {
       clearTimeout(wallTimer);
@@ -268,6 +275,8 @@ export async function dispatchWorker(
   exec: Exec = realExec,
   spawnProcess: SpawnWorkerProcess = realSpawnWorkerProcess,
   log: Log = noopLog,
+  /** Forwarded onto the process request; the fleet heartbeat's activity signal. */
+  onActivity: () => void = () => {},
 ): Promise<WorkerOutcome> {
   const branch = `${AGENT_BRANCH_PREFIX}${ticket}-attempt-${config.attempt}`;
   const worktree = join(RUN_DIR, "worktrees", `ticket-${ticket}`);
@@ -321,6 +330,7 @@ export async function dispatchWorker(
       stderrPath: stderrLog,
       timeoutMs: config.timeoutMs,
       stallMs: config.stallMs,
+      onActivity,
     });
     const newCommits = Number(
       (

--- a/src/app/act.ts
+++ b/src/app/act.ts
@@ -12,16 +12,36 @@ import {
 } from "../adapters/tracker.js";
 import { type ConflictOutcome, pushAgentBranch } from "../adapters/worker.js";
 import { reclassifyCorrelatedFailures } from "../core/classify.js";
+import { heartbeatSnapshot, type WorkerActivity } from "../core/heartbeat.js";
 import type { Log } from "../core/log.js";
+import { renderHeartbeat } from "../core/render.js";
 import type { Action, WorkerOutcome } from "../core/types.js";
+
+/** How often the fleet heartbeat reports, while any Worker is in flight. */
+const HEARTBEAT_INTERVAL_MS = 60_000;
+
+/**
+ * Starts a recurring callback every `ms`; returns a function that cancels
+ * it. The run loop's existing treatment of time (an injected clock plus an
+ * injected waiter) extended with the one new primitive the heartbeat needs:
+ * something to cancel immediately once the last Worker settles, rather than
+ * waiting out a pending wait.
+ */
+export type IntervalScheduler = (
+  ms: number,
+  callback: () => void,
+) => () => void;
 
 /**
  * Dispatch one Worker against one claimed ticket; the caller binds the
- * attempt number to a model (the retry ladder).
+ * attempt number to a model (the retry ladder). `onActivity` is called
+ * whenever the Worker process produces output — the fleet heartbeat's
+ * activity signal, riding the process adapter's existing observation.
  */
 export type DispatchWorker = (
   ticket: number,
   attempt: number,
+  onActivity: () => void,
 ) => Promise<WorkerOutcome>;
 
 /** Open the draft PR for a successful Attempt; resolves with the PR URL. */
@@ -73,6 +93,75 @@ export interface ActDeps {
   dispatchConflict: DispatchConflictWorker;
   exec: Exec;
   log: Log;
+  /** The heartbeat's clock, following the run loop's existing treatment of time. */
+  now: () => number;
+  /** The heartbeat's scheduler, following the run loop's existing treatment of time. */
+  scheduleInterval: IntervalScheduler;
+}
+
+/** One spawned Worker's handle onto the fleet heartbeat: touch on activity, stop once settled. */
+interface HeartbeatHandle {
+  touch: () => void;
+  stop: () => void;
+}
+
+/**
+ * Tracks every in-flight dispatch Worker's activity and reports the fleet
+ * heartbeat once a minute, starting the scheduler on the first Worker and
+ * cancelling it the moment the last one settles. Kept apart from the
+ * action-dispatch switch below, which only calls `start`/`touch`/`stop` —
+ * the heartbeat's own lifecycle is a separate concern from performing one
+ * planned write.
+ */
+function createHeartbeat(
+  now: () => number,
+  scheduleInterval: IntervalScheduler,
+  log: Log,
+): { start: (ticket: number, attempt: number) => HeartbeatHandle } {
+  const activity = new Map<string, WorkerActivity>();
+  let stopScheduler: (() => void) | undefined;
+
+  function stopIfIdle(): void {
+    if (activity.size === 0 && stopScheduler !== undefined) {
+      stopScheduler();
+      stopScheduler = undefined;
+    }
+  }
+
+  return {
+    start(ticket, attempt) {
+      const key = `${ticket}:${attempt}`;
+      const startedAtMs = now();
+      activity.set(key, {
+        ticket,
+        attempt,
+        startedAtMs,
+        lastActivityAtMs: startedAtMs,
+      });
+      if (stopScheduler === undefined) {
+        stopScheduler = scheduleInterval(HEARTBEAT_INTERVAL_MS, () => {
+          if (activity.size === 0) return;
+          const heartbeats = heartbeatSnapshot([...activity.values()], now());
+          log({
+            kind: "heartbeat",
+            level: "info",
+            msg: renderHeartbeat(heartbeats),
+            workers: heartbeats,
+          });
+        });
+      }
+      return {
+        touch: () => {
+          const entry = activity.get(key);
+          if (entry) entry.lastActivityAtMs = now();
+        },
+        stop: () => {
+          activity.delete(key);
+          stopIfIdle();
+        },
+      };
+    },
+  };
 }
 
 function describeConflict(outcome: ConflictOutcome): string {
@@ -99,15 +188,28 @@ function describeConflict(outcome: ConflictOutcome): string {
  * world and re-plans whatever is still due. PR upkeep runs alongside dispatch:
  * the mechanical branch update and draft→ready flip are immediate tracker
  * writes; a conflict Worker runs concurrently like a spawn, its resolved
- * rebase pushed (or the PR handed to a human) once it settles.
+ * rebase pushed (or the PR handed to a human) once it settles. While any
+ * dispatch Worker is in flight, a fleet heartbeat reports all of them once a
+ * minute — elapsed time and time since last output, independently — and
+ * stops the moment the last one settles.
  */
 export async function act(
   actions: Action[],
   deps: ActDeps,
 ): Promise<ActReport> {
-  const { dispatch, openPr, dispatchConflict, exec, log } = deps;
+  const {
+    dispatch,
+    openPr,
+    dispatchConflict,
+    exec,
+    log,
+    now,
+    scheduleInterval,
+  } = deps;
   const workers: Promise<SpawnResult>[] = [];
   const conflicts: Promise<ConflictSpawnResult>[] = [];
+  const heartbeat = createHeartbeat(now, scheduleInterval, log);
+
   for (const action of actions) {
     switch (action.type) {
       case "claim":
@@ -185,9 +287,11 @@ export async function act(
           ticket: action.ticket,
           attempt: action.attempt,
         });
+        const handle = heartbeat.start(action.ticket, action.attempt);
         workers.push(
-          dispatch(action.ticket, action.attempt).then(
-            async (outcome): Promise<SpawnResult> => {
+          dispatch(action.ticket, action.attempt, handle.touch)
+            .finally(handle.stop)
+            .then(async (outcome): Promise<SpawnResult> => {
               if (!outcome.ok) return { outcome, log: workerLog };
               try {
                 return {
@@ -198,8 +302,7 @@ export async function act(
               } catch (error) {
                 return { outcome, prFailure: error, log: workerLog };
               }
-            },
-          ),
+            }),
         );
         workerLog({
           kind: "spawn",

--- a/src/app/tick.ts
+++ b/src/app/tick.ts
@@ -10,15 +10,23 @@ import type { Log } from "../core/log.js";
 import { plan } from "../core/plan.js";
 import { buildPlanReport } from "../core/render.js";
 import type { Action, WorldSnapshot } from "../core/types.js";
-import { act } from "./act.js";
+import { act, type IntervalScheduler } from "./act.js";
+
+/** The Tick's effects, injectable for tests, matching the run loop's pattern. */
+export interface TickDeps {
+  log: Log;
+  now: () => number;
+  scheduleInterval: IntervalScheduler;
+}
 
 /** One full observe → plan → act pass — the single Tick both commands share. */
 export async function tickOnce(
   config: ResolvedConfig,
   dryRun: boolean,
   dispatchPaused = false,
-  log: Log,
+  deps: TickDeps,
 ): Promise<{ world: WorldSnapshot; actions: Action[]; infraFailures: number }> {
+  const { log, now, scheduleInterval } = deps;
   // Every command this Tick issues through the adapters — gh and git alike
   // — plus its exit code, is narrated at debug through the same seam:
   // detail that does not exist today, hidden from the console unless
@@ -44,7 +52,7 @@ export async function tickOnce(
   if (!dryRun) {
     const titles = new Map(world.tickets.map((t) => [t.number, t.title]));
     const report = await act(actions, {
-      dispatch: (ticket, attempt) =>
+      dispatch: (ticket, attempt, onActivity) =>
         dispatchWorker(
           ticket,
           {
@@ -58,6 +66,7 @@ export async function tickOnce(
           exec,
           realSpawnWorkerProcess,
           log,
+          onActivity,
         ),
       openPr: (outcome) =>
         openPrForOutcome(
@@ -82,6 +91,8 @@ export async function tickOnce(
         ),
       exec,
       log,
+      now,
+      scheduleInterval,
     });
     infraFailures = report.infraFailures;
   }

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -4,6 +4,7 @@ import { Logger } from "tslog";
 import { fileTransport } from "tslog/transports/file";
 import { loadConfigFile } from "../adapters/config-file.js";
 import { probeEnvironment, RUN_DIR } from "../adapters/worker.js";
+import type { IntervalScheduler } from "../app/act.js";
 import { tickOnce } from "../app/tick.js";
 import {
   type Flags,
@@ -30,6 +31,8 @@ export interface Context extends CommandContext {
   readonly probe: (model: string) => Promise<boolean>;
   readonly now: () => number;
   readonly sleep: (ms: number) => Promise<void>;
+  /** The fleet heartbeat's scheduler; see src/app/act.ts. */
+  readonly scheduleInterval: IntervalScheduler;
   /** The single logging seam narration travels through; see src/core/log.ts. */
   readonly log: Log;
   /** The verbosity flag: lowers the console's minimum level to debug. Scoped to the console sink only. */
@@ -164,14 +167,20 @@ function buildLog(
 export function buildRealContext(cwd: string = process.cwd()): Context {
   const cliProcess = nodeProcessAdapter();
   const { log, setVerbose } = buildLog(cliProcess, cwd);
+  const now = () => Date.now();
+  const scheduleInterval: IntervalScheduler = (ms, callback) => {
+    const id = setInterval(callback, ms);
+    return () => clearInterval(id);
+  };
   return {
     process: cliProcess,
     loadConfig: (flags) => resolveConfig(loadConfigFile(cwd), flags),
     tick: (config, dryRun, dispatchPaused) =>
-      tickOnce(config, dryRun, dispatchPaused, log),
+      tickOnce(config, dryRun, dispatchPaused, { log, now, scheduleInterval }),
     probe: (model) => probeEnvironment(model),
-    now: () => Date.now(),
+    now,
     sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    scheduleInterval,
     log,
     setVerbose,
   };

--- a/src/core/heartbeat.ts
+++ b/src/core/heartbeat.ts
@@ -1,0 +1,35 @@
+/**
+ * The fleet heartbeat's pure arithmetic: how long a Worker has run, and how
+ * long since it last produced output — the two signals that distinguish
+ * slow from stuck (elapsed alone cannot).
+ */
+
+/** One in-flight Worker's activity clock, tracked by the act phase. */
+export interface WorkerActivity {
+  ticket: number;
+  attempt: number;
+  startedAtMs: number;
+  /** Updated on every stdout chunk the Worker process emits. */
+  lastActivityAtMs: number;
+}
+
+/** One Worker's heartbeat reading at a point in time. */
+export interface WorkerHeartbeat {
+  ticket: number;
+  attempt: number;
+  elapsedMs: number;
+  sinceOutputMs: number;
+}
+
+/** Snapshot every in-flight Worker's heartbeat reading at `nowMs`. Pure. */
+export function heartbeatSnapshot(
+  workers: WorkerActivity[],
+  nowMs: number,
+): WorkerHeartbeat[] {
+  return workers.map((worker) => ({
+    ticket: worker.ticket,
+    attempt: worker.attempt,
+    elapsedMs: nowMs - worker.startedAtMs,
+    sinceOutputMs: nowMs - worker.lastActivityAtMs,
+  }));
+}

--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -1,3 +1,4 @@
+import type { WorkerHeartbeat } from "./heartbeat.js";
 import type { CompleteReport, PlanReport, StuckReport } from "./render.js";
 import type { FailureReason, InfraReason, WorkerOutcome } from "./types.js";
 
@@ -38,6 +39,7 @@ export type LogEvent = LogEventBase &
     | { kind: "conflict-dispatch"; ticket: number }
     | { kind: "spawn" }
     | { kind: "worker-outcome"; outcome: WorkerOutcome }
+    | { kind: "heartbeat"; workers: WorkerHeartbeat[] }
     | { kind: "pr-opened"; prUrl: string }
     | { kind: "pr-open-failed" }
     | { kind: "cost-overrun"; costUsd: number }

--- a/src/core/render.ts
+++ b/src/core/render.ts
@@ -1,4 +1,5 @@
 import { modelForAttempt, type ResolvedConfig } from "./config.js";
+import type { WorkerHeartbeat } from "./heartbeat.js";
 import { dispatchableSet } from "./plan.js";
 import {
   type Action,
@@ -185,6 +186,28 @@ export function renderPlanReport(report: PlanReport): string {
 
   if (report.dryRun) lines.push("Dry run: no writes performed.");
   return lines.join("\n");
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0 ? `${minutes}m${seconds}s` : `${seconds}s`;
+}
+
+/**
+ * Render the fleet heartbeat: one line covering every in-flight Worker, each
+ * with its elapsed time and time since its last output — the two signals
+ * that distinguish slow from stuck. Pure.
+ */
+export function renderHeartbeat(workers: WorkerHeartbeat[]): string {
+  const entries = workers
+    .map(
+      (w) =>
+        `#${w.ticket} attempt ${w.attempt} (elapsed ${formatDuration(w.elapsedMs)}, since output ${formatDuration(w.sinceOutputMs)})`,
+    )
+    .join(", ");
+  return `Heartbeat: ${workers.length} Worker${workers.length === 1 ? "" : "s"} in flight — ${entries}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/adapters/worker.test.ts
+++ b/tests/adapters/worker.test.ts
@@ -130,6 +130,7 @@ describe("dispatchWorker", () => {
         stderrPath: ".border-collie/transcripts/ticket-4-attempt-1.stderr.log",
         timeoutMs: 60_000,
         stallMs: 30_000,
+        onActivity: expect.any(Function),
       },
     ]);
   });
@@ -159,6 +160,20 @@ describe("dispatchWorker", () => {
     const { spawn } = fakeSpawn(0);
 
     await expect(dispatchWorker(4, CONFIG, exec, spawn)).resolves.toBeDefined();
+  });
+
+  it("forwards the activity callback onto the process request — the heartbeat rides the existing seam", async () => {
+    const { exec } = fakeExec({ newCommits: "1" });
+    const { spawn, requests } = fakeSpawn(0);
+    const activity: number[] = [];
+
+    await dispatchWorker(4, CONFIG, exec, spawn, undefined, () =>
+      activity.push(1),
+    );
+
+    requests[0]?.onActivity?.();
+    requests[0]?.onActivity?.();
+    expect(activity).toEqual([1, 1]);
   });
 
   it("serializes git phases across concurrent dispatches (repo-level locks), keeping Workers concurrent", async () => {
@@ -773,6 +788,23 @@ describe("realSpawnWorkerProcess", () => {
       stderrTail: "warned\n",
     });
     expect(readFileSync(req.transcriptPath, "utf8")).toContain("event");
+  });
+
+  it("calls onActivity for every stdout chunk — the same observation that re-arms the stall watchdog", async () => {
+    let calls = 0;
+    const req: WorkerProcessRequest = {
+      ...request(`console.log("one"); console.log("two")`, {
+        timeoutMs: 5_000,
+        stallMs: 5_000,
+      }),
+      onActivity: () => {
+        calls += 1;
+      },
+    };
+
+    await realSpawnWorkerProcess(req);
+
+    expect(calls).toBeGreaterThan(0);
   });
 
   it("kills a process that outlives the wall-clock timeout even while it keeps emitting output", async () => {

--- a/tests/app/act.test.ts
+++ b/tests/app/act.test.ts
@@ -5,6 +5,7 @@ import {
   act,
   type DispatchConflictWorker,
   type DispatchWorker,
+  type IntervalScheduler,
   type OpenPr,
 } from "../../src/app/act.js";
 import type { Log, LogBindings, LogEvent } from "../../src/core/log.js";
@@ -54,6 +55,27 @@ function noopLog(): Log {
 
 function msgs(events: LogEvent[]): string[] {
   return events.map((e) => e.msg);
+}
+
+/** A fixed clock and a scheduler that never fires, for tests unconcerned with the heartbeat. */
+const now = () => 0;
+const scheduleInterval: IntervalScheduler = () => () => {};
+
+/** Records every (ms, callback) the heartbeat scheduled, letting a test fire ticks manually. */
+function fakeScheduler(): {
+  scheduleInterval: IntervalScheduler;
+  starts: { ms: number; callback: () => void }[];
+  cancelCount: () => number;
+} {
+  const starts: { ms: number; callback: () => void }[] = [];
+  let cancelled = 0;
+  const scheduleInterval: IntervalScheduler = (ms, callback) => {
+    starts.push({ ms, callback });
+    return () => {
+      cancelled += 1;
+    };
+  };
+  return { scheduleInterval, starts, cancelCount: () => cancelled };
 }
 
 const noDispatch: DispatchWorker = async (ticket) => {
@@ -128,6 +150,8 @@ describe("act", () => {
         openPr,
         dispatchConflict: noConflict,
         exec,
+        now,
+        scheduleInterval,
         log,
       },
     );
@@ -172,6 +196,8 @@ describe("act", () => {
         openPr,
         dispatchConflict: noConflict,
         exec,
+        now,
+        scheduleInterval,
         log,
       },
     );
@@ -206,6 +232,8 @@ describe("act", () => {
       openPr,
       dispatchConflict: noConflict,
       exec,
+      now,
+      scheduleInterval,
       log: noopLog(),
     });
 
@@ -248,6 +276,8 @@ describe("act", () => {
         openPr,
         dispatchConflict: noConflict,
         exec,
+        now,
+        scheduleInterval,
         log,
       },
     );
@@ -315,6 +345,8 @@ describe("act", () => {
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
       exec,
+      now,
+      scheduleInterval,
       log: noopLog(),
     });
 
@@ -331,6 +363,8 @@ describe("act", () => {
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
       exec,
+      now,
+      scheduleInterval,
       log: noopLog(),
     });
 
@@ -363,6 +397,8 @@ describe("act", () => {
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
       exec,
+      now,
+      scheduleInterval,
       log: noopLog(),
     });
 
@@ -404,6 +440,8 @@ describe("act", () => {
           openPr: recordingOpenPr().openPr,
           dispatchConflict: noConflict,
           exec,
+          now,
+          scheduleInterval,
           log,
         },
       );
@@ -431,6 +469,8 @@ describe("act", () => {
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
       exec,
+      now,
+      scheduleInterval,
       log,
     });
 
@@ -476,6 +516,8 @@ describe("act", () => {
       openPr,
       dispatchConflict: noConflict,
       exec,
+      now,
+      scheduleInterval,
       log,
     });
 
@@ -506,6 +548,8 @@ describe("act", () => {
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
       exec,
+      now,
+      scheduleInterval,
       log,
     });
 
@@ -548,6 +592,8 @@ describe("act", () => {
         openPr: recordingOpenPr().openPr,
         dispatchConflict: noConflict,
         exec,
+        now,
+        scheduleInterval,
         log,
       },
     );
@@ -573,6 +619,8 @@ describe("act", () => {
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
       exec,
+      now,
+      scheduleInterval,
       log: noopLog(),
     });
 
@@ -599,6 +647,8 @@ describe("act", () => {
           openPr,
           dispatchConflict: noConflict,
           exec,
+          now,
+          scheduleInterval,
           log,
         },
       ),
@@ -623,6 +673,8 @@ describe("act", () => {
         openPr,
         dispatchConflict: noConflict,
         exec,
+        now,
+        scheduleInterval,
         log,
       }),
     ).rejects.toThrow("gh pr create exploded");
@@ -640,6 +692,189 @@ describe("act", () => {
   });
 });
 
+describe("act: heartbeat", () => {
+  it("emits no heartbeat when no Worker is running", async () => {
+    const { exec } = recordingExec();
+    const { log, events } = recordingLog();
+    const scheduler = fakeScheduler();
+
+    await act([{ type: "release", ticket: 4, assignees: ["operator"] }], {
+      dispatch: noDispatch,
+      openPr: recordingOpenPr().openPr,
+      dispatchConflict: noConflict,
+      exec,
+      now,
+      scheduleInterval: scheduler.scheduleInterval,
+      log,
+    });
+
+    expect(scheduler.starts).toEqual([]);
+    expect(events.some((e) => e.kind === "heartbeat")).toBe(false);
+  });
+
+  it("schedules the heartbeat once a minute, at info, and reports it stops once every Worker settles", async () => {
+    const { exec } = recordingExec();
+    const { log, events } = recordingLog();
+    const scheduler = fakeScheduler();
+    let releaseWorker!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseWorker = resolve;
+    });
+    const dispatch: DispatchWorker = async () => {
+      await gate;
+      return outcome(7);
+    };
+
+    const pending = act([{ type: "spawn", ticket: 7, attempt: 1 }], {
+      dispatch,
+      openPr: recordingOpenPr().openPr,
+      dispatchConflict: noConflict,
+      exec,
+      now,
+      scheduleInterval: scheduler.scheduleInterval,
+      log,
+    });
+
+    expect(scheduler.starts).toHaveLength(1);
+    expect(scheduler.starts[0]?.ms).toBe(60_000);
+    expect(scheduler.cancelCount()).toBe(0);
+
+    scheduler.starts[0]?.callback();
+    const heartbeat = events.find((e) => e.kind === "heartbeat");
+    expect(heartbeat?.level).toBe("info");
+    expect(heartbeat).toMatchObject({
+      workers: [{ ticket: 7, attempt: 1, elapsedMs: 0, sinceOutputMs: 0 }],
+    });
+
+    releaseWorker();
+    await pending;
+
+    expect(scheduler.cancelCount()).toBe(1);
+  });
+
+  it("reports elapsed time and time since output independently, updated via the Worker's activity callback", async () => {
+    const { exec } = recordingExec();
+    const { log, events } = recordingLog();
+    const scheduler = fakeScheduler();
+    const clock = { ms: 0 };
+    let activityCallback!: () => void;
+    let releaseWorker!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseWorker = resolve;
+    });
+    const dispatch: DispatchWorker = async (ticket, _attempt, onActivity) => {
+      activityCallback = onActivity;
+      await gate;
+      return outcome(ticket);
+    };
+
+    const pending = act([{ type: "spawn", ticket: 7, attempt: 1 }], {
+      dispatch,
+      openPr: recordingOpenPr().openPr,
+      dispatchConflict: noConflict,
+      exec,
+      now: () => clock.ms,
+      scheduleInterval: scheduler.scheduleInterval,
+      log,
+    });
+
+    clock.ms = 20_000;
+    activityCallback(); // the Worker produced output at t=20s
+    clock.ms = 90_000;
+    scheduler.starts[0]?.callback(); // the heartbeat fires at t=90s
+
+    const heartbeat = events.find((e) => e.kind === "heartbeat");
+    expect(heartbeat).toMatchObject({
+      workers: [
+        { ticket: 7, attempt: 1, elapsedMs: 90_000, sinceOutputMs: 70_000 },
+      ],
+    });
+
+    releaseWorker();
+    await pending;
+  });
+
+  it("covers the whole fleet on one line and keeps running while any Worker is still in flight", async () => {
+    const { exec } = recordingExec();
+    const { log, events } = recordingLog();
+    const scheduler = fakeScheduler();
+    let releaseSlow!: () => void;
+    const slowGate = new Promise<void>((resolve) => {
+      releaseSlow = resolve;
+    });
+    const dispatch: DispatchWorker = async (ticket) => {
+      if (ticket === 4) return outcome(4);
+      await slowGate;
+      return outcome(ticket);
+    };
+    // openPr runs only after #4's dispatch promise has settled and its
+    // activity entry cleared — awaiting it is a deterministic way to know
+    // #4 dropped out of the fleet before the heartbeat is made to fire.
+    let ticket4Settled!: () => void;
+    const ticket4SettledPromise = new Promise<void>((resolve) => {
+      ticket4Settled = resolve;
+    });
+    const openPr: OpenPr = async (settledOutcome) => {
+      if (settledOutcome.ticket === 4) ticket4Settled();
+      return `https://github.com/o/r/pull/${settledOutcome.ticket}0`;
+    };
+
+    const pending = act(
+      [
+        { type: "spawn", ticket: 2, attempt: 1 },
+        { type: "spawn", ticket: 4, attempt: 1 },
+      ],
+      {
+        dispatch,
+        openPr,
+        dispatchConflict: noConflict,
+        exec,
+        now,
+        scheduleInterval: scheduler.scheduleInterval,
+        log,
+      },
+    );
+    await ticket4SettledPromise;
+
+    scheduler.starts[0]?.callback();
+    const heartbeat = events.find((e) => e.kind === "heartbeat");
+    expect(heartbeat).toMatchObject({
+      workers: [{ ticket: 2, attempt: 1 }],
+    });
+    // Still one Worker in flight (#2): the scheduler is not cancelled yet.
+    expect(scheduler.cancelCount()).toBe(0);
+
+    releaseSlow();
+    await pending;
+
+    expect(scheduler.cancelCount()).toBe(1);
+  });
+
+  it("starts only one heartbeat scheduler for a Tick spawning several Workers", async () => {
+    const { exec } = recordingExec();
+    const dispatch: DispatchWorker = async (ticket) => outcome(ticket);
+    const scheduler = fakeScheduler();
+
+    await act(
+      [
+        { type: "spawn", ticket: 2, attempt: 1 },
+        { type: "spawn", ticket: 4, attempt: 1 },
+      ],
+      {
+        dispatch,
+        openPr: recordingOpenPr().openPr,
+        dispatchConflict: noConflict,
+        exec,
+        now,
+        scheduleInterval: scheduler.scheduleInterval,
+        log: noopLog(),
+      },
+    );
+
+    expect(scheduler.starts).toHaveLength(1);
+  });
+});
+
 describe("act: PR upkeep", () => {
   it("mechanically updates a behind PR's branch via the tracker", async () => {
     const { exec, calls } = recordingExec();
@@ -650,6 +885,8 @@ describe("act: PR upkeep", () => {
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
       exec,
+      now,
+      scheduleInterval,
       log,
     });
 
@@ -673,6 +910,8 @@ describe("act: PR upkeep", () => {
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
       exec,
+      now,
+      scheduleInterval,
       log,
     });
 
@@ -710,6 +949,8 @@ describe("act: PR upkeep", () => {
         openPr: recordingOpenPr().openPr,
         dispatchConflict,
         exec,
+        now,
+        scheduleInterval,
         log,
       },
     );
@@ -755,6 +996,8 @@ describe("act: PR upkeep", () => {
         openPr: recordingOpenPr().openPr,
         dispatchConflict,
         exec,
+        now,
+        scheduleInterval,
         log,
       },
     );
@@ -824,6 +1067,8 @@ describe("act: PR upkeep", () => {
         openPr: recordingOpenPr().openPr,
         dispatchConflict,
         exec,
+        now,
+        scheduleInterval,
         log,
       },
     );
@@ -859,6 +1104,8 @@ describe("act: PR upkeep", () => {
           openPr: recordingOpenPr().openPr,
           dispatchConflict,
           exec,
+          now,
+          scheduleInterval,
           log,
         },
       ),

--- a/tests/cli/app.test.ts
+++ b/tests/cli/app.test.ts
@@ -117,6 +117,7 @@ function fakeContext(
     },
     now: () => 0,
     sleep: async () => {},
+    scheduleInterval: () => () => {},
     log: recordingLog(events),
     setVerbose: (verbose) => {
       verbosityCalls.push(verbose);

--- a/tests/core/heartbeat.test.ts
+++ b/tests/core/heartbeat.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  heartbeatSnapshot,
+  type WorkerActivity,
+} from "../../src/core/heartbeat.js";
+
+function activity(overrides: Partial<WorkerActivity> = {}): WorkerActivity {
+  return {
+    ticket: 4,
+    attempt: 1,
+    startedAtMs: 0,
+    lastActivityAtMs: 0,
+    ...overrides,
+  };
+}
+
+describe("heartbeatSnapshot", () => {
+  it("reports elapsed time and time since output independently", () => {
+    const workers = [
+      activity({ ticket: 4, startedAtMs: 0, lastActivityAtMs: 20_000 }),
+    ];
+
+    expect(heartbeatSnapshot(workers, 90_000)).toEqual([
+      { ticket: 4, attempt: 1, elapsedMs: 90_000, sinceOutputMs: 70_000 },
+    ]);
+  });
+
+  it("reports zero time since output for a Worker whose latest chunk landed just now", () => {
+    const workers = [
+      activity({ ticket: 4, startedAtMs: 0, lastActivityAtMs: 90_000 }),
+    ];
+
+    expect(heartbeatSnapshot(workers, 90_000)).toEqual([
+      { ticket: 4, attempt: 1, elapsedMs: 90_000, sinceOutputMs: 0 },
+    ]);
+  });
+
+  it("snapshots every in-flight Worker, keeping each reading independent", () => {
+    const workers = [
+      activity({
+        ticket: 2,
+        attempt: 1,
+        startedAtMs: 0,
+        lastActivityAtMs: 60_000,
+      }),
+      activity({
+        ticket: 4,
+        attempt: 2,
+        startedAtMs: 30_000,
+        lastActivityAtMs: 119_000,
+      }),
+    ];
+
+    expect(heartbeatSnapshot(workers, 120_000)).toEqual([
+      { ticket: 2, attempt: 1, elapsedMs: 120_000, sinceOutputMs: 60_000 },
+      { ticket: 4, attempt: 2, elapsedMs: 90_000, sinceOutputMs: 1_000 },
+    ]);
+  });
+
+  it("answers empty for no in-flight Workers", () => {
+    expect(heartbeatSnapshot([], 60_000)).toEqual([]);
+  });
+});

--- a/tests/core/render.test.ts
+++ b/tests/core/render.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ResolvedConfig } from "../../src/core/config.js";
+import type { WorkerHeartbeat } from "../../src/core/heartbeat.js";
 import {
   buildCompleteReport,
   buildPlanReport,
@@ -7,6 +8,7 @@ import {
   type CompleteReport,
   type PlanReport,
   renderCompleteReport,
+  renderHeartbeat,
   renderPlanReport,
   renderStuckReport,
   type StuckReport,
@@ -381,6 +383,31 @@ describe("buildStuckReport", () => {
     );
 
     expect(report.tickets[0]?.reasons).toEqual([]);
+  });
+});
+
+describe("renderHeartbeat", () => {
+  it("renders elapsed time and time since output per Worker, on one line", () => {
+    const workers: WorkerHeartbeat[] = [
+      { ticket: 2, attempt: 1, elapsedMs: 125_000, sinceOutputMs: 5_000 },
+      { ticket: 4, attempt: 2, elapsedMs: 60_000, sinceOutputMs: 60_000 },
+    ];
+
+    expect(renderHeartbeat(workers)).toBe(
+      "Heartbeat: 2 Workers in flight — " +
+        "#2 attempt 1 (elapsed 2m5s, since output 5s), " +
+        "#4 attempt 2 (elapsed 1m0s, since output 1m0s)",
+    );
+  });
+
+  it("uses the singular for exactly one Worker", () => {
+    const workers: WorkerHeartbeat[] = [
+      { ticket: 7, attempt: 1, elapsedMs: 30_000, sinceOutputMs: 0 },
+    ];
+
+    expect(renderHeartbeat(workers)).toBe(
+      "Heartbeat: 1 Worker in flight — #7 attempt 1 (elapsed 30s, since output 0s)",
+    );
   });
 });
 


### PR DESCRIPTION
Add a per-minute fleet heartbeat while dispatch Workers are in flight, so a long Tick no longer looks dead.

## Summary

- While any dispatch Worker is running, `act` emits one `info` heartbeat every minute covering the whole fleet, each entry reporting elapsed time and time since that Worker's last output — independent signals, since elapsed alone can't tell slow from stuck.
- The activity signal rides the Worker process adapter's existing per-chunk stdout observation (the one that already re-arms the stall watchdog), surfaced through a new `onActivity` callback on `WorkerProcessRequest` — no new process seam, and the Worker's stream-json transcript is never parsed.
- The heartbeat scheduler starts on the first in-flight Worker and is cancelled the instant the last one settles; no heartbeat fires when nothing is running.
- The clock and interval scheduler are injected into the act phase (`ActDeps.now` / `ActDeps.scheduleInterval`), following the run loop's existing treatment of time — no test depends on real elapsed time.
- The new `heartbeat` `LogEvent` carries per-Worker `{ ticket, attempt, elapsedMs, sinceOutputMs }` as structured fields, so once the durable JSON log file lands (#50) a run's heartbeat history is queryable, not just prose.

## Design notes

- Scoped to dispatch Workers only (the `spawn` action), not Conflict Workers — CONTEXT.md defines "Worker" as a session dispatched against a Ticket and calls out Conflict Worker as a distinct variant with no Attempt number. A Conflict Worker in flight still produces no heartbeat line; if that's wanted, it's a natural follow-up.
- The heartbeat's own start/track/stop lifecycle is factored into a small `createHeartbeat` controller inside `act.ts`, kept apart from the action-dispatch switch so that switch still reads as "perform one planned write."
- `tickOnce` picked up a `TickDeps` record (`log`, `now`, `scheduleInterval`) instead of three more positional parameters, matching the existing `RunDeps`/`ActDeps` pattern.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (282 tests, all passing)
- [x] New tests: `tests/core/heartbeat.test.ts` (pure elapsed/since-output arithmetic), `tests/core/render.test.ts` (heartbeat line rendering), `tests/adapters/worker.test.ts` (the `onActivity` callback fires per stdout chunk through the real and faked process seam), `tests/app/act.test.ts` (heartbeat starts/stops/covers the fleet, driven by fake clock and scheduler, no real elapsed time)

Closes #54