### PR TITLE
ci(spike): lengthen the longevity prompt past the danger zone

### DIFF
--- a/.github/spike/README.md
+++ b/.github/spike/README.md
@@ -52,11 +52,17 @@ chosen, and each difference is itself an observation: Job B needs a
 wall-clock ceiling from a step timeout rather than `timeout(1)`, and gives back
 no separate stderr stream at all.
 
-The prompt is a three-pass read-only analysis of `src/` and `tests/` — around
+The prompt is a four-pass read-only analysis of `src/` and `tests/` — around
 forty files and ten thousand lines. It is chosen to generate continuous tool
 activity well past the 10–15 minute danger zone without editing a file, making
 a network call, running a writing `git` command, or touching the tracker, all
 of which it forbids explicitly.
+
+It also forbids batching: one tool call per step, one file at a time. The first
+run of this spike covered all thirty-nine files in forty-three turns and
+finished in nine minutes, answering nothing — the session was never the
+constraint, the work was. Serialising the reads and adding the cross-reference
+pass is what makes the run long enough to be worth measuring.
 
 `spike-observe.ts` deliberately reuses the Orchestrator's own
 `classifyInfrastructure`, `parseResultEvent`, and `lastResultLine` from
@@ -120,7 +126,7 @@ question, because the token lasted the whole time. `elapsedSeconds` next to
 timeout at 45.
 
 `tokenSurvival` is three-valued, and `inconclusive` is not a failure. A session
-that simply finished its three passes in fifteen minutes never tested the token;
+that simply finished its four passes in fifteen minutes never tested the token;
 lengthen the prompt or raise the turn cap and run it again rather than reading
 it as a dead substrate. `model` and `maxTurns` are recorded next to the verdict
 for the same reason — a pass measured under weakened dispatch inputs does not

--- a/.github/spike/oauth-longevity-prompt.md
+++ b/.github/spike/oauth-longevity-prompt.md
@@ -25,28 +25,50 @@ Breaking any of these invalidates the run.
   is nobody to answer, and stopping early is the one outcome that makes the
   measurement worthless.
 
+## Pace
+
+One tool call per message, always. Do not batch reads, do not issue tool calls
+in parallel, and do not read two files in one step. Work one file at a time and
+report on it before moving to the next.
+
+This is not a style preference. The measurement needs a session that stays busy
+for a long stretch of wall-clock time, and batching collapses that stretch to
+nothing. A first run of this prompt covered thirty-nine files in forty-three
+turns and finished in nine minutes, which answered nothing.
+
 ## Work
 
-Do three passes, in order, over the same file list.
+Do four passes, in order, over the same file list.
 
 **Pass 1 — inventory.** List every file under `src/` and `tests/`, sorted
-lexically by path. Report the list. This ordering is the spine of the next two
-passes; use it unchanged.
+lexically by path. Report the list. This ordering is the spine of every pass
+that follows; use it unchanged.
 
-**Pass 2 — describe.** Walk the list in order. Read each file in full, then for
-every symbol it exports — function, type, interface, constant, class — write
-two to four sentences covering: what it does, what it assumes about its inputs
-and about the environment around it, and how it fails. Report each file's
-descriptions as you finish it, rather than saving them all for the end.
+**Pass 2 — describe.** Walk the list in order, one file per step. Read each file
+in full, then for every symbol it exports — function, type, interface, constant,
+class — write two to four sentences covering: what it does, what it assumes
+about its inputs and about the environment around it, and how it fails. Report
+each file's descriptions as you finish it, rather than saving them all for the
+end.
 
-**Pass 3 — verify.** Walk the same list again in the same order. Re-read each
-file and check every description you wrote in pass 2 against the code it
-describes. For each one, report either that it holds or what specifically is
-wrong with it and what the corrected description is. Do not take pass 2 on
-trust; the point of this pass is to look again.
+**Pass 3 — verify.** Walk the same list again in the same order, one file per
+step. Re-read each file and check every description you wrote in pass 2 against
+the code it describes. For each one, report either that it holds or what
+specifically is wrong with it and what the corrected description is. Do not take
+pass 2 on trust; the point of this pass is to look again.
 
-Keep every description and correction in your replies. Write nothing to disk.
+**Pass 4 — cross-reference.** Go through every exported symbol you catalogued in
+pass 2, in the same file order, one symbol per step. Search the repository for
+its call sites, and report: how many there are, which layers they sit in
+(`core`, `adapters`, `app`, `cli`, or tests), whether the symbol is covered by a
+test that exercises it directly, and whether any call site contradicts the
+description you settled on in pass 3. Keep going until every symbol has been
+looked up. Do not sample, do not stop at the interesting ones, and do not
+shorten the pass because it is repetitive — the repetition is the point.
 
-When all three passes are complete, close with one paragraph on what the three
-passes together say about how this codebase separates its pure core from its
-I/O adapters.
+Keep every description, correction, and cross-reference in your replies. Write
+nothing to disk.
+
+If you complete all four passes, close with one paragraph on what they together
+say about how this codebase separates its pure core from its I/O adapters. It is
+expected and fine to be stopped before you get there.


### PR DESCRIPTION
Refs #63. The prompt change that turned the spike from inconclusive into an answer.

## Why

The first dispatch ([run 30637310067](https://github.com/lyeyixian/border-collie/actions/runs/30637310067)) answered nothing. Both jobs finished cleanly — Job A in 9m over 43 turns, Job B in 12.6m over 78 — so neither reached the 20-minute threshold and neither tested the token.

Turns were never the constraint (43 and 78 of 200). The work was: the session batched thirty-nine file reads into a handful of parallel calls and ran out of things to do.

## What

- Forbid batching. One tool call per step, one file at a time, stated as a measurement requirement rather than a style preference, with the first run's numbers quoted so the instruction reads as load-bearing.
- Add a fourth pass cross-referencing every exported symbol against its call sites — layers, test coverage, and any contradiction with the description settled in pass 3.
- Tell the session that being stopped before the end is expected, so it does not compress the work to reach a tidy finish.

## Result

[Run 30638593819](https://github.com/lyeyixian/border-collie/actions/runs/30638593819): Job A ran 1408s over 196 turns, Job B 1400s over 201. Both cleared the 20-minute threshold with no authentication signature, which is what the spike existed to find out. Full finding on #63.