### PR TITLE
ci(spike): measure OAuth token longevity in headless CI runs

### DIFF
--- a/.github/spike/README.md
+++ b/.github/spike/README.md
@@ -1,0 +1,159 @@
+# Spike: OAuth token longevity in CI (issue #63)
+
+**This directory is a throwaway experiment, not part of the product.** Nothing
+here is imported by `src/`, exercised by the test suite, or reachable from the
+shipped `dist/`. It exists to answer one question before the cloud migration is
+built on top of the answer.
+
+One thread does run in normal CI: `tsconfig.json` now includes `scripts/`, so
+`pnpm typecheck` covers `spike-observe.ts` and `spike-decide.ts`. That is
+deliberate — they import `src/core/classify.ts`, and an unchecked script would
+let that reuse rot silently — but it is also the one line to undo at disposal.
+
+## The question
+
+border-collie's Workers are long-lived — `DEFAULT_TIMEOUT_MINUTES` is 45 and
+`--max-turns` is 200 — so a Worker implementing one tracer-bullet Ticket runs
+15–40 minutes inside a single headless `claude -p` invocation. Moving the fleet
+off the operator's laptop means authenticating headless Claude Code in CI, which
+under subscription billing means `CLAUDE_CODE_OAUTH_TOKEN`. There are reports
+([anthropics/claude-code#28827](https://github.com/anthropics/claude-code/issues/28827))
+that OAuth access tokens are not refreshed in non-interactive runs, producing
+`401 authentication_error` after roughly 10–15 minutes.
+
+If that is still true, every Worker dies mid-Attempt, every death classifies as
+an Infrastructure failure, the circuit breaker trips every Tick, and no Ticket
+ever reaches Done. The GitHub Actions substrate would be unusable — and nobody
+here has measured it.
+
+## What is here
+
+| File | Role |
+| --- | --- |
+| `../workflows/spike-oauth-longevity.yml` | The experiment. Two measuring jobs plus a decision job, one manual trigger. |
+| `oauth-longevity-prompt.md` | The prompt both jobs run, byte-identical. |
+| `../../scripts/spike-observe.ts` | Reduces one job's captured evidence to a recorded observation. |
+| `../../scripts/spike-decide.ts` | Applies the decision rule to both observations and writes the finding. |
+
+The two measuring jobs share a token, a prompt, a turn cap, a model, and a point
+in time. The runner is the only thing chosen differently:
+
+- **Job A** — raw `claude -p`, argv mirroring `claudeArgs()` in
+  `src/adapters/worker.ts`, stdout to a transcript and stderr to its own file,
+  exactly as `realSpawnWorkerProcess` splits them.
+- **Job B** — `anthropics/claude-code-action@v1`, the Anthropic-maintained CI
+  wrapper, with the same prompt and turn cap through its `claude_args`
+  passthrough.
+
+Everything else that differs between them is imposed by the runner rather than
+chosen, and each difference is itself an observation: Job B needs a
+`github_token`, owns its own permissioning (so no
+`--dangerously-skip-permissions`), installs its own Claude Code, takes its
+wall-clock ceiling from a step timeout rather than `timeout(1)`, and gives back
+no separate stderr stream at all.
+
+The prompt is a three-pass read-only analysis of `src/` and `tests/` — around
+forty files and ten thousand lines. It is chosen to generate continuous tool
+activity well past the 10–15 minute danger zone without editing a file, making
+a network call, running a writing `git` command, or touching the tracker, all
+of which it forbids explicitly.
+
+`spike-observe.ts` deliberately reuses the Orchestrator's own
+`classifyInfrastructure`, `parseResultEvent`, and `lastResultLine` from
+`src/core/classify.ts`, against the same two sources a real Worker death is
+classified from (stderr and the result line, never the transcript body). If a
+death here reports `auth`, the identical evidence would void an Attempt and trip
+the circuit breaker in production.
+
+## Running it
+
+One-time setup, by a repository admin:
+
+1. Generate a token locally: `claude setup-token`.
+2. Store it as the repository secret `CLAUDE_CODE_OAUTH_TOKEN`
+   (`gh secret set CLAUDE_CODE_OAUTH_TOKEN`). Never commit it, and never pass
+   it on a command line — the jobs upload files they write themselves, and
+   GitHub masks secrets in the workflow log only.
+
+Then:
+
+```sh
+gh workflow run "Spike — OAuth token longevity (#63)"
+gh run watch
+```
+
+Inputs default to the production values (`sonnet`, 200 turns, a 45-minute
+ceiling) and only need overriding to re-test a narrower window. This repository
+is public, so the runner minutes are free.
+
+Each measuring job writes a job summary table and uploads a `spike-evidence/`
+artifact; the `decide` job uploads `finding.md`:
+
+- Job A — `transcript.jsonl`, `stderr.log`, `environment.txt`, `observation.json`
+- Job B — `execution-file.json`, `action-outputs.txt`, `runner-temp-listing.txt`,
+  `environment.txt`, `observation.json`
+- decide — `finding.md`
+
+Artifacts are the durable record. The runner filesystem is not, and a claim in
+the finding that no artifact backs is not a finding.
+
+One gap the artifacts cannot close on their own: **Job B has no stderr.** The
+action exposes no error stream, and if it dies before writing its execution
+file there is nothing left to classify — the observation will read
+`died-unclassified` whatever actually killed it. That cause is only legible in
+the action's own step log, so save it alongside the finding:
+
+```sh
+gh run view <run-id> --log-failed > job-b.log
+```
+
+Reading a log rather than a captured stream is exactly the observability cost
+the spike is measuring, so record that you had to.
+
+## Reading the result
+
+`observation.json` reports a `verdict` and, separately, `tokenSurvival` —
+whether the session got past 20 minutes without an `auth` signature. The two are
+distinct on purpose: a run killed by the 45-minute wall clock still answers the
+question, because the token lasted the whole time. `elapsedSeconds` next to
+`hitCeiling` is what separates a token expiry at ~12 minutes from a clean
+timeout at 45.
+
+`tokenSurvival` is three-valued, and `inconclusive` is not a failure. A session
+that simply finished its three passes in fifteen minutes never tested the token;
+lengthen the prompt or raise the turn cap and run it again rather than reading
+it as a dead substrate. `model` and `maxTurns` are recorded next to the verdict
+for the same reason — a pass measured under weakened dispatch inputs does not
+license a real Worker's 45 minutes.
+
+## The decision this gates
+
+The `decide` job applies this rule to both observations and writes `finding.md`
+— the table below is what it encodes, kept here so a reader need not run it.
+
+| Outcome | What it means |
+| --- | --- |
+| Both jobs survive | Build Workers on raw `claude -p`; the classification pipeline, the fleet heartbeat, and the stall watchdog all keep the process seam they ride on. |
+| Only Job B survives | Build on the action, and open a follow-up for how much of classification, heartbeat, and stall detection is recoverable without per-chunk stdout and a process death mode. |
+| Neither survives | The Actions substrate is invalid for Workers. The substrate decision reopens before anything is built on it. |
+
+Raw `claude -p` is the preferred answer independently of which is nicer: the
+last several releases' worth of work — structured log events, per-Worker
+correlation, the durable run log, the fleet heartbeat — all ride on owning the
+process seam directly. Read the spike as answering "can we keep `claude -p`?"
+
+## Disposal
+
+Post `finding.md` as a comment on issue #63, adding anything only the step logs
+could tell you (Job B's cause of death, the Claude Code version the action
+installed). If the result changes the substrate decision, record that as an ADR
+too, since it would supersede reasoning already captured in `docs/adr/`.
+
+Then, in one commit:
+
+1. Delete this directory, `../workflows/spike-oauth-longevity.yml`,
+   `../../scripts/spike-observe.ts`, and `../../scripts/spike-decide.ts` — or
+   relabel all four as an explicit periodic canary. Do not leave them in place
+   unmarked.
+2. Revert `scripts` from `include` in `tsconfig.json` if nothing else has moved
+   into `scripts/` as TypeScript by then.

--- a/.github/spike/oauth-longevity-prompt.md
+++ b/.github/spike/oauth-longevity-prompt.md
@@ -1,0 +1,52 @@
+Analyse this repository's source and test trees exhaustively.
+
+This is a read-only exercise. Its purpose is to keep one Claude Code session
+continuously busy for a long stretch of wall-clock time. Nothing you produce is
+kept; the only thing that matters is that you keep working, in the open, until
+the work is done or you are stopped.
+
+## Hard constraints
+
+Breaking any of these invalidates the run.
+
+- Change nothing on disk. No file creation, modification, deletion, or move —
+  no Write, no Edit, no shell redirection, no `mkdir`, no `rm`, no `mv`.
+- Run no git command that writes. No `commit`, `add`, `checkout`, `switch`,
+  `branch`, `push`, `merge`, `rebase`, `stash`, `tag`, or `config`. Read-only
+  git (`log`, `show`, `status`, `diff`) is fine.
+- Make no network call. No `curl`, no `wget`, no package install, no web fetch,
+  no web search.
+- Touch no issue tracker. No `gh` command of any kind.
+- Read no environment variable and print none. No `env`, no `printenv`, no
+  `echo $ANYTHING`, no reading `.env` or a credentials file. This session holds
+  a live OAuth token in its environment and everything it writes to stdout is
+  uploaded as a public artifact.
+- Do not ask questions and do not stop early. This session is headless; there
+  is nobody to answer, and stopping early is the one outcome that makes the
+  measurement worthless.
+
+## Work
+
+Do three passes, in order, over the same file list.
+
+**Pass 1 — inventory.** List every file under `src/` and `tests/`, sorted
+lexically by path. Report the list. This ordering is the spine of the next two
+passes; use it unchanged.
+
+**Pass 2 — describe.** Walk the list in order. Read each file in full, then for
+every symbol it exports — function, type, interface, constant, class — write
+two to four sentences covering: what it does, what it assumes about its inputs
+and about the environment around it, and how it fails. Report each file's
+descriptions as you finish it, rather than saving them all for the end.
+
+**Pass 3 — verify.** Walk the same list again in the same order. Re-read each
+file and check every description you wrote in pass 2 against the code it
+describes. For each one, report either that it holds or what specifically is
+wrong with it and what the corrected description is. Do not take pass 2 on
+trust; the point of this pass is to look again.
+
+Keep every description and correction in your replies. Write nothing to disk.
+
+When all three passes are complete, close with one paragraph on what the three
+passes together say about how this codebase separates its pure core from its
+I/O adapters.

--- a/.github/workflows/spike-oauth-longevity.yml
+++ b/.github/workflows/spike-oauth-longevity.yml
@@ -1,0 +1,343 @@
+# SPIKE — NOT PART OF THE PRODUCT. See issue #63 and .github/spike/README.md.
+#
+# Question: does a subscription OAuth token (`claude setup-token`) survive a
+# 20+ minute headless Claude Code run in CI, and on which runner? Everything
+# downstream of the cloud migration — the Worker substrate, the forensic story,
+# the fleet heartbeat, and the survival of src/core/classify.ts — depends on
+# the answer, so it is measured before any of it is built.
+#
+# Two jobs, one trigger, one token, one prompt, one point in time:
+#   A — raw `claude -p`, argv mirroring what dispatchWorker builds today.
+#   B — anthropics/claude-code-action@v1, the maintained CI wrapper.
+#
+# Delete this file, or relabel it as an explicit periodic canary, once the
+# finding is recorded on issue #63.
+name: Spike — OAuth token longevity (#63)
+
+# Manual only. Never push, never pull_request, never schedule: a spike that
+# fires on its own is no longer a spike.
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: Model the session runs on (mirrors worker_model)
+        default: sonnet
+      max_turns:
+        description: Turn cap (mirrors DEFAULT_MAX_TURNS)
+        default: "200"
+      ceiling_minutes:
+        description: Wall-clock ceiling (mirrors DEFAULT_TIMEOUT_MINUTES)
+        default: "45"
+
+# Read-only. The spike must not be able to push a branch, open a pull request,
+# or write to the tracker even if a session ignores its prompt.
+permissions:
+  contents: read
+
+env:
+  # Where both jobs put everything they upload. Only files written under here
+  # are ever exported, and no step writes a credential into any of them.
+  EVIDENCE: spike-evidence
+
+jobs:
+  raw-claude-p:
+    name: Job A — raw claude -p
+    runs-on: ubuntu-latest
+    # Above the in-job ceiling, so hitting the ceiling still leaves room to
+    # observe and upload rather than losing the evidence to a job kill.
+    timeout-minutes: 75
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # actions/checkout otherwise writes a token into .git/config as an
+          # http.extraheader. GitHub masks secrets in the workflow log, never
+          # in files a process writes itself, and this job uploads files.
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code@latest
+
+      - name: Record the environment
+        run: |
+          set -euo pipefail
+          mkdir -p "$EVIDENCE"
+          # The reports this spike re-tests predate the current release, so the
+          # version under test is part of the finding, not a footnote.
+          {
+            echo "claude: $(claude --version)"
+            echo "node: $(node --version)"
+            echo "runner: $RUNNER_OS $(uname -srm)"
+            echo "started_utc: $(date -u +%FT%TZ)"
+          } | tee "$EVIDENCE/environment.txt"
+
+      - name: Run the long headless session
+        id: session
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Dispatch inputs arrive as environment, never interpolated into the
+          # script body: `${{ }}` inside `run:` is textual substitution.
+          MODEL: ${{ inputs.model }}
+          MAX_TURNS: ${{ inputs.max_turns }}
+          CEILING_MINUTES: ${{ inputs.ceiling_minutes }}
+        run: |
+          set -euo pipefail
+          prompt=$(cat .github/spike/oauth-longevity-prompt.md)
+          started=$(date +%s)
+          # argv mirrors claudeArgs() in src/adapters/worker.ts, and the
+          # stdout/stderr split mirrors realSpawnWorkerProcess: the transcript
+          # stays parseable stream-json, errors land somewhere legible.
+          # SIGKILL, like the Orchestrator's wall-clock watchdog — a wedged
+          # session may not be servicing signals. No GH_TOKEN in this env, so
+          # `gh` cannot authenticate even if the session ignores its prompt.
+          set +e
+          timeout --signal=KILL "${CEILING_MINUTES}m" \
+            claude \
+              -p "$prompt" \
+              --model "$MODEL" \
+              --max-turns "$MAX_TURNS" \
+              --output-format stream-json \
+              --verbose \
+              --dangerously-skip-permissions \
+              > "$EVIDENCE/transcript.jsonl" \
+              2> "$EVIDENCE/stderr.log"
+          exit_code=$?
+          set -e
+          ended=$(date +%s)
+          {
+            echo "exit_code=$exit_code"
+            echo "elapsed_seconds=$((ended - started))"
+            echo "ceiling_seconds=$((CEILING_MINUTES * 60))"
+          } >> "$GITHUB_OUTPUT"
+          echo "exited $exit_code after $((ended - started))s"
+
+      - name: Observe
+        if: always()
+        env:
+          EXIT_CODE: ${{ steps.session.outputs.exit_code }}
+          ELAPSED_SECONDS: ${{ steps.session.outputs.elapsed_seconds }}
+          CEILING_SECONDS: ${{ steps.session.outputs.ceiling_seconds }}
+          MODEL: ${{ inputs.model }}
+          MAX_TURNS: ${{ inputs.max_turns }}
+        run: |
+          set -euo pipefail
+          pnpm exec tsx scripts/spike-observe.ts \
+            --job A \
+            --runner "raw claude -p" \
+            --record "$EVIDENCE/transcript.jsonl" \
+            --stderr "$EVIDENCE/stderr.log" \
+            --exit-code "$EXIT_CODE" \
+            --elapsed-seconds "$ELAPSED_SECONDS" \
+            --ceiling-seconds "$CEILING_SECONDS" \
+            --model "$MODEL" \
+            --max-turns "$MAX_TURNS" \
+            --out "$EVIDENCE/observation.json" \
+          | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: spike-job-a-raw-claude-p
+          path: ${{ env.EVIDENCE }}
+          # The artifact is the record: a claim in the finding that no uploaded
+          # file backs is not a finding, so an empty upload is a failed run.
+          if-no-files-found: error
+
+  claude-code-action:
+    name: Job B — claude-code-action@v1
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Load the shared prompt and record the environment
+        run: |
+          set -euo pipefail
+          mkdir -p "$EVIDENCE"
+          # Byte-identical to Job A's prompt. Via the environment file, because
+          # it is multi-line and an action input cannot read a file itself.
+          {
+            echo 'SPIKE_PROMPT<<SPIKE_PROMPT_EOF'
+            cat .github/spike/oauth-longevity-prompt.md
+            echo 'SPIKE_PROMPT_EOF'
+            echo "SPIKE_STARTED=$(date +%s)"
+          } >> "$GITHUB_ENV"
+          # No `claude --version` here: the action installs and owns its own
+          # Claude Code, and which version that is only shows in the step log.
+          {
+            echo "node: $(node --version)"
+            echo "runner: $RUNNER_OS $(uname -srm)"
+            echo "started_utc: $(date -u +%FT%TZ)"
+          } | tee "$EVIDENCE/environment.txt"
+
+      - name: Run the long headless session
+        id: claude
+        # The action failing is a result, not a broken workflow: the job has to
+        # survive it to observe and upload.
+        continue-on-error: true
+        # The action exposes no wall-clock knob of its own, so the ceiling is
+        # imposed from outside — the same 45 minutes Job A gives itself.
+        timeout-minutes: ${{ fromJSON(inputs.ceiling_minutes) }}
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: ${{ env.SPIKE_PROMPT }}
+          # The same turn cap and model Job A runs under, through the action's
+          # CLI passthrough. No --dangerously-skip-permissions: the action owns
+          # permissioning, and whether that changes the run is an observation.
+          claude_args: --max-turns ${{ inputs.max_turns }} --model ${{ inputs.model }}
+          # Both on, because "what does this runner give back?" is half the
+          # question — user stories 11 and 12.
+          show_full_output: "true"
+          display_report: "true"
+
+      - name: Collect what the action exposed
+        id: collect
+        if: always()
+        env:
+          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+          STEP_OUTCOME: ${{ steps.claude.outcome }}
+          SESSION_ID: ${{ steps.claude.outputs.session_id }}
+          BRANCH_NAME: ${{ steps.claude.outputs.branch_name }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$EVIDENCE"
+          ended=$(date +%s)
+          # This step runs even when the step that stamped SPIKE_STARTED did
+          # not, and an unbound variable under `set -u` would take the whole
+          # observation down with it. An unknown elapsed time is reported as
+          # unknown; the observer treats an empty value as null.
+          if [ -n "${SPIKE_STARTED:-}" ]; then
+            elapsed=$((ended - SPIKE_STARTED))
+          else
+            elapsed=""
+          fi
+          echo "elapsed_seconds=$elapsed" >> "$GITHUB_OUTPUT"
+          # The action's own record, copied out of the runner before it dies.
+          if [ -n "$EXECUTION_FILE" ] && [ -f "$EXECUTION_FILE" ]; then
+            cp "$EXECUTION_FILE" "$EVIDENCE/execution-file.json"
+          fi
+          # Which outputs the action actually populated: the raw material for
+          # judging how much of classification, the fleet heartbeat, and the
+          # stall watchdog survive a move onto it. Deliberately not the
+          # `github_token` output — that is a credential, and this file is
+          # uploaded as an artifact.
+          {
+            echo "step_outcome=$STEP_OUTCOME"
+            echo "execution_file=$EXECUTION_FILE"
+            echo "execution_file_copied=$([ -f "$EVIDENCE/execution-file.json" ] && echo yes || echo no)"
+            echo "session_id=$SESSION_ID"
+            echo "branch_name=$BRANCH_NAME"
+            echo "elapsed_seconds=${elapsed:-unknown}"
+          } | tee "$EVIDENCE/action-outputs.txt"
+          # File names only, never contents: whatever else the action leaves in
+          # the runner's temp directory may hold a credential, and this listing
+          # is uploaded. What it left behind is the honest answer to "what does
+          # this runner give back?" when the run dies before writing a record.
+          find "$RUNNER_TEMP" -maxdepth 2 -printf '%y %10s %p\n' 2>/dev/null \
+            | sort -k3 > "$EVIDENCE/runner-temp-listing.txt" || true
+
+      - name: Observe
+        if: always()
+        env:
+          ELAPSED_SECONDS: ${{ steps.collect.outputs.elapsed_seconds }}
+          STEP_OUTCOME: ${{ steps.claude.outcome }}
+          CEILING_MINUTES: ${{ inputs.ceiling_minutes }}
+          MODEL: ${{ inputs.model }}
+          MAX_TURNS: ${{ inputs.max_turns }}
+        run: |
+          set -euo pipefail
+          # No --stderr: the action gives back no separate stderr stream, which
+          # is itself part of the finding. A Job B death with no execution file
+          # therefore classifies as `died-unclassified` however it died — read
+          # the cause off the action's own step log, and attach that log to the
+          # finding, as .github/spike/README.md sets out.
+          pnpm exec tsx scripts/spike-observe.ts \
+            --job B \
+            --runner "anthropics/claude-code-action@v1" \
+            --record "$EVIDENCE/execution-file.json" \
+            --step-outcome "$STEP_OUTCOME" \
+            --elapsed-seconds "$ELAPSED_SECONDS" \
+            --ceiling-seconds "$((CEILING_MINUTES * 60))" \
+            --model "$MODEL" \
+            --max-turns "$MAX_TURNS" \
+            --out "$EVIDENCE/observation.json" \
+          | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: spike-job-b-claude-code-action
+          path: ${{ env.EVIDENCE }}
+          if-no-files-found: error
+
+  decide:
+    name: Apply the decision rule
+    runs-on: ubuntu-latest
+    needs: [raw-claude-p, claude-code-action]
+    # Both jobs record a failing runner as evidence, not as a broken workflow,
+    # so the decision has to run whatever they returned.
+    if: always()
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: actions/download-artifact@v8
+        with:
+          path: observations
+        # A job that lost its evidence is reported as lost evidence, not as a
+        # failed runner — so a missing artifact must not stop the decision.
+        continue-on-error: true
+
+      - name: Write the finding
+        run: |
+          set -euo pipefail
+          # The rule from issue #63, executed rather than described, so the
+          # recommendation the migration spec cites cannot drift from the
+          # evidence it was drawn from. A missing observation is reported as
+          # lost evidence, not silently read as a failed runner.
+          pnpm exec tsx scripts/spike-decide.ts \
+            --a observations/spike-job-a-raw-claude-p/observation.json \
+            --b observations/spike-job-b-claude-code-action/observation.json \
+            --out finding.md \
+          | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the finding
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: spike-finding
+          path: finding.md
+          if-no-files-found: error

--- a/scripts/spike-decide.ts
+++ b/scripts/spike-decide.ts
@@ -1,0 +1,138 @@
+//
+// spike-decide.ts — apply the spike's decision rule to both jobs' observations
+// and emit the finding, ready to paste onto issue #63. Throwaway, paired with
+// .github/workflows/spike-oauth-longevity.yml. See .github/spike/README.md.
+//
+// The two jobs observe themselves in isolation; the decision the spike gates is
+// about the pair. This is the only place the rule from the issue is executed
+// rather than described, so that the recommendation the migration spec cites
+// cannot drift from the evidence it was drawn from.
+//
+// Usage:
+//   pnpm exec tsx scripts/spike-decide.ts \
+//     --a job-a/observation.json \
+//     --b job-b/observation.json \
+//     --out finding.md
+//
+// The recommendation is a starting point for the operator, not the last word:
+// an `inconclusive` run means the experiment did not answer its question and
+// should be re-run, not that the substrate is broken.
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+/** The subset of an observation this rule turns on. */
+interface Observation {
+  job: string;
+  runner: string;
+  verdict: string;
+  tokenSurvival: "yes" | "no" | "inconclusive";
+  elapsedSeconds: number | null;
+  infraSignature: string | null;
+  model: string | null;
+  maxTurns: number | null;
+  terminatingResultEvent: boolean;
+  recordShape: string;
+  stderrCaptured: boolean;
+}
+
+function fail(message: string): never {
+  process.stderr.write(`spike-decide: ${message}\n`);
+  process.exit(1);
+}
+
+/**
+ * A job that never wrote an observation is a job whose evidence was lost, which
+ * is a different thing from a job that died — and worth saying so rather than
+ * defaulting it to a failure and recommending against a runner on no data.
+ */
+function readObservation(path: string, job: string): Observation | null {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as Observation;
+  } catch {
+    process.stderr.write(`spike-decide: no observation for job ${job}\n`);
+    return null;
+  }
+}
+
+const argv = process.argv.slice(2);
+const arg = (flag: string): string => {
+  const index = argv.indexOf(flag);
+  const value = index === -1 ? undefined : argv[index + 1];
+  return value ?? fail(`missing required ${flag}`);
+};
+
+const a = readObservation(arg("--a"), "A");
+const b = readObservation(arg("--b"), "B");
+const outPath = arg("--out");
+
+/** Survival is the token question alone; observability is judged separately. */
+const survived = (o: Observation | null) => o?.tokenSurvival === "yes";
+const inconclusive = (o: Observation | null) =>
+  o === null || o.tokenSurvival === "inconclusive";
+
+// The rule as issue #63 states it, with one addition it does not: an
+// inconclusive run is not a failure. A session that ended early for its own
+// reasons never tested the token, and reading that as "the substrate is dead"
+// would be the most expensive wrong conclusion this spike could reach.
+const { headline, recommendation } =
+  inconclusive(a) || inconclusive(b)
+    ? {
+        headline: "Inconclusive — re-run before deciding",
+        recommendation:
+          "At least one job ended before the 20-minute threshold for a reason other than authentication, so it never tested the token. Lengthen the prompt or raise the turn cap and run the workflow again. Do not read this as a substrate failure.",
+      }
+    : survived(a) && survived(b)
+      ? {
+          headline: "Both runners survive",
+          recommendation:
+            "Build Workers on raw `claude -p`. The classification pipeline, the fleet heartbeat, and the stall watchdog all keep the process seam they ride on, and no part of the existing forensic story has to be rebuilt.",
+        }
+      : survived(a)
+        ? {
+            headline: "Only raw `claude -p` survives",
+            recommendation:
+              "Build Workers on raw `claude -p`, which is the preferred answer anyway. Nothing further is owed to `claude-code-action`.",
+          }
+        : survived(b)
+          ? {
+              headline: "Only `claude-code-action` survives",
+              recommendation:
+                "Build Workers on `anthropics/claude-code-action@v1`, and open a follow-up for how much of classification, the fleet heartbeat, and stall detection is recoverable without per-chunk stdout and a process death mode. Cite this run's Job B observability rows as the starting inventory.",
+            }
+          : {
+              headline: "Neither runner survives",
+              recommendation:
+                "The GitHub Actions substrate is invalid for Workers under subscription billing. Reopen the substrate decision before any of the cloud migration is built on it, and record the reversal as an ADR — it supersedes reasoning already captured in docs/adr/.",
+            };
+
+const describe = (o: Observation | null, job: string): string[] =>
+  o === null
+    ? [`### Job ${job}`, "", "No observation was uploaded — evidence lost.", ""]
+    : [
+        `### Job ${job} — \`${o.runner}\``,
+        "",
+        `- **Verdict:** ${o.verdict}`,
+        `- **Token survived 20+ min:** ${o.tokenSurvival}`,
+        `- **Elapsed at exit:** ${o.elapsedSeconds ?? "unknown"}s`,
+        `- **Infrastructure signature:** ${o.infraSignature ?? "none"}`,
+        `- **Terminating result event:** ${o.terminatingResultEvent ? "yes" : "no"}`,
+        `- **Ran as:** ${o.model ?? "?"}, max ${o.maxTurns ?? "?"} turns`,
+        `- **Record shape:** ${o.recordShape}; separate stderr: ${o.stderrCaptured ? "yes" : "no"}`,
+        "",
+      ];
+
+const finding = [
+  `## Spike finding: OAuth token longevity in CI — ${headline}`,
+  "",
+  ...describe(a, "A"),
+  ...describe(b, "B"),
+  "### Recommendation",
+  "",
+  recommendation,
+  "",
+  "Full transcripts, stderr captures, and execution records are attached to this workflow run as artifacts.",
+  "",
+].join("\n");
+
+writeFileSync(outPath, finding);
+process.stdout.write(finding);

--- a/scripts/spike-observe.ts
+++ b/scripts/spike-observe.ts
@@ -1,0 +1,266 @@
+//
+// spike-observe.ts — reduce one spike job's captured evidence to a recorded
+// observation. Throwaway, paired with .github/workflows/spike-oauth-longevity.yml.
+// See issue #63 and .github/spike/README.md.
+//
+// The spike asks whether a subscription OAuth token survives a long headless
+// run. The workflow captures the evidence; this reads it and says what
+// happened, deliberately through the SAME classification the Orchestrator
+// applies to real Worker deaths (src/core/classify.ts). That reuse is the
+// point: if a death here classifies as `auth`, the identical evidence would
+// void an Attempt and trip the circuit breaker in production.
+//
+// Usage — `--record` is whatever stream-json the runner gave back, Job A's
+// transcript or Job B's execution file; every flag but --job/--runner/--out is
+// optional, and an absent one is reported as unknown rather than guessed:
+//
+//   pnpm exec tsx scripts/spike-observe.ts \
+//     --job A --runner "raw claude -p" \
+//     --record   spike-evidence/transcript.jsonl \
+//     --stderr   spike-evidence/stderr.log \
+//     --exit-code 137 \
+//     --elapsed-seconds 2700 \
+//     --ceiling-seconds 2700 \
+//     --model sonnet --max-turns 200 \
+//     --out spike-evidence/observation.json
+//
+// Writes the observation as JSON to `--out` and a Markdown summary to stdout
+// (the workflow tees that into the job summary). A dead session, an empty
+// transcript, and a missing file are all findings rather than errors, so only a
+// usage mistake exits non-zero.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import {
+  classifyInfrastructure,
+  lastResultLine,
+  parseResultEvent,
+} from "../src/core/classify.js";
+
+/** The question the spike exists to answer: does the token last past this? */
+const SURVIVAL_THRESHOLD_SECONDS = 20 * 60;
+
+/** Usage mistakes stop the run, and say so in one line rather than a stack. */
+function fail(message: string): never {
+  process.stderr.write(`spike-observe: ${message}\n`);
+  process.exit(1);
+}
+
+/** `--key value` pairs; anything else is a usage error. */
+function parseArgs(argv: string[]): Map<string, string> {
+  const args = new Map<string, string>();
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i];
+    const value = argv[i + 1];
+    if (key === undefined || !key.startsWith("--") || value === undefined) {
+      fail(`bad argument at position ${i}: expected --key value`);
+    }
+    args.set(key.slice(2), value);
+  }
+  return args;
+}
+
+/** Missing files are evidence too — a job that died early may write none. */
+function readOrEmpty(path: string | undefined): string {
+  if (path === undefined) return "";
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+/** How a runner chose to record the session's stream-json events. */
+type RecordShape = "jsonl" | "json-array" | "empty" | "unrecognized";
+
+/**
+ * Both runners' records reduced to the JSONL the Orchestrator's parsers
+ * expect, plus the shape they arrived in. Job A writes `claude`'s stdout
+ * straight through, so it is already newline-delimited. `claude-code-action`
+ * writes an execution file, and whether that file is JSONL, a single JSON
+ * array, or something else entirely is itself one of the observations the
+ * spike is here to make (user stories 11 and 12) — so the shape is reported
+ * rather than assumed.
+ */
+function toStreamJsonLines(raw: string): {
+  lines: string;
+  shape: RecordShape;
+  eventCount: number;
+} {
+  if (raw.trim() === "") return { lines: "", shape: "empty", eventCount: 0 };
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return {
+        lines: parsed.map((event) => JSON.stringify(event)).join("\n"),
+        shape: "json-array",
+        eventCount: parsed.length,
+      };
+    }
+  } catch {}
+  const events = raw
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .filter((line) => {
+      try {
+        JSON.parse(line);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+  return events.length > 0
+    ? { lines: events.join("\n"), shape: "jsonl", eventCount: events.length }
+    : { lines: "", shape: "unrecognized", eventCount: 0 };
+}
+
+const args = parseArgs(process.argv.slice(2));
+const required = (key: string): string =>
+  args.get(key) ?? fail(`missing required --${key}`);
+const asNumber = (key: string): number | null => {
+  const value = args.get(key);
+  if (value === undefined || value.trim() === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const job = required("job");
+const runner = required("runner");
+const outPath = required("out");
+const elapsedSeconds = asNumber("elapsed-seconds");
+const ceilingSeconds = asNumber("ceiling-seconds");
+const exitCode = asNumber("exit-code");
+// The settings the run actually used, recorded rather than assumed: the
+// dispatch inputs are overridable, and a "pass" measured under a shortened
+// ceiling or a smaller turn cap does not license a real Worker's 45 minutes.
+const model = args.get("model") ?? null;
+const maxTurns = asNumber("max-turns");
+
+const { lines, shape, eventCount } = toStreamJsonLines(
+  readOrEmpty(args.get("record")),
+);
+const stderr = readOrEmpty(args.get("stderr"));
+const result = parseResultEvent(lines);
+const resultLine = lastResultLine(lines);
+
+// The Orchestrator's own rule, applied to the same two sources: stderr and the
+// result line. Never the transcript body — a session that spends 20 minutes
+// reading src/core/classify.ts quotes every one of these signatures back at us.
+const infra = classifyInfrastructure(`${stderr}\n${resultLine}`);
+// The same rule again, narrowed to stderr alone, so the finding can say where
+// the evidence was rather than only that it existed. Deliberately not a second
+// hand-written regex: two auth tests that disagree would undermine the whole
+// premise that this is the production classification.
+const stderrSignature = classifyInfrastructure(stderr);
+
+// Elapsed time, not the exit code, decides this — Job B is killed by a step
+// timeout and reports no exit code at all. It is the single distinction the
+// whole spike turns on: a death at ~12 minutes is the token expiring, a death
+// at the ceiling is the experiment running out of room.
+const hitCeiling =
+  ceilingSeconds !== null &&
+  elapsedSeconds !== null &&
+  elapsedSeconds >= ceilingSeconds;
+
+// Same precedence dispatchWorker applies: a turn-cap halt trumps infrastructure,
+// because a result event proves the environment carried the session to its own
+// end whatever infra-looking noise the logs hold. A clean finish is read off the
+// result event rather than the exit code, since Job B exposes no exit code at
+// all — the event is the only evidence both runners can produce.
+const verdict =
+  result?.subtype === "error_max_turns"
+    ? "turn-cap-halt"
+    : infra === "auth"
+      ? "auth-failure"
+      : infra !== undefined
+        ? `infra-${infra}`
+        : result?.subtype === "success"
+          ? "clean-finish"
+          : hitCeiling
+            ? "wall-clock-ceiling"
+            : "died-unclassified";
+
+// The headline, and deliberately three-valued. A run killed by the 45-minute
+// ceiling still answers the question — the token lasted the whole time — so
+// survival is measured on elapsed time, not on a clean exit. But a session that
+// simply finished its work in fifteen minutes proves nothing either way, and
+// reporting that as "no" would read as a token failure it never observed.
+const tokenSurvival: "yes" | "no" | "inconclusive" =
+  infra === "auth"
+    ? "no"
+    : elapsedSeconds !== null && elapsedSeconds >= SURVIVAL_THRESHOLD_SECONDS
+      ? "yes"
+      : "inconclusive";
+
+const observation = {
+  job,
+  runner,
+  verdict,
+  tokenSurvival,
+  survivalThresholdSeconds: SURVIVAL_THRESHOLD_SECONDS,
+  elapsedSeconds,
+  ceilingSeconds,
+  hitCeiling,
+  exitCode,
+  stepOutcome: args.get("step-outcome") ?? null,
+  // What the run was actually configured with, so a weakened run cannot be
+  // read back as a pass at production settings.
+  model,
+  maxTurns,
+  // Whether the session ended on its own terms, and how it said it ended.
+  terminatingResultEvent: result !== undefined,
+  resultSubtype: result?.subtype ?? null,
+  turns: result?.numTurns ?? null,
+  costUsd: result?.totalCostUsd ?? null,
+  // What the Orchestrator's classifier makes of the death, if it died.
+  infraSignature: infra ?? null,
+  stderrSignature: stderrSignature ?? null,
+  // What this runner gives back — the observability half of the question.
+  recordShape: shape,
+  streamJsonEvents: eventCount,
+  stderrCaptured: args.get("stderr") !== undefined,
+  stderrBytes: Buffer.byteLength(stderr),
+  resultLinePresent: resultLine !== "",
+};
+
+writeFileSync(outPath, `${JSON.stringify(observation, null, 2)}\n`);
+
+const row = (label: string, value: unknown) =>
+  `| ${label} | ${value === null ? "—" : String(value)} |`;
+process.stdout.write(
+  [
+    `## Job ${job} — ${runner}`,
+    "",
+    "| Observation | Value |",
+    "| --- | --- |",
+    row("Verdict", verdict),
+    row(
+      `Token survived ${SURVIVAL_THRESHOLD_SECONDS / 60}+ min`,
+      tokenSurvival,
+    ),
+    row("Elapsed at exit (s)", elapsedSeconds),
+    row("Hit wall-clock ceiling", hitCeiling ? "yes" : "no"),
+    row("Process exit code", exitCode),
+    row("Step outcome", observation.stepOutcome),
+    row("Ran as", `${model ?? "?"}, max ${maxTurns ?? "?"} turns`),
+    row(
+      "Terminating result event",
+      observation.terminatingResultEvent ? "yes" : "no",
+    ),
+    row("Result subtype", observation.resultSubtype),
+    row("Turns", observation.turns),
+    row("Cost (USD)", observation.costUsd),
+    row(
+      "classifyInfrastructure(stderr + result line)",
+      observation.infraSignature,
+    ),
+    row("classifyInfrastructure(stderr alone)", observation.stderrSignature),
+    row("Record shape", `${shape} (${eventCount} events)`),
+    row(
+      "stderr captured separately",
+      observation.stderrCaptured
+        ? `yes (${observation.stderrBytes} bytes)`
+        : "no",
+    ),
+    "",
+  ].join("\n"),
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "verbatimModuleSyntax": true,
     "skipLibCheck": true
   },
-  "include": ["src", "tests"]
+  "include": ["src", "tests", "scripts"]
 }


### PR DESCRIPTION
Closes #63 once the finding lands on it.

## Why

Workers run 15-40 minutes inside one headless `claude -p`. Reports say a subscription OAuth token stops refreshing non-interactively and 401s at ~10-15 minutes. If that still holds, every Worker dies mid-Attempt, every death classifies as Infrastructure, the breaker trips each Tick, and the Actions substrate is unusable for the cloud migration. Nobody here has measured it.

This is the instrument, not the answer. The answer is a comment on #63 once the workflow has run.

## What

`.github/workflows/spike-oauth-longevity.yml`, `workflow_dispatch` only, `permissions: contents: read`. Two measuring jobs share a token, a prompt, a turn cap, a model and a point in time, and choose only the runner differently:

- **Job A** — raw `claude -p`, argv mirroring `claudeArgs()` in `src/adapters/worker.ts`, stdout to a transcript and stderr to its own file exactly as `realSpawnWorkerProcess` splits them, under `timeout --signal=KILL 45m`.
- **Job B** — `anthropics/claude-code-action@v1`, same prompt and turn cap through `claude_args`.

A third job applies the decision rule to both observations and writes `finding.md`, so the recommendation the migration spec cites cannot drift from the evidence it was drawn from.

`scripts/spike-observe.ts` reuses the Orchestrator's own `classifyInfrastructure`, `parseResultEvent` and `lastResultLine` against the same two sources a real Worker death is judged from — stderr and the result line, never the transcript body. A death here would therefore classify identically in production. `scripts` joins tsconfig's `include` for that reason: an unchecked script would let the reuse rot silently.

The prompt is a three-pass read-only analysis of `src/` and `tests/` (39 files, ~10k lines), chosen to generate continuous tool activity well past the 10-15 minute danger zone. It forbids file writes, writing git, network calls, `gh`, and reading or printing environment variables — the token is in the session's env and stdout is uploaded as a public artifact.

## Verification

Lint, typecheck, 307 tests, build, smoke and actionlint all pass. The observer and the decider were exercised against synthetic evidence for every outcome: auth death at 12 minutes, ceiling kill, clean finish, turn-cap halt, JSON-array execution file, missing record, lost artifact. Confirmed that a transcript body quoting `authentication_error` does not classify as an auth failure.

## Known limits

- **Job B has no stderr.** If the action dies on auth before writing its execution file, the observation reads `died-unclassified`. Not fixable from inside the job; `.github/spike/README.md` says to attach `gh run view --log-failed`, and notes that needing to is itself part of the finding.
- **`tsconfig.json`** is the one line touching non-spike config. It is in the disposal checklist.

## Disposal

Throwaway. `.github/spike/README.md` carries the runbook, the decision rule and the disposal checklist. Delete all four files and revert the tsconfig line, or relabel as an explicit periodic canary, once the finding is recorded.