### PR TITLE
feat(logging): debug-level instrumentation and a verbosity flag

### DIFF
--- a/src/adapters/tracker.ts
+++ b/src/adapters/tracker.ts
@@ -59,9 +59,10 @@ function exitCodeOf(error: unknown): number | null {
 /**
  * Decorates an `Exec` with a `debug` event per call, carrying the command and
  * its exit code — detail that does not exist today, so an operator can see
- * what the Orchestrator actually asked the tracker to do without reproducing
- * the run. Neither `cmd`/`args` nor an exit code ever carries a credential:
- * `gh` and `git` read auth from the environment, never argv.
+ * every `gh`/`git` command the Orchestrator actually issued, and how it
+ * exited, without reproducing the run. Neither `cmd`/`args` nor an exit code
+ * ever carries a credential: `gh` and `git` read auth from the environment,
+ * never argv.
  */
 export function withDebugLogging(exec: Exec, log: Log): Exec {
   return async (cmd, args) => {

--- a/src/adapters/tracker.ts
+++ b/src/adapters/tracker.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { Scope } from "../core/config.js";
+import type { Log } from "../core/log.js";
 import {
   type AttemptFailure,
   attemptMarker,
@@ -41,6 +42,54 @@ export const realExec: Exec = async (cmd, args) => {
   });
   return stdout;
 };
+
+/** The numeric exit code on a failed `execFile`, or null when the process never reported one (e.g. it never spawned). */
+function exitCodeOf(error: unknown): number | null {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof (error as { code: unknown }).code === "number"
+  ) {
+    return (error as { code: number }).code;
+  }
+  return null;
+}
+
+/**
+ * Decorates an `Exec` with a `debug` event per call, carrying the command and
+ * its exit code — detail that does not exist today, so an operator can see
+ * what the Orchestrator actually asked the tracker to do without reproducing
+ * the run. Neither `cmd`/`args` nor an exit code ever carries a credential:
+ * `gh` and `git` read auth from the environment, never argv.
+ */
+export function withDebugLogging(exec: Exec, log: Log): Exec {
+  return async (cmd, args) => {
+    try {
+      const stdout = await exec(cmd, args);
+      log({
+        kind: "tracker-command",
+        level: "debug",
+        msg: `${cmd} ${args.join(" ")} (exit 0)`,
+        cmd,
+        args,
+        exitCode: 0,
+      });
+      return stdout;
+    } catch (error) {
+      const exitCode = exitCodeOf(error);
+      log({
+        kind: "tracker-command",
+        level: "debug",
+        msg: `${cmd} ${args.join(" ")} (exit ${exitCode ?? "unknown"})`,
+        cmd,
+        args,
+        exitCode,
+      });
+      throw error;
+    }
+  };
+}
 
 interface GithubIssue {
   number: number;

--- a/src/adapters/worker.ts
+++ b/src/adapters/worker.ts
@@ -6,6 +6,7 @@ import {
   lastResultLine,
   parseResultEvent,
 } from "../core/classify.js";
+import type { Log, LogEvent } from "../core/log.js";
 import {
   AGENT_BRANCH_PREFIX,
   type FailureReason,
@@ -257,11 +258,16 @@ export async function branchCommitSubjects(
  * recorded progress (ADR 0001: GitHub is the only state store), so
  * re-running the Tick supersedes it.
  */
+/** No-op default for the optional `log` parameter, so every existing caller need not pass one. */
+const noopLog: Log = ((_event: LogEvent) => {}) as Log;
+noopLog.child = () => noopLog;
+
 export async function dispatchWorker(
   ticket: number,
   config: WorkerConfig,
   exec: Exec = realExec,
   spawnProcess: SpawnWorkerProcess = realSpawnWorkerProcess,
+  log: Log = noopLog,
 ): Promise<WorkerOutcome> {
   const branch = `${AGENT_BRANCH_PREFIX}${ticket}-attempt-${config.attempt}`;
   const worktree = join(RUN_DIR, "worktrees", `ticket-${ticket}`);
@@ -289,6 +295,18 @@ export async function dispatchWorker(
       "origin/HEAD",
     ]);
     return (await exec("git", ["rev-parse", branch])).trim();
+  });
+  // Logged once the worktree actually exists, so an operator can find a
+  // Worker's evidence — the worktree while it runs, the transcript any time
+  // after — without deriving the paths by hand.
+  log({
+    kind: "worker-paths",
+    level: "debug",
+    msg: `Worker for #${ticket} (attempt ${config.attempt}): worktree ${worktree}, transcript ${transcript}`,
+    ticket,
+    attempt: config.attempt,
+    worktree,
+    transcript,
   });
 
   try {
@@ -451,6 +469,7 @@ export async function dispatchConflictWorker(
   config: ConflictWorkerConfig,
   exec: Exec = realExec,
   spawnProcess: SpawnWorkerProcess = realSpawnWorkerProcess,
+  log: Log = noopLog,
 ): Promise<ConflictOutcome> {
   const worktree = join(RUN_DIR, "conflict-worktrees", `pr-${pr}`);
   const transcript = join(RUN_DIR, "transcripts", `pr-${pr}-conflict.jsonl`);
@@ -477,6 +496,14 @@ export async function dispatchConflictWorker(
     await exec("git", ["-C", worktree, "rebase", "origin/HEAD"]).catch(
       () => {},
     );
+  });
+  log({
+    kind: "conflict-worker-paths",
+    level: "debug",
+    msg: `Conflict Worker for PR #${pr}: worktree ${worktree}, transcript ${transcript}`,
+    pr,
+    worktree,
+    transcript,
   });
 
   try {

--- a/src/app/run.ts
+++ b/src/app/run.ts
@@ -144,6 +144,12 @@ export async function run(
       msg: `Next Tick in ${pollSeconds}s.`,
       pollSeconds,
     });
+    deps.log({
+      kind: "tick-wait",
+      level: "debug",
+      msg: `waiting ${pollSeconds}s before the next Tick`,
+      pollSeconds,
+    });
     await deps.sleep(pollSeconds * 1000);
   }
 }

--- a/src/app/tick.ts
+++ b/src/app/tick.ts
@@ -1,5 +1,5 @@
 import { openPrForOutcome } from "../adapters/pr.js";
-import { readScope, realExec } from "../adapters/tracker.js";
+import { readScope, realExec, withDebugLogging } from "../adapters/tracker.js";
 import { dispatchConflictWorker, dispatchWorker } from "../adapters/worker.js";
 import { modelForAttempt, type ResolvedConfig } from "../core/config.js";
 import type { Log } from "../core/log.js";
@@ -15,7 +15,11 @@ export async function tickOnce(
   dispatchPaused = false,
   log: Log,
 ): Promise<{ world: WorldSnapshot; actions: Action[]; infraFailures: number }> {
-  const world = await readScope(config.scope);
+  // Every tracker command this Tick issues, plus its exit code, is narrated
+  // at debug through the same seam — detail that does not exist today, kept
+  // out of the default console but always in the durable file.
+  const exec = withDebugLogging(realExec, log);
+  const world = await readScope(config.scope, exec);
   const actions = plan(world, {
     maxWorkers: config.maxWorkers,
     maxOpenPrs: config.maxOpenPrs,
@@ -36,27 +40,42 @@ export async function tickOnce(
     const titles = new Map(world.tickets.map((t) => [t.number, t.title]));
     const report = await act(actions, {
       dispatch: (ticket, attempt) =>
-        dispatchWorker(ticket, {
-          model: modelForAttempt(config, attempt),
-          attempt,
-          timeoutMs: config.timeoutMinutes * 60_000,
-          stallMs: config.stallMinutes * 60_000,
-          maxTurns: config.maxTurns,
-          maxCostUsd: config.maxCostUsd,
-        }),
+        dispatchWorker(
+          ticket,
+          {
+            model: modelForAttempt(config, attempt),
+            attempt,
+            timeoutMs: config.timeoutMinutes * 60_000,
+            stallMs: config.stallMinutes * 60_000,
+            maxTurns: config.maxTurns,
+            maxCostUsd: config.maxCostUsd,
+          },
+          undefined,
+          undefined,
+          log,
+        ),
       openPr: (outcome) =>
         openPrForOutcome(
           outcome,
           titles.get(outcome.ticket) ?? `Ticket #${outcome.ticket}`,
+          exec,
         ),
       dispatchConflict: (pr, ticket, headRef) =>
-        dispatchConflictWorker(pr, ticket, headRef, {
-          model: config.model,
-          timeoutMs: config.timeoutMinutes * 60_000,
-          stallMs: config.stallMinutes * 60_000,
-          maxTurns: config.maxTurns,
-        }),
-      exec: realExec,
+        dispatchConflictWorker(
+          pr,
+          ticket,
+          headRef,
+          {
+            model: config.model,
+            timeoutMs: config.timeoutMinutes * 60_000,
+            stallMs: config.stallMinutes * 60_000,
+            maxTurns: config.maxTurns,
+          },
+          undefined,
+          undefined,
+          log,
+        ),
+      exec,
       log,
     });
     infraFailures = report.infraFailures;

--- a/src/app/tick.ts
+++ b/src/app/tick.ts
@@ -1,6 +1,10 @@
 import { openPrForOutcome } from "../adapters/pr.js";
 import { readScope, realExec, withDebugLogging } from "../adapters/tracker.js";
-import { dispatchConflictWorker, dispatchWorker } from "../adapters/worker.js";
+import {
+  dispatchConflictWorker,
+  dispatchWorker,
+  realSpawnWorkerProcess,
+} from "../adapters/worker.js";
 import { modelForAttempt, type ResolvedConfig } from "../core/config.js";
 import type { Log } from "../core/log.js";
 import { plan } from "../core/plan.js";
@@ -15,9 +19,10 @@ export async function tickOnce(
   dispatchPaused = false,
   log: Log,
 ): Promise<{ world: WorldSnapshot; actions: Action[]; infraFailures: number }> {
-  // Every tracker command this Tick issues, plus its exit code, is narrated
-  // at debug through the same seam — detail that does not exist today, kept
-  // out of the default console but always in the durable file.
+  // Every command this Tick issues through the adapters — gh and git alike
+  // — plus its exit code, is narrated at debug through the same seam:
+  // detail that does not exist today, hidden from the console unless
+  // --verbose is passed.
   const exec = withDebugLogging(realExec, log);
   const world = await readScope(config.scope, exec);
   const actions = plan(world, {
@@ -50,8 +55,8 @@ export async function tickOnce(
             maxTurns: config.maxTurns,
             maxCostUsd: config.maxCostUsd,
           },
-          undefined,
-          undefined,
+          exec,
+          realSpawnWorkerProcess,
           log,
         ),
       openPr: (outcome) =>
@@ -71,8 +76,8 @@ export async function tickOnce(
             stallMs: config.stallMinutes * 60_000,
             maxTurns: config.maxTurns,
           },
-          undefined,
-          undefined,
+          exec,
+          realSpawnWorkerProcess,
           log,
         ),
       exec,

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -30,7 +30,7 @@ export interface Context extends CommandContext {
   readonly sleep: (ms: number) => Promise<void>;
   /** The single logging seam narration travels through; see src/core/log.ts. */
   readonly log: Log;
-  /** The verbosity flag: lowers the console's minimum level to debug. Never affects the file. */
+  /** The verbosity flag: lowers the console's minimum level to debug. Scoped to the console sink only. */
   readonly setVerbose: (verbose: boolean) => void;
 }
 

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -30,6 +30,8 @@ export interface Context extends CommandContext {
   readonly sleep: (ms: number) => Promise<void>;
   /** The single logging seam narration travels through; see src/core/log.ts. */
   readonly log: Log;
+  /** The verbosity flag: lowers the console's minimum level to debug. Never affects the file. */
+  readonly setVerbose: (verbose: boolean) => void;
 }
 
 /**
@@ -61,11 +63,13 @@ function tagFor(bindings: LogBindings): string {
 
 /**
  * Console sink for the Orchestrator's narration: pretty, colored, leveled,
- * timestamped, at a minimum level of `info`. Code-position and stack capture
- * are disabled — this is domain narration, not application debugging. Color
- * (and `NO_COLOR`/`FORCE_COLOR`) and TTY detection are handled by tslog
- * itself. Constructed only here: `core` and `app` never import the library,
- * they only see the `Log` function type.
+ * timestamped, at a minimum level of `info` — lowered to `debug` by the
+ * verbosity flag via `setMinLevel`, tslog's supported way to change a
+ * logger's level after construction. Code-position and stack capture are
+ * disabled — this is domain narration, not application debugging. Color (and
+ * `NO_COLOR`/`FORCE_COLOR`) and TTY detection are handled by tslog itself.
+ * Constructed only here: `core` and `app` never import the library, they
+ * only see the `Log` function type.
  *
  * The three report kinds bypass tslog entirely: they print as the familiar
  * unadorned block straight to the process's stdout, byte-identical to before
@@ -76,7 +80,10 @@ function tagFor(bindings: LogBindings): string {
  * Ticket/Attempt (or PR) as real fields once a structured sink exists to
  * read them.
  */
-function buildLog(cliProcess: StricliProcess): Log {
+function buildLog(cliProcess: StricliProcess): {
+  log: Log;
+  setVerbose: (verbose: boolean) => void;
+} {
   const rootLogger = new Logger({
     minLevel: "INFO",
     stack: { capture: "off" },
@@ -99,13 +106,16 @@ function buildLog(cliProcess: StricliProcess): Log {
       );
     return log;
   }
-  return wrap(rootLogger);
+  return {
+    log: wrap(rootLogger),
+    setVerbose: (verbose) => rootLogger.setMinLevel(verbose ? "DEBUG" : "INFO"),
+  };
 }
 
 /** The real context: today's collaborators, wired exactly as the entry point wired them before. */
 export function buildRealContext(): Context {
   const cliProcess = nodeProcessAdapter();
-  const log = buildLog(cliProcess);
+  const { log, setVerbose } = buildLog(cliProcess);
   return {
     process: cliProcess,
     loadConfig: (flags) => resolveConfig(loadConfigFile(process.cwd()), flags),
@@ -115,5 +125,6 @@ export function buildRealContext(): Context {
     now: () => Date.now(),
     sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
     log,
+    setVerbose,
   };
 }

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -16,7 +16,7 @@ export interface CliFlags {
   pollSeconds?: number;
   model?: string;
   retryModel?: string;
-  /** CLI-only, like `dryRun`: lowers the console's minimum level to debug, never the file's. */
+  /** CLI-only, like `dryRun`: lowers the console's minimum level to debug. */
   verbose: boolean;
 }
 
@@ -118,8 +118,7 @@ export const sharedFlags = {
   },
   verbose: {
     kind: "boolean",
-    brief:
-      "lower the console's minimum level to debug (the durable file is already at debug regardless)",
+    brief: "lower the console's minimum level to debug, for live debugging",
     default: false,
   },
 } as const satisfies FlagParametersForType<CliFlags, CommandContext>;

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -6,7 +6,7 @@ import {
 } from "../core/config.js";
 import type { Context } from "./context.js";
 
-/** The nine-flag set shared by `tick` and `run`; every field optional except the two booleans. */
+/** The ten-flag set shared by `tick` and `run`; every field optional except the three booleans. */
 export interface CliFlags {
   dryRun: boolean;
   parent?: number;
@@ -16,6 +16,8 @@ export interface CliFlags {
   pollSeconds?: number;
   model?: string;
   retryModel?: string;
+  /** CLI-only, like `dryRun`: lowers the console's minimum level to debug, never the file's. */
+  verbose: boolean;
 }
 
 /** The CLI's flags shape narrowed to what config resolution accepts (drops `dryRun`, a CLI-only concern). */
@@ -113,5 +115,11 @@ export const sharedFlags = {
     brief: "model second attempts run on (default opus, overrides config file)",
     placeholder: "name",
     optional: true,
+  },
+  verbose: {
+    kind: "boolean",
+    brief:
+      "lower the console's minimum level to debug (the durable file is already at debug regardless)",
+    default: false,
   },
 } as const satisfies FlagParametersForType<CliFlags, CommandContext>;

--- a/src/cli/run-command.ts
+++ b/src/cli/run-command.ts
@@ -9,6 +9,7 @@ async function runHandler(
   this: Context,
   flags: CliFlags,
 ): Promise<undefined | Error> {
+  this.setVerbose(flags.verbose);
   if (flags.dryRun) {
     return new ConfigError(
       "--dry-run only applies to tick: a dry run never progresses the loop",

--- a/src/cli/tick-command.ts
+++ b/src/cli/tick-command.ts
@@ -7,6 +7,7 @@ async function tickHandler(
   this: Context,
   flags: CliFlags,
 ): Promise<undefined | Error> {
+  this.setVerbose(flags.verbose);
   const config = resolveConfigFromFlags(this, flags);
   if (config instanceof Error) return config;
 

--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -50,9 +50,29 @@ export type LogEvent = LogEventBase &
     | { kind: "breaker-still-open"; trips: number; nextProbeMs: number }
     | { kind: "breaker-open"; infraFailures: number; nextProbeMs: number }
     | { kind: "next-tick"; pollSeconds: number }
+    | { kind: "tick-wait"; pollSeconds: number }
     | { kind: "plan-report"; report: PlanReport }
     | { kind: "stuck-report"; report: StuckReport }
     | { kind: "complete-report"; report: CompleteReport }
+    | {
+        kind: "tracker-command";
+        cmd: string;
+        args: string[];
+        exitCode: number | null;
+      }
+    | {
+        kind: "worker-paths";
+        ticket: number;
+        attempt: number;
+        worktree: string;
+        transcript: string;
+      }
+    | {
+        kind: "conflict-worker-paths";
+        pr: number;
+        worktree: string;
+        transcript: string;
+      }
   );
 
 /** Fields a Worker's (or Conflict Worker's) sub-logger binds onto every event it emits. */

--- a/tests/adapters/tracker.test.ts
+++ b/tests/adapters/tracker.test.ts
@@ -12,7 +12,9 @@ import {
   releaseTicket,
   updatePrBranch,
   voidAttempt,
+  withDebugLogging,
 } from "../../src/adapters/tracker.js";
+import type { Log, LogEvent } from "../../src/core/log.js";
 import {
   type AttemptFailure,
   attemptMarker,
@@ -954,5 +956,76 @@ describe("commentConflictUnresolved", () => {
         expect.stringContaining(CONFLICT_UNRESOLVED_MARKER),
       ],
     ]);
+  });
+});
+
+function recordingLog(): { log: Log; events: LogEvent[] } {
+  const events: LogEvent[] = [];
+  const log = ((event: LogEvent) => {
+    events.push(event);
+  }) as Log;
+  log.child = () => log;
+  return { log, events };
+}
+
+describe("withDebugLogging", () => {
+  it("logs the command and a 0 exit code at debug on success, without altering the result", async () => {
+    const exec: Exec = async () => "stdout output";
+    const { log, events } = recordingLog();
+
+    const result = await withDebugLogging(exec, log)("gh", [
+      "issue",
+      "view",
+      "5",
+    ]);
+
+    expect(result).toBe("stdout output");
+    expect(events).toEqual([
+      {
+        kind: "tracker-command",
+        level: "debug",
+        msg: "gh issue view 5 (exit 0)",
+        cmd: "gh",
+        args: ["issue", "view", "5"],
+        exitCode: 0,
+      },
+    ]);
+  });
+
+  it("logs the command and its exit code at debug on failure, then rethrows", async () => {
+    const error = Object.assign(new Error("exit status 1"), { code: 1 });
+    const exec: Exec = async () => {
+      throw error;
+    };
+    const { log, events } = recordingLog();
+
+    await expect(
+      withDebugLogging(exec, log)("gh", ["issue", "edit", "5"]),
+    ).rejects.toBe(error);
+
+    expect(events).toEqual([
+      {
+        kind: "tracker-command",
+        level: "debug",
+        msg: "gh issue edit 5 (exit 1)",
+        cmd: "gh",
+        args: ["issue", "edit", "5"],
+        exitCode: 1,
+      },
+    ]);
+  });
+
+  it("logs an unknown exit code when the failure carries none (e.g. the process never spawned)", async () => {
+    const exec: Exec = async () => {
+      throw new Error("spawn gh ENOENT");
+    };
+    const { log, events } = recordingLog();
+
+    await expect(
+      withDebugLogging(exec, log)("gh", ["issue", "view", "5"]),
+    ).rejects.toThrow("ENOENT");
+
+    expect(events[0]).toMatchObject({ exitCode: null });
+    expect(events[0]?.msg).toContain("exit unknown");
   });
 });

--- a/tests/adapters/worker.test.ts
+++ b/tests/adapters/worker.test.ts
@@ -18,6 +18,16 @@ import {
   type WorkerProcessRequest,
   workerPrompt,
 } from "../../src/adapters/worker.js";
+import type { Log, LogEvent } from "../../src/core/log.js";
+
+function recordingLog(): { log: Log; events: LogEvent[] } {
+  const events: LogEvent[] = [];
+  const log = ((event: LogEvent) => {
+    events.push(event);
+  }) as Log;
+  log.child = () => log;
+  return { log, events };
+}
 
 const WORKTREE = ".border-collie/worktrees/ticket-4";
 const BRANCH = "border-collie/ticket-4-attempt-1";
@@ -122,6 +132,33 @@ describe("dispatchWorker", () => {
         stallMs: 30_000,
       },
     ]);
+  });
+
+  it("logs the worktree and transcript paths at debug once the worktree exists, before spawning", async () => {
+    const { exec } = fakeExec({ newCommits: "3" });
+    const { spawn } = fakeSpawn(0);
+    const { log, events } = recordingLog();
+
+    await dispatchWorker(4, CONFIG, exec, spawn, log);
+
+    expect(events).toEqual([
+      {
+        kind: "worker-paths",
+        level: "debug",
+        msg: `Worker for #4 (attempt 1): worktree ${WORKTREE}, transcript ${TRANSCRIPT}`,
+        ticket: 4,
+        attempt: 1,
+        worktree: WORKTREE,
+        transcript: TRANSCRIPT,
+      },
+    ]);
+  });
+
+  it("logs nothing when no log is injected — existing callers are unaffected", async () => {
+    const { exec } = fakeExec({ newCommits: "3" });
+    const { spawn } = fakeSpawn(0);
+
+    await expect(dispatchWorker(4, CONFIG, exec, spawn)).resolves.toBeDefined();
   });
 
   it("serializes git phases across concurrent dispatches (repo-level locks), keeping Workers concurrent", async () => {
@@ -568,6 +605,33 @@ describe("dispatchConflictWorker", () => {
     });
     expect(requests[0]?.args).toContain(conflictWorkerPrompt());
     expect(requests[0]?.args).toContain("sonnet");
+  });
+
+  it("logs the worktree and transcript paths at debug once the rebase is set up, before spawning", async () => {
+    const { exec } = fakeConflictExec();
+    const { spawn } = fakeSpawn(0);
+    const { log, events } = recordingLog();
+
+    await dispatchConflictWorker(
+      30,
+      3,
+      HEAD_REF,
+      CONFLICT_CONFIG,
+      exec,
+      spawn,
+      log,
+    );
+
+    expect(events).toEqual([
+      {
+        kind: "conflict-worker-paths",
+        level: "debug",
+        msg: `Conflict Worker for PR #30: worktree ${CONFLICT_WT}, transcript ${CONFLICT_TRANSCRIPT}`,
+        pr: 30,
+        worktree: CONFLICT_WT,
+        transcript: CONFLICT_TRANSCRIPT,
+      },
+    ]);
   });
 
   it("resolves when the Worker exits cleanly and the branch now sits atop the base", async () => {

--- a/tests/app/run.test.ts
+++ b/tests/app/run.test.ts
@@ -350,7 +350,7 @@ describe("run", () => {
     expect(nextTick).toMatchObject({ pollSeconds: 45 });
   });
 
-  it("also logs the inter-Tick wait at debug, so the durable file has it even when the console hides it", async () => {
+  it("also logs the inter-Tick wait at debug, hidden from the console by default", async () => {
     const inFlight = world(
       [ticket({ number: 2, assignees: ["operator"], hasAgentClaim: true })],
       [2],

--- a/tests/app/run.test.ts
+++ b/tests/app/run.test.ts
@@ -350,6 +350,23 @@ describe("run", () => {
     expect(nextTick).toMatchObject({ pollSeconds: 45 });
   });
 
+  it("also logs the inter-Tick wait at debug, so the durable file has it even when the console hides it", async () => {
+    const inFlight = world(
+      [ticket({ number: 2, assignees: ["operator"], hasAgentClaim: true })],
+      [2],
+    );
+    const state = scriptedDeps([
+      { world: inFlight, actions: [] },
+      { world: world([ticket({ number: 2, state: "closed" })]), actions: [] },
+    ]);
+
+    await run(45, state.deps);
+
+    const tickWait = state.events.find((e) => e.kind === "tick-wait");
+    expect(tickWait?.level).toBe("debug");
+    expect(tickWait).toMatchObject({ pollSeconds: 45 });
+  });
+
   it("resumes from tracker truth when re-run after a human fixes a Stuck state", async () => {
     // Nothing but GitHub carries state: a run that exits Stuck ...
     const escalated = ticket({ number: 7, labels: ["ready-for-human"] });

--- a/tests/cli/app.test.ts
+++ b/tests/cli/app.test.ts
@@ -66,6 +66,7 @@ interface FakeContext {
   }[];
   probeCalls: string[];
   events: LogEvent[];
+  verbosityCalls: boolean[];
 }
 
 function fakeContext(
@@ -84,6 +85,7 @@ function fakeContext(
   }[] = [];
   const probeCalls: string[] = [];
   const events: LogEvent[] = [];
+  const verbosityCalls: boolean[] = [];
   const tickResults = overrides.tickResults ?? [{ world: CLOSED_WORLD }];
 
   const context: Context = {
@@ -116,6 +118,9 @@ function fakeContext(
     now: () => 0,
     sleep: async () => {},
     log: recordingLog(events),
+    setVerbose: (verbose) => {
+      verbosityCalls.push(verbose);
+    },
   };
 
   return {
@@ -126,6 +131,7 @@ function fakeContext(
     tickCalls,
     probeCalls,
     events,
+    verbosityCalls,
   };
 }
 
@@ -152,6 +158,14 @@ describe("argv → flags mapping", () => {
     await runCli(["tick", "--dry-run", "--parent", "1"], fake.context);
 
     expect(fake.loadConfigCalls[0]).not.toHaveProperty("dryRun");
+  });
+
+  it("drops --verbose from the flags object handed to config resolution", async () => {
+    const fake = fakeContext();
+
+    await runCli(["tick", "--verbose", "--parent", "1"], fake.context);
+
+    expect(fake.loadConfigCalls[0]).not.toHaveProperty("verbose");
   });
 
   it("omits unset flags entirely rather than passing them as undefined", async () => {
@@ -196,6 +210,40 @@ describe("integer flag rejection", () => {
 
     expect(fake.context.process.exitCode).toBe(1);
     expect(fake.stderr()).toContain("-1");
+  });
+});
+
+describe("verbosity flag", () => {
+  it("lowers the console's minimum level to debug for tick when --verbose is passed", async () => {
+    const fake = fakeContext();
+
+    await runCli(["tick", "--verbose", "--parent", "1"], fake.context);
+
+    expect(fake.verbosityCalls).toEqual([true]);
+  });
+
+  it("leaves the console at its default level for tick when --verbose is omitted", async () => {
+    const fake = fakeContext();
+
+    await runCli(["tick", "--parent", "1"], fake.context);
+
+    expect(fake.verbosityCalls).toEqual([false]);
+  });
+
+  it("lowers the console's minimum level to debug for run when --verbose is passed", async () => {
+    const fake = fakeContext({ tickResults: [{ world: CLOSED_WORLD }] });
+
+    await runCli(["run", "--verbose", "--parent", "1"], fake.context);
+
+    expect(fake.verbosityCalls).toEqual([true]);
+  });
+
+  it("does not affect config resolution — only the console sink", async () => {
+    const fake = fakeContext();
+
+    await runCli(["tick", "--verbose", "--parent", "1"], fake.context);
+
+    expect(fake.tickCalls).toHaveLength(1);
   });
 });
 
@@ -311,6 +359,14 @@ describe("help", () => {
 
     expect(fake.context.process.exitCode).toBeFalsy();
     expect(fake.stdout()).toContain("USAGE");
+  });
+
+  it("documents --verbose alongside the other flags in per-command help", async () => {
+    const fake = fakeContext();
+
+    await runCli(["tick", "--help"], fake.context);
+
+    expect(fake.stdout()).toContain("--verbose");
   });
 
   it("carries the tick/run lifecycle prose into per-command help", async () => {


### PR DESCRIPTION
Adds the `debug`-level detail from #53 across the adapters: every `gh`/`git` command issued through the injected `Exec` seam is now narrated at `debug` along with its exit code, a dispatched Worker's (and Conflict Worker's) worktree and transcript paths are logged at `debug` as soon as the worktree exists, and a `--verbose` flag lowers the console's minimum level to `debug` for live debugging.

`withDebugLogging` (`src/adapters/tracker.ts`) decorates the `Exec` seam with one `debug`-level `tracker-command` event per call, carrying the command, its args, and its exit code (read off the `execFile` error's `.code` on failure). `src/app/tick.ts` builds a single wrapped `exec` per Tick and threads it through every place a `gh`/`git` command can run that Tick — the observe phase's `readScope`, every tracker write in `act()`, PR opening, and the dispatched/conflict Workers' own worktree setup — so a failed `git worktree add` gets the same command/exit-code trail as a failed `gh` call, not just the gh-facing half.

`dispatchWorker`/`dispatchConflictWorker` (`src/adapters/worker.ts`) take an optional `log` parameter, defaulting to a no-op so every existing caller is unaffected, and emit a `worker-paths`/`conflict-worker-paths` debug event once the worktree exists and before the Worker spawns — so an operator can find a Worker's evidence without deriving the paths by hand, even while it's still running.

`src/app/run.ts` gets a new `tick-wait` debug event alongside the existing info-level `next-tick` announcement, capturing the inter-Tick wait at debug without touching #49's already-settled `info` narration.

The `--verbose` flag (`src/cli/flags.ts`) is CLI-only, like `--dry-run`. `Context.setVerbose` (`src/cli/context.ts`) calls tslog's `logger.setMinLevel("DEBUG" | "INFO")` on the console sink; both command handlers call it first, before doing anything else. It's documented via the flag's own `brief`, shown alongside every other flag in `--help`.

No credential or token value is at risk: `gh`/`git` never take auth as argv anywhere in this codebase (verified by grep), so echoing `cmd`/`args`/paths at debug introduces no new exposure.

This branch doesn't yet have the durable JSON file sink (#50) or per-Worker sub-loggers (#51) — both separate, unmerged siblings under the same epic (#47) — so comments and help text describe only what's true on this base: these events flow through the injected `Log` seam at `debug`, ready for a file sink to pick up once one exists, and `--verbose` only ever touches the console.

Lint, typecheck, and the full test suite (282 tests) pass.

Closes #53