### PR TITLE
refactor(act): extract Attempt settling from the act phase

### DIFF
--- a/src/app/act.ts
+++ b/src/app/act.ts
@@ -5,10 +5,8 @@ import {
   type Exec,
   escalateTicket,
   markPrReady,
-  releaseFailedTicket,
   releaseTicket,
   updatePrBranch,
-  voidAttempt,
 } from "../adapters/tracker.js";
 import { type ConflictOutcome, pushAgentBranch } from "../adapters/worker.js";
 import { reclassifyCorrelatedFailures } from "../core/classify.js";
@@ -16,6 +14,7 @@ import { heartbeatSnapshot, type WorkerActivity } from "../core/heartbeat.js";
 import type { Log } from "../core/log.js";
 import { renderHeartbeat } from "../core/render.js";
 import type { Action, WorkerOutcome } from "../core/types.js";
+import { settleAttempt } from "./settle.js";
 
 /** How often the fleet heartbeat reports, while any Worker is in flight. */
 const HEARTBEAT_INTERVAL_MS = 60_000;
@@ -68,16 +67,6 @@ interface SpawnResult {
 interface ConflictSpawnResult {
   outcome: ConflictOutcome;
   log: Log;
-}
-
-function describeOutcome(outcome: WorkerOutcome): string {
-  const commits = `${outcome.newCommits} new commit${outcome.newCommits === 1 ? "" : "s"}`;
-  const where = `on ${outcome.branch} (transcript: ${outcome.transcript})`;
-  if (outcome.ok) return `Worker succeeded: ${commits} ${where}`;
-  if (outcome.infra !== undefined) {
-    return `Worker hit an infrastructure failure (${outcome.infra}): attempt ${outcome.attempt} voided, exit ${outcome.exitCode} ${where}`;
-  }
-  return `Worker failed attempt ${outcome.attempt} (${outcome.failure}): exit ${outcome.exitCode}, ${commits} ${where}`;
 }
 
 /** What one Tick's act phase reports back to the loop. */
@@ -176,22 +165,20 @@ function describeConflict(outcome: ConflictOutcome): string {
  * at a time, narrating each as it lands. Spawns are the exception: each
  * Worker starts as its action is reached but runs concurrently, its branch
  * becoming a draft PR the moment it succeeds, and the Tick waits for all of
- * them before reporting outcomes. A failed attempt is then released with its
- * forensic record — the write that makes attempt history live on the
- * tracker, where the next Tick's retry ladder and a later Escalation read it
- * back. An infrastructure-classified failure is voided instead: a comment
- * that uncounts the claim while keeping it held, so an outage burns no
- * Attempts — and the same-way-same-Tick heuristic reclassifies correlated
- * deaths once every Worker has settled. The report's infra count is what
- * trips the caller's circuit breaker. A tracker failure mid-way throws — the
- * stateless recovery story is re-running the Tick, which recomputes the
- * world and re-plans whatever is still due. PR upkeep runs alongside dispatch:
- * the mechanical branch update and draft→ready flip are immediate tracker
- * writes; a conflict Worker runs concurrently like a spawn, its resolved
- * rebase pushed (or the PR handed to a human) once it settles. While any
- * dispatch Worker is in flight, a fleet heartbeat reports all of them once a
- * minute — elapsed time and time since last output, independently — and
- * stops the moment the last one settles.
+ * them before reporting outcomes. The same-way-same-Tick heuristic
+ * reclassifies correlated deaths once every Worker has settled, then each
+ * outcome's write — the forensic release for a Ticket failure, the void for
+ * an Infrastructure failure — is delegated to `settleAttempt`, the unit a
+ * Worker settling its own Attempt will one day share. The report's infra
+ * count is what trips the caller's circuit breaker. A tracker failure
+ * mid-way throws — the stateless recovery story is re-running the Tick,
+ * which recomputes the world and re-plans whatever is still due. PR upkeep
+ * runs alongside dispatch: the mechanical branch update and draft→ready flip
+ * are immediate tracker writes; a conflict Worker runs concurrently like a
+ * spawn, its resolved rebase pushed (or the PR handed to a human) once it
+ * settles. While any dispatch Worker is in flight, a fleet heartbeat reports
+ * all of them once a minute — elapsed time and time since last output,
+ * independently — and stops the moment the last one settles.
  */
 export async function act(
   actions: Action[],
@@ -334,64 +321,7 @@ export async function act(
     log: spawn.log,
   }));
   for (const { outcome, prUrl, log: workerLog } of outcomes) {
-    workerLog({
-      kind: "worker-outcome",
-      level: outcome.infra !== undefined ? "warn" : "info",
-      msg: describeOutcome(outcome),
-      outcome,
-    });
-    if (prUrl !== undefined) {
-      workerLog({
-        kind: "pr-opened",
-        level: "info",
-        msg: `opened draft PR: ${prUrl}`,
-        prUrl,
-      });
-    }
-    if (outcome.costOverrun && outcome.costUsd !== undefined) {
-      workerLog({
-        kind: "cost-overrun",
-        level: "warn",
-        msg: `cost overrun: attempt ${outcome.attempt} spent $${outcome.costUsd.toFixed(2)} — the ticket may be cut too big for one Worker`,
-        costUsd: outcome.costUsd,
-      });
-    }
-    if (outcome.infra !== undefined) {
-      await voidAttempt(
-        outcome.ticket,
-        {
-          attempt: outcome.attempt,
-          reason: outcome.infra,
-          model: outcome.model,
-          transcript: outcome.transcript,
-        },
-        exec,
-      );
-      workerLog({
-        kind: "attempt-voided",
-        level: "warn",
-        msg: `voided attempt ${outcome.attempt} (${outcome.infra}); claim held`,
-        reason: outcome.infra,
-      });
-    } else if (outcome.failure) {
-      await releaseFailedTicket(
-        outcome.ticket,
-        {
-          attempt: outcome.attempt,
-          reason: outcome.failure,
-          model: outcome.model,
-          branch: outcome.branch,
-          transcript: outcome.transcript,
-        },
-        exec,
-      );
-      workerLog({
-        kind: "attempt-released",
-        level: "info",
-        msg: `released with the attempt record (failed attempt ${outcome.attempt})`,
-        reason: outcome.failure,
-      });
-    }
+    await settleAttempt(outcome, prUrl, workerLog, exec);
   }
   // Conflict Workers settle alongside the dispatch Workers: a resolved merge is
   // pushed to the PR's branch, an unresolved one handed to a human with the

--- a/src/app/settle.ts
+++ b/src/app/settle.ts
@@ -1,0 +1,97 @@
+import {
+  type Exec,
+  releaseFailedTicket,
+  voidAttempt,
+} from "../adapters/tracker.js";
+import type { Log } from "../core/log.js";
+import type { WorkerOutcome } from "../core/types.js";
+
+function describeOutcome(outcome: WorkerOutcome): string {
+  const commits = `${outcome.newCommits} new commit${outcome.newCommits === 1 ? "" : "s"}`;
+  const where = `on ${outcome.branch} (transcript: ${outcome.transcript})`;
+  if (outcome.ok) return `Worker succeeded: ${commits} ${where}`;
+  if (outcome.infra !== undefined) {
+    return `Worker hit an infrastructure failure (${outcome.infra}): attempt ${outcome.attempt} voided, exit ${outcome.exitCode} ${where}`;
+  }
+  return `Worker failed attempt ${outcome.attempt} (${outcome.failure}): exit ${outcome.exitCode}, ${commits} ${where}`;
+}
+
+/**
+ * Settle one finished Attempt: narrate the outcome, then perform the single
+ * tracker write its shape implies — a forensic release for a Ticket failure,
+ * a void for an Infrastructure failure, neither for a success (whose only
+ * write, opening the draft PR, has already happened by the time this runs;
+ * `prUrl` just carries the result forward to narrate). The caller's `log`
+ * carries this Attempt's ticket/attempt bindings, so every line it emits
+ * stays tellable apart from a sibling Attempt settling concurrently.
+ *
+ * A single per-outcome unit shareable by anything that finishes an Attempt
+ * and needs the same write — today the act phase, once every Worker in a
+ * Tick has settled and correlated failures are reclassified; later a Worker
+ * settling its own Attempt in its own process (issue #71).
+ */
+export async function settleAttempt(
+  outcome: WorkerOutcome,
+  prUrl: string | undefined,
+  log: Log,
+  exec: Exec,
+): Promise<void> {
+  log({
+    kind: "worker-outcome",
+    level: outcome.infra !== undefined ? "warn" : "info",
+    msg: describeOutcome(outcome),
+    outcome,
+  });
+  if (prUrl !== undefined) {
+    log({
+      kind: "pr-opened",
+      level: "info",
+      msg: `opened draft PR: ${prUrl}`,
+      prUrl,
+    });
+  }
+  if (outcome.costOverrun && outcome.costUsd !== undefined) {
+    log({
+      kind: "cost-overrun",
+      level: "warn",
+      msg: `cost overrun: attempt ${outcome.attempt} spent $${outcome.costUsd.toFixed(2)} — the ticket may be cut too big for one Worker`,
+      costUsd: outcome.costUsd,
+    });
+  }
+  if (outcome.infra !== undefined) {
+    await voidAttempt(
+      outcome.ticket,
+      {
+        attempt: outcome.attempt,
+        reason: outcome.infra,
+        model: outcome.model,
+        transcript: outcome.transcript,
+      },
+      exec,
+    );
+    log({
+      kind: "attempt-voided",
+      level: "warn",
+      msg: `voided attempt ${outcome.attempt} (${outcome.infra}); claim held`,
+      reason: outcome.infra,
+    });
+  } else if (outcome.failure) {
+    await releaseFailedTicket(
+      outcome.ticket,
+      {
+        attempt: outcome.attempt,
+        reason: outcome.failure,
+        model: outcome.model,
+        branch: outcome.branch,
+        transcript: outcome.transcript,
+      },
+      exec,
+    );
+    log({
+      kind: "attempt-released",
+      level: "info",
+      msg: `released with the attempt record (failed attempt ${outcome.attempt})`,
+      reason: outcome.failure,
+    });
+  }
+}

--- a/tests/app/act.test.ts
+++ b/tests/app/act.test.ts
@@ -11,7 +11,6 @@ import {
 import type { Log, LogBindings, LogEvent } from "../../src/core/log.js";
 import {
   type AttemptFailure,
-  attemptMarker,
   CLAIM_MARKER,
   CONFLICT_UNRESOLVED_MARKER,
   RELEASE_MARKER,
@@ -241,7 +240,7 @@ describe("act", () => {
   });
 
   it("runs spawned Workers concurrently, opens a PR per success, and reports each outcome", async () => {
-    const { exec } = recordingExec();
+    const { exec, calls } = recordingExec();
     const { openPr, opened } = recordingOpenPr();
     const { log, events } = recordingLog();
     const dispatched: number[] = [];
@@ -284,6 +283,39 @@ describe("act", () => {
 
     expect(dispatched).toEqual([2, 4]);
     expect(opened).toEqual([2]); // only the success becomes a PR
+    // Wiring check: act() reaches the tracker through settleAttempt with the
+    // right ticket per outcome — a success writes nothing beyond its claim,
+    // a Ticket failure is released with its forensic record. Exact write
+    // content is settleAttempt's own tests' job.
+    expect(calls).toEqual([
+      ["gh", "issue", "edit", "2", "--add-assignee", "@me"],
+      [
+        "gh",
+        "issue",
+        "comment",
+        "2",
+        "--body",
+        expect.stringContaining(CLAIM_MARKER),
+      ],
+      ["gh", "issue", "edit", "4", "--add-assignee", "@me"],
+      [
+        "gh",
+        "issue",
+        "comment",
+        "4",
+        "--body",
+        expect.stringContaining(CLAIM_MARKER),
+      ],
+      ["gh", "issue", "edit", "4", "--remove-assignee", "@me"],
+      [
+        "gh",
+        "issue",
+        "comment",
+        "4",
+        "--body",
+        expect.stringContaining(RELEASE_MARKER),
+      ],
+    ]);
     expect(events.map((e) => e.kind)).toEqual([
       "claim",
       "spawn",
@@ -353,104 +385,6 @@ describe("act", () => {
     expect(attempts).toEqual([[7, 2]]);
   });
 
-  it("releases a failed attempt with its forensic record after Workers settle", async () => {
-    const { exec, calls } = recordingExec();
-    const dispatch: DispatchWorker = async () =>
-      outcome(7, { attempt: 2, exitCode: null, failure: "stall", ok: false });
-
-    await act([{ type: "spawn", ticket: 7, attempt: 2 }], {
-      dispatch,
-      openPr: recordingOpenPr().openPr,
-      dispatchConflict: noConflict,
-      exec,
-      now,
-      scheduleInterval,
-      log: noopLog(),
-    });
-
-    const record: AttemptFailure = {
-      attempt: 2,
-      reason: "stall",
-      model: "sonnet",
-      branch: "border-collie/ticket-7",
-      transcript: ".border-collie/transcripts/ticket-7.jsonl",
-    };
-    expect(calls).toEqual([
-      ["gh", "issue", "edit", "7", "--remove-assignee", "@me"],
-      [
-        "gh",
-        "issue",
-        "comment",
-        "7",
-        "--body",
-        expect.stringContaining(attemptMarker(record)),
-      ],
-    ]);
-  });
-
-  it("performs no tracker writes for a successful attempt", async () => {
-    const { exec, calls } = recordingExec();
-    const dispatch: DispatchWorker = async () => outcome(7);
-
-    await act([{ type: "spawn", ticket: 7, attempt: 1 }], {
-      dispatch,
-      openPr: recordingOpenPr().openPr,
-      dispatchConflict: noConflict,
-      exec,
-      now,
-      scheduleInterval,
-      log: noopLog(),
-    });
-
-    expect(calls).toEqual([]);
-  });
-
-  it("assigns worker-outcome levels per the level table: success and a retried Ticket failure are info, an infrastructure failure is warn", async () => {
-    const cases: { outcome: WorkerOutcome; level: "info" | "warn" }[] = [
-      { outcome: outcome(2), level: "info" },
-      {
-        outcome: outcome(4, {
-          exitCode: 1,
-          newCommits: 0,
-          failure: "nonzero-exit",
-          ok: false,
-        }),
-        level: "info",
-      },
-      {
-        outcome: outcome(6, {
-          exitCode: 1,
-          newCommits: 0,
-          infra: "network",
-          ok: false,
-        }),
-        level: "warn",
-      },
-    ];
-
-    for (const { outcome: scriptedOutcome, level } of cases) {
-      const { exec } = recordingExec();
-      const { log, events } = recordingLog();
-      const dispatch: DispatchWorker = async () => scriptedOutcome;
-
-      await act(
-        [{ type: "spawn", ticket: scriptedOutcome.ticket, attempt: 1 }],
-        {
-          dispatch,
-          openPr: recordingOpenPr().openPr,
-          dispatchConflict: noConflict,
-          exec,
-          now,
-          scheduleInterval,
-          log,
-        },
-      );
-
-      const workerOutcome = events.find((e) => e.kind === "worker-outcome");
-      expect(workerOutcome?.level).toBe(level);
-    }
-  });
-
   it("escalates: forensic comment, then the ready-for-agent → ready-for-human label swap, logged at warn", async () => {
     const { exec, calls } = recordingExec();
     const { log, events } = recordingLog();
@@ -504,10 +438,9 @@ describe("act", () => {
     ]);
   });
 
-  it("flags a cost overrun on a finished attempt while still opening its PR, logged at warn", async () => {
+  it("still opens the PR for a cost-overrun Attempt (the write settleAttempt performs is unaffected)", async () => {
     const { exec, calls } = recordingExec();
     const { openPr, opened } = recordingOpenPr();
-    const { log, events } = recordingLog();
     const dispatch: DispatchWorker = async () =>
       outcome(7, { costUsd: 25.5, turns: 80, costOverrun: true });
 
@@ -518,23 +451,15 @@ describe("act", () => {
       exec,
       now,
       scheduleInterval,
-      log,
+      log: noopLog(),
     });
 
     expect(opened).toEqual([7]); // the work is kept — discarding refunds nothing
     expect(calls).toEqual([]); // no tracker writes: not a failure
-    const costOverrun = events.find((e) => e.kind === "cost-overrun");
-    expect(costOverrun?.level).toBe("warn");
-    expect(costOverrun?.msg).toBe(
-      "cost overrun: attempt 1 spent $25.50 — the ticket may be cut too big for one Worker",
-    );
-    // Bound by the Worker's sub-logger, not repeated per call site.
-    expect(costOverrun).toMatchObject({ ticket: 7, attempt: 1 });
   });
 
-  it("voids an infrastructure-classified attempt: comment only, claim held, counted in the report, logged at warn", async () => {
+  it("reaches the tracker for an infrastructure-voided attempt and counts it in the report", async () => {
     const { exec, calls } = recordingExec();
-    const { log, events } = recordingLog();
     const dispatch: DispatchWorker = async () =>
       outcome(7, {
         exitCode: 1,
@@ -550,9 +475,11 @@ describe("act", () => {
       exec,
       now,
       scheduleInterval,
-      log,
+      log: noopLog(),
     });
 
+    // Wiring check: act() reaches the tracker through settleAttempt for this
+    // ticket. Exact write content is settleAttempt's own tests' job.
     expect(calls).toEqual([
       [
         "gh",
@@ -564,11 +491,6 @@ describe("act", () => {
       ],
     ]);
     expect(report).toEqual({ infraFailures: 1 });
-    const voided = events.find((e) => e.kind === "attempt-voided");
-    expect(voided?.level).toBe("warn");
-    expect(voided?.msg).toBe("voided attempt 1 (usage-limit); claim held");
-    // Bound by the Worker's sub-logger, not repeated per call site.
-    expect(voided).toMatchObject({ ticket: 7, attempt: 1 });
   });
 
   it("reclassifies several Workers failing the same way in one Tick as correlated infrastructure", async () => {

--- a/tests/app/settle.test.ts
+++ b/tests/app/settle.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import type { Exec } from "../../src/adapters/tracker.js";
+import { settleAttempt } from "../../src/app/settle.js";
+import type { Log, LogBindings, LogEvent } from "../../src/core/log.js";
+import {
+  type AttemptFailure,
+  attemptMarker,
+  VOID_MARKER,
+  type WorkerOutcome,
+} from "../../src/core/types.js";
+
+function recordingExec(): { exec: Exec; calls: string[][] } {
+  const calls: string[][] = [];
+  const exec: Exec = async (cmd, args) => {
+    calls.push([cmd, ...args]);
+    return "";
+  };
+  return { exec, calls };
+}
+
+/**
+ * Records emitted events, merging the sub-logger's bindings onto every event
+ * it forwards — exactly what a real sink sees, mirroring the Worker
+ * sub-logger `settleAttempt` is always called with.
+ */
+function recordingLog(): { log: Log; events: LogEvent[] } {
+  const events: LogEvent[] = [];
+  function make(bindings: LogBindings): Log {
+    const fn = ((event: LogEvent) => {
+      events.push({ ...bindings, ...event } as LogEvent);
+    }) as Log;
+    fn.child = (childBindings) => make({ ...bindings, ...childBindings });
+    return fn;
+  }
+  return { log: make({ ticket: 7, attempt: 1 }), events };
+}
+
+function msgs(events: LogEvent[]): string[] {
+  return events.map((e) => e.msg);
+}
+
+function outcome(overrides: Partial<WorkerOutcome> = {}): WorkerOutcome {
+  return {
+    ticket: 7,
+    attempt: 1,
+    branch: "border-collie/ticket-7",
+    base: "base-sha",
+    transcript: ".border-collie/transcripts/ticket-7.jsonl",
+    model: "sonnet",
+    exitCode: 0,
+    newCommits: 2,
+    failure: undefined,
+    infra: undefined,
+    costUsd: undefined,
+    turns: undefined,
+    costOverrun: false,
+    ok: true,
+    ...overrides,
+  };
+}
+
+describe("settleAttempt", () => {
+  it("narrates a success and its PR, performing no tracker write", async () => {
+    const { exec, calls } = recordingExec();
+    const { log, events } = recordingLog();
+
+    await settleAttempt(
+      outcome({ newCommits: 3 }),
+      "https://github.com/o/r/pull/70",
+      log,
+      exec,
+    );
+
+    expect(calls).toEqual([]);
+    expect(events.map((e) => e.kind)).toEqual(["worker-outcome", "pr-opened"]);
+    expect(events.every((e) => e.level === "info")).toBe(true);
+    expect(msgs(events)).toEqual([
+      "Worker succeeded: 3 new commits on border-collie/ticket-7 (transcript: .border-collie/transcripts/ticket-7.jsonl)",
+      "opened draft PR: https://github.com/o/r/pull/70",
+    ]);
+    // Bound by the caller's sub-logger, not repeated per call site.
+    expect(
+      events.every(
+        (e) =>
+          (e as { ticket?: number }).ticket === 7 &&
+          (e as { attempt?: number }).attempt === 1,
+      ),
+    ).toBe(true);
+  });
+
+  it("narrates a success with no PR logged when none was opened", async () => {
+    const { log, events } = recordingLog();
+
+    await settleAttempt(outcome(), undefined, log, recordingExec().exec);
+
+    expect(events.map((e) => e.kind)).toEqual(["worker-outcome"]);
+  });
+
+  it("releases a failed attempt with its forensic record, logged at info", async () => {
+    const { exec, calls } = recordingExec();
+    const { log, events } = recordingLog();
+
+    await settleAttempt(
+      outcome({
+        attempt: 2,
+        exitCode: null,
+        newCommits: 0,
+        failure: "stall",
+        ok: false,
+      }),
+      undefined,
+      log,
+      exec,
+    );
+
+    const record: AttemptFailure = {
+      attempt: 2,
+      reason: "stall",
+      model: "sonnet",
+      branch: "border-collie/ticket-7",
+      transcript: ".border-collie/transcripts/ticket-7.jsonl",
+    };
+    expect(calls).toEqual([
+      ["gh", "issue", "edit", "7", "--remove-assignee", "@me"],
+      [
+        "gh",
+        "issue",
+        "comment",
+        "7",
+        "--body",
+        expect.stringContaining(attemptMarker(record)),
+      ],
+    ]);
+    expect(events.map((e) => e.kind)).toEqual([
+      "worker-outcome",
+      "attempt-released",
+    ]);
+    expect(events.map((e) => e.level)).toEqual(["info", "info"]);
+    expect(msgs(events)).toEqual([
+      "Worker failed attempt 2 (stall): exit null, 0 new commits on border-collie/ticket-7 (transcript: .border-collie/transcripts/ticket-7.jsonl)",
+      "released with the attempt record (failed attempt 2)",
+    ]);
+  });
+
+  it("voids an infrastructure-classified attempt: comment only, claim held, logged at warn", async () => {
+    const { exec, calls } = recordingExec();
+    const { log, events } = recordingLog();
+
+    await settleAttempt(
+      outcome({ exitCode: 1, newCommits: 0, infra: "usage-limit", ok: false }),
+      undefined,
+      log,
+      exec,
+    );
+
+    expect(calls).toEqual([
+      [
+        "gh",
+        "issue",
+        "comment",
+        "7",
+        "--body",
+        expect.stringContaining(VOID_MARKER),
+      ],
+    ]);
+    expect(events.map((e) => e.kind)).toEqual([
+      "worker-outcome",
+      "attempt-voided",
+    ]);
+    expect(events.map((e) => e.level)).toEqual(["warn", "warn"]);
+    expect(msgs(events)).toEqual([
+      "Worker hit an infrastructure failure (usage-limit): attempt 1 voided, exit 1 on border-collie/ticket-7 (transcript: .border-collie/transcripts/ticket-7.jsonl)",
+      "voided attempt 1 (usage-limit); claim held",
+    ]);
+  });
+
+  it("flags a cost overrun on a finished attempt while performing no tracker write, logged at warn", async () => {
+    const { exec, calls } = recordingExec();
+    const { log, events } = recordingLog();
+
+    await settleAttempt(
+      outcome({ costUsd: 25.5, turns: 80, costOverrun: true }),
+      "https://github.com/o/r/pull/70",
+      log,
+      exec,
+    );
+
+    expect(calls).toEqual([]); // no tracker writes: not a failure
+    expect(events.map((e) => e.kind)).toEqual([
+      "worker-outcome",
+      "pr-opened",
+      "cost-overrun",
+    ]);
+    const costOverrun = events.find((e) => e.kind === "cost-overrun");
+    expect(costOverrun?.level).toBe("warn");
+    expect(costOverrun?.msg).toBe(
+      "cost overrun: attempt 1 spent $25.50 — the ticket may be cut too big for one Worker",
+    );
+  });
+});


### PR DESCRIPTION
refactor(act): extract Attempt settling from the act phase

Turning a finished Worker Attempt into tracker writes — opening the draft pull request on success, posting the forensic release for a Ticket failure, voiding an Infrastructure failure, flagging a cost overrun — used to happen inline in the act phase once every Worker had settled. This moves it into `settleAttempt`, a single unit the act phase calls per outcome, in `src/app/settle.ts`.

This is a prefactor with no behaviour change: the same writes, in the same order, emitting the same log events. It exists so a Worker running in its own process can later perform exactly these writes without duplicating them (#71).

The actual PR-opening call stays in the act phase's per-Worker spawn handling, unchanged — it still fires concurrently, the moment each Worker succeeds, rather than waiting for the whole Tick's Workers to settle. `settleAttempt` takes the already-resolved PR URL and is responsible for narrating the outcome, the PR-opened event, a cost overrun, and performing the void/release tracker write — exactly what used to run in the act phase's per-outcome loop after `Promise.allSettled` and correlated-failure reclassification.

## Changes

- `src/app/settle.ts`: new `settleAttempt(outcome, prUrl, log, exec)`, extracted from `act.ts`'s post-settle loop.
- `src/app/act.ts`: the loop now delegates to `settleAttempt`; `ActDeps` is unchanged.
- `tests/app/settle.test.ts`: new — the per-outcome-shape write assertions (success, Ticket failure, Infrastructure failure, cost overrun) now live with the extracted unit.
- `tests/app/act.test.ts`: trimmed of the assertions that moved, with lightweight wiring checks kept so act()'s delegation into `settleAttempt` (correct outcome, PR URL, and tracker exec reaching the right ticket) stays covered end to end.

## Testing

- `npm run typecheck`, `npm run lint`, `npm test` (309/309 passing).

Closes #65