### PR TITLE
feat(plan): confine dispatch to an off-hours window

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -42,6 +42,10 @@ An attempt that failed because of the ticket or the work — crash, no commits, 
 **Infrastructure failure**:
 A failure caused by the environment — usage limit, rate limit, auth, network, or several Workers failing the same way within one Tick (correlated). Counts as nothing; voids the attempt (a marker comment uncounts the claim while keeping it held) and trips the circuit breaker (pause dispatch, resume when the environment recovers).
 
+**Working hours**:
+The operator's configured off-hours window — a timezone plus start/end hour, resolved fresh each Tick against wall-clock time rather than encoded in a cron expression. While now falls inside it, only the quota-consuming actions (claims, spawns, Conflict Workers) are suppressed; closures, releases, Escalations, mechanical rebases, and the draft-to-ready flip still run every hour, so the world is current when the fleet wakes. Independent of the circuit breaker's pause, which means the environment is broken, not that the operator is awake — either or both may apply at once.
+_Avoid_: quiet hours, breaker, dispatch pause (that phrase names the circuit breaker's wider suppression, not this narrower one)
+
 **Escalation**:
 Handing a ticket to a human after its attempts are exhausted: swap `ready-for-agent` → `ready-for-human`, unassign, leave a forensic comment. An escalated ticket stops being Dispatchable by construction; its dependents stay blocked.
 

--- a/src/app/tick.ts
+++ b/src/app/tick.ts
@@ -10,6 +10,7 @@ import type { Log } from "../core/log.js";
 import { plan } from "../core/plan.js";
 import { buildPlanReport } from "../core/render.js";
 import type { Action, WorldSnapshot } from "../core/types.js";
+import { isWithinWorkingHours } from "../core/work-hours.js";
 import { act, type IntervalScheduler } from "./act.js";
 
 /** The Tick's effects, injectable for tests, matching the run loop's pattern. */
@@ -33,14 +34,19 @@ export async function tickOnce(
   // --verbose is passed.
   const exec = withDebugLogging(realExec, log);
   const world = await readScope(config.scope, exec);
+  // Resolved fresh against wall-clock time each Tick (CONTEXT.md "Working
+  // hours") — not encoded in a cron expression.
+  const withinWorkingHours = isWithinWorkingHours(config.workingHours, now());
   const actions = plan(world, {
     maxWorkers: config.maxWorkers,
     maxOpenPrs: config.maxOpenPrs,
     dispatchPaused,
+    withinWorkingHours,
   });
   const planReport = buildPlanReport(config, world, actions, {
     dryRun,
     dispatchPaused,
+    withinWorkingHours,
   });
   log({
     kind: "plan-report",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,3 +1,5 @@
+import { isValidTimeZone, type WorkingHours } from "./work-hours.js";
+
 /** File name looked up at the target repo's root. */
 export const CONFIG_FILE = "border-collie.json";
 
@@ -47,6 +49,12 @@ export interface ResolvedConfig {
   maxTurns: number;
   /** Budget alarm: spend in USD above which a finished Attempt is flagged, not failed. */
   maxCostUsd: number;
+  /**
+   * The working-hours gate (CONTEXT.md "Working hours"): confines dispatch
+   * to an off-hours window. Absent means the gate never applies — dispatch
+   * runs at every hour, today's default.
+   */
+  workingHours?: WorkingHours;
 }
 
 function asPositiveInt(value: unknown, name: string): number {
@@ -75,6 +83,51 @@ function asNonEmptyString(value: unknown, name: string): string {
     );
   }
   return value;
+}
+
+/** An hour of day: an integer in [0,24). */
+function asHour(value: unknown, name: string): number {
+  if (
+    typeof value !== "number" ||
+    !Number.isInteger(value) ||
+    value < 0 ||
+    value > 23
+  ) {
+    throw new ConfigError(
+      `${name} must be an integer from 0 to 23, got ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}
+
+/**
+ * The working-hours gate's window (CONTEXT.md "Working hours"): timezone,
+ * work_start_hour, work_end_hour. All three or none — a partial window has
+ * no sensible default. Undefined means the gate never applies.
+ */
+function resolveWorkingHours(
+  file: Record<string, unknown>,
+): WorkingHours | undefined {
+  const { timezone, work_start_hour, work_end_hour } = file;
+  if (
+    timezone === undefined &&
+    work_start_hour === undefined &&
+    work_end_hour === undefined
+  ) {
+    return undefined;
+  }
+  const resolvedTimezone = asNonEmptyString(timezone, "timezone");
+  if (!isValidTimeZone(resolvedTimezone)) {
+    throw new ConfigError(
+      `timezone must be a valid IANA time zone, got ${JSON.stringify(timezone)}`,
+    );
+  }
+  const startHour = asHour(work_start_hour, "work_start_hour");
+  const endHour = asHour(work_end_hour, "work_end_hour");
+  if (startHour === endHour) {
+    throw new ConfigError("work_start_hour and work_end_hour must differ");
+  }
+  return { timezone: resolvedTimezone, startHour, endHour };
 }
 
 /**
@@ -132,7 +185,8 @@ export function resolveConfig(
     file.worker_max_cost_usd ?? DEFAULT_MAX_COST_USD,
     "worker_max_cost_usd",
   );
-  const shared = {
+  const workingHours = resolveWorkingHours(file);
+  const shared: Omit<ResolvedConfig, "scope"> = {
     maxWorkers,
     maxOpenPrs,
     pollSeconds,
@@ -143,6 +197,7 @@ export function resolveConfig(
     maxTurns,
     maxCostUsd,
   };
+  if (workingHours !== undefined) shared.workingHours = workingHours;
 
   if (flags.all) {
     if (flags.parent !== undefined) {

--- a/src/core/plan.ts
+++ b/src/core/plan.ts
@@ -89,15 +89,18 @@ function isEscalationDue(ticket: Ticket, world: WorldSnapshot): boolean {
  * updated head (the update re-runs CI). Draft→ready is otherwise decided on CI
  * alone — a green draft, or one in a repo with no CI configured, flips to
  * ready-for-review — and independent of mergeability, so a fresh no-CI draft
- * surfaces even while GitHub is still computing whether it is behind.
+ * surfaces even while GitHub is still computing whether it is behind. The
+ * Conflict Worker is quota-consuming, so the working-hours gate (CONTEXT.md
+ * "Working hours") suppresses it; the mechanical update and the ready flip
+ * are not, and run regardless.
  */
-function prUpkeep(world: WorldSnapshot): Action[] {
+function prUpkeep(world: WorldSnapshot, withinWorkingHours: boolean): Action[] {
   const actions: Action[] = [];
   for (const pr of [...world.openAgentPrs].sort(
     (a, b) => a.number - b.number,
   )) {
     if (pr.mergeable === "conflicted") {
-      if (!pr.conflictWorkerAsked) {
+      if (!pr.conflictWorkerAsked && !withinWorkingHours) {
         actions.push({
           type: "conflict-worker",
           pr: pr.number,
@@ -131,7 +134,12 @@ function prUpkeep(world: WorldSnapshot): Action[] {
  * fleet to human review bandwidth, resuming as merges land. PR upkeep sits
  * between closure and recovery: it keeps the PRs a merge just left behind
  * current, and consumes no Worker slots (the conflict Worker aside). While the
- * circuit breaker is open (dispatchPaused) only closes are planned.
+ * circuit breaker is open (dispatchPaused) only closes are planned. The
+ * working-hours gate (CONTEXT.md "Working hours", withinWorkingHours) is a
+ * narrower, independent suppression: only the quota-consuming actions —
+ * claims, spawns, the conflict Worker — drop out, so closes, releases,
+ * escalations, and the rest of PR upkeep keep the world current while the
+ * fleet is quiet.
  */
 export function plan(world: WorldSnapshot, config: PlanConfig): Action[] {
   const openTickets = new Set(
@@ -148,6 +156,8 @@ export function plan(world: WorldSnapshot, config: PlanConfig): Action[] {
   // escalations wait for a healthy environment rather than judging tickets
   // during one.
   if (config.dispatchPaused) return closes;
+
+  const withinWorkingHours = config.withinWorkingHours ?? false;
 
   const releases: Action[] = world.tickets
     .filter((ticket) => isOrphanedClaim(ticket, world))
@@ -171,21 +181,23 @@ export function plan(world: WorldSnapshot, config: PlanConfig): Action[] {
   // models the human reviewer's bandwidth, and every agent PR occupies it
   // whichever run opened it.
   const headroom = Math.max(0, config.maxOpenPrs - world.openAgentPrs.length);
-  const dispatches: Action[] = dispatchableSet(world)
-    .filter((ticket) => ticket.agentClaimCount < MAX_ATTEMPTS)
-    .slice(0, Math.max(0, Math.min(config.maxWorkers, headroom)))
-    .flatMap((ticket) => [
-      { type: "claim", ticket: ticket.number },
-      {
-        type: "spawn",
-        ticket: ticket.number,
-        attempt: ticket.agentClaimCount + 1,
-      },
-    ]);
+  const dispatches: Action[] = withinWorkingHours
+    ? []
+    : dispatchableSet(world)
+        .filter((ticket) => ticket.agentClaimCount < MAX_ATTEMPTS)
+        .slice(0, Math.max(0, Math.min(config.maxWorkers, headroom)))
+        .flatMap((ticket) => [
+          { type: "claim", ticket: ticket.number },
+          {
+            type: "spawn",
+            ticket: ticket.number,
+            attempt: ticket.agentClaimCount + 1,
+          },
+        ]);
 
   return [
     ...closes,
-    ...prUpkeep(world),
+    ...prUpkeep(world, withinWorkingHours),
     ...releases,
     ...escalations,
     ...dispatches,

--- a/src/core/render.ts
+++ b/src/core/render.ts
@@ -16,6 +16,7 @@ import {
 /** Why dispatch is paused this Tick, or absent when it isn't. */
 export type PlanPausedReason =
   | { kind: "breaker" }
+  | { kind: "working-hours" }
   | { kind: "max-open-prs"; openCount: number };
 
 /** One planned action, resolved to exactly the fields its console line needs. */
@@ -92,7 +93,12 @@ export function buildPlanReport(
   {
     dryRun,
     dispatchPaused = false,
-  }: { dryRun: boolean; dispatchPaused?: boolean },
+    withinWorkingHours = false,
+  }: {
+    dryRun: boolean;
+    dispatchPaused?: boolean;
+    withinWorkingHours?: boolean;
+  },
 ): PlanReport {
   const { scope, maxWorkers, maxOpenPrs } = config;
   const scopeLabel =
@@ -104,6 +110,8 @@ export function buildPlanReport(
   let paused: PlanPausedReason | null = null;
   if (dispatchPaused) {
     paused = { kind: "breaker" };
+  } else if (withinWorkingHours && dispatchable.length > 0) {
+    paused = { kind: "working-hours" };
   } else if (
     dispatchable.length > 0 &&
     world.openAgentPrs.length >= maxOpenPrs
@@ -166,6 +174,10 @@ export function renderPlanReport(report: PlanReport): string {
   if (report.paused?.kind === "breaker") {
     lines.push(
       "Dispatch paused: circuit breaker open (infrastructure failure), claims held",
+    );
+  } else if (report.paused?.kind === "working-hours") {
+    lines.push(
+      "Dispatch paused: within working hours — claims, spawns, and Conflict Workers wait for the off-hours window",
     );
   } else if (report.paused?.kind === "max-open-prs") {
     lines.push(

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -302,6 +302,18 @@ export interface PlanConfig {
    * Omitted means closed (dispatch flows).
    */
   dispatchPaused?: boolean;
+  /**
+   * True while now falls within the operator's configured working hours
+   * (CONTEXT.md "Working hours"): claims, spawns, and Conflict Workers are
+   * suppressed so the fleet doesn't compete for the quota the operator is
+   * using interactively. Closures, releases, Escalations, mechanical
+   * rebases, and the draft-to-ready flip still run. Independent of
+   * `dispatchPaused` — the circuit breaker's pause means the environment is
+   * broken, not that the operator is awake, and either or both may apply.
+   * Omitted means outside the window (dispatch flows), including when no
+   * window is configured at all.
+   */
+  withinWorkingHours?: boolean;
 }
 
 /**

--- a/src/core/work-hours.ts
+++ b/src/core/work-hours.ts
@@ -1,0 +1,56 @@
+/**
+ * The working-hours gate (CONTEXT.md "Working hours"): confines dispatch to
+ * an off-hours window so the fleet works while the operator sleeps instead
+ * of competing for the quota the operator is using interactively. A
+ * timezone plus a start/end hour, resolved fresh against wall-clock time
+ * each Tick — deliberately not encoded in a cron expression, so the window
+ * stays readable in the operator's own timezone and portable between users.
+ * Independent of the circuit breaker's dispatch pause (breaker.ts), which
+ * means the environment itself is broken, not that the operator is awake.
+ */
+export interface WorkingHours {
+  /** IANA time zone the start/end hours are read in. */
+  timezone: string;
+  /** Local hour of day [0,24) working hours start. */
+  startHour: number;
+  /** Local hour of day [0,24) working hours end. Less than startHour wraps past midnight. */
+  endHour: number;
+}
+
+/** The local hour of day [0,24) at `nowMs`, read in `timezone`. */
+function localHour(timezone: string, nowMs: number): number {
+  const formatted = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hour: "numeric",
+    hour12: false,
+  }).format(new Date(nowMs));
+  return Number(formatted);
+}
+
+/**
+ * True when `nowMs`, read in the window's timezone, falls within the
+ * configured working hours — the quota-consuming actions the gate suppresses
+ * are due to pause. `undefined` means no window is configured: the gate
+ * never applies, so dispatch runs at every hour.
+ */
+export function isWithinWorkingHours(
+  workingHours: WorkingHours | undefined,
+  nowMs: number,
+): boolean {
+  if (workingHours === undefined) return false;
+  const { timezone, startHour, endHour } = workingHours;
+  const hour = localHour(timezone, nowMs);
+  return startHour < endHour
+    ? hour >= startHour && hour < endHour
+    : hour >= startHour || hour < endHour;
+}
+
+/** True when `timezone` is a time zone name the runtime's Intl implementation recognizes. */
+export function isValidTimeZone(timezone: string): boolean {
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: timezone });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/app/run.test.ts
+++ b/tests/app/run.test.ts
@@ -122,6 +122,16 @@ describe("runStatus", () => {
 
     expect(runStatus(world([held]), [], true)).toEqual({ state: "running" });
   });
+
+  it("is never stuck while a ticket sits dispatchable but suppressed by the working-hours gate", () => {
+    // The gate suppresses the claim/spawn Actions (empty actions, as plan()
+    // would produce), but dispatchableSet is gate-blind — the ticket becomes
+    // claimable the moment the off-hours window opens, so this is throttled,
+    // not Stuck (CONTEXT.md "Working hours").
+    expect(runStatus(world([ticket({ number: 2 })]), [])).toEqual({
+      state: "running",
+    });
+  });
 });
 
 /**

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -215,6 +215,82 @@ describe("resolveConfig", () => {
     );
   });
 
+  it("resolves the working-hours window from the config file", () => {
+    const resolved = resolveConfig(
+      {
+        parent: 1,
+        timezone: "Europe/London",
+        work_start_hour: 9,
+        work_end_hour: 18,
+      },
+      {},
+    );
+
+    expect(resolved.workingHours).toEqual({
+      timezone: "Europe/London",
+      startHour: 9,
+      endHour: 18,
+    });
+  });
+
+  it("leaves the working-hours gate unconfigured when the file omits it", () => {
+    const resolved = resolveConfig({ parent: 1 }, {});
+
+    expect(resolved.workingHours).toBeUndefined();
+  });
+
+  it("rejects a partial working-hours window", () => {
+    expect(() =>
+      resolveConfig({ parent: 1, timezone: "Europe/London" }, {}),
+    ).toThrow(ConfigError);
+    expect(() =>
+      resolveConfig({ parent: 1, work_start_hour: 9, work_end_hour: 18 }, {}),
+    ).toThrow(ConfigError);
+  });
+
+  it("rejects an unrecognized timezone", () => {
+    expect(() =>
+      resolveConfig(
+        {
+          parent: 1,
+          timezone: "Not/AZone",
+          work_start_hour: 9,
+          work_end_hour: 18,
+        },
+        {},
+      ),
+    ).toThrow(ConfigError);
+  });
+
+  it("rejects an out-of-range or non-integer working hour", () => {
+    expect(() =>
+      resolveConfig(
+        { parent: 1, timezone: "UTC", work_start_hour: 24, work_end_hour: 18 },
+        {},
+      ),
+    ).toThrow(ConfigError);
+    expect(() =>
+      resolveConfig(
+        {
+          parent: 1,
+          timezone: "UTC",
+          work_start_hour: 9.5,
+          work_end_hour: 18,
+        },
+        {},
+      ),
+    ).toThrow(ConfigError);
+  });
+
+  it("rejects equal start and end working hours", () => {
+    expect(() =>
+      resolveConfig(
+        { parent: 1, timezone: "UTC", work_start_hour: 9, work_end_hour: 9 },
+        {},
+      ),
+    ).toThrow(ConfigError);
+  });
+
   it("rejects a malformed config file", () => {
     expect(() => resolveConfig("not an object", {})).toThrow(ConfigError);
     expect(() => resolveConfig({ parent: "one" }, {})).toThrow(ConfigError);

--- a/tests/core/plan.test.ts
+++ b/tests/core/plan.test.ts
@@ -534,6 +534,115 @@ describe("plan: circuit breaker", () => {
   });
 });
 
+describe("plan: working hours", () => {
+  it("plans no claim or spawn for a dispatchable ticket within working hours", () => {
+    const actions = plan(world([ticket({ number: 7 })]), {
+      maxWorkers: 3,
+      maxOpenPrs: 5,
+      withinWorkingHours: true,
+    });
+
+    expect(actions).toEqual([]);
+  });
+
+  it("still closes, releases, and escalates within working hours", () => {
+    const actions = plan(
+      world(
+        [
+          ticket({ number: 9 }),
+          ticket({ number: 6, assignees: ["operator"], hasAgentClaim: true }),
+          ticket({
+            number: 5,
+            agentClaimCount: 2,
+            attemptFailures: [failure(1), failure(2)],
+          }),
+        ],
+        [],
+        [mergedPr(9)],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5, withinWorkingHours: true },
+    );
+
+    expect(actions).toEqual([
+      { type: "close", ticket: 9, prUrl: "https://github.com/o/r/pull/90" },
+      { type: "release", ticket: 6, assignees: ["operator"] },
+      { type: "escalate", ticket: 5, failures: [failure(1), failure(2)] },
+    ]);
+  });
+
+  it("still mechanically updates a behind PR and flips a green draft ready within working hours", () => {
+    const actions = plan(
+      worldWithPrs(
+        [
+          ticket({ number: 3, assignees: ["operator"], hasAgentClaim: true }),
+          ticket({ number: 4, assignees: ["operator"], hasAgentClaim: true }),
+        ],
+        [
+          openPr(3, { number: 30, behind: true }),
+          openPr(4, { number: 40, draft: true, ci: "passing" }),
+        ],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5, withinWorkingHours: true },
+    );
+
+    expect(actions).toEqual([
+      { type: "update-branch", pr: 30, ticket: 3 },
+      { type: "mark-ready", pr: 40, ticket: 4 },
+    ]);
+  });
+
+  it("suppresses the Conflict Worker within working hours, without touching update or ready", () => {
+    const actions = plan(
+      worldWithPrs(
+        [ticket({ number: 3, assignees: ["operator"], hasAgentClaim: true })],
+        [openPr(3, { number: 30, mergeable: "conflicted" })],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5, withinWorkingHours: true },
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it("is independent of the circuit breaker: both suppress dispatch, but the breaker also suppresses PR upkeep and releases", () => {
+    const held = ticket({
+      number: 4,
+      assignees: ["operator"],
+      hasAgentClaim: true,
+    });
+    const bothGated = plan(world([held]), {
+      maxWorkers: 3,
+      maxOpenPrs: 5,
+      withinWorkingHours: true,
+      dispatchPaused: true,
+    });
+    const workingHoursOnly = plan(world([held]), {
+      maxWorkers: 3,
+      maxOpenPrs: 5,
+      withinWorkingHours: true,
+    });
+
+    // Breaker open wins: only closes, even with the working-hours gate also active.
+    expect(bothGated).toEqual([]);
+    // Working hours alone still releases the orphaned claim.
+    expect(workingHoursOnly).toEqual([
+      { type: "release", ticket: 4, assignees: ["operator"] },
+    ]);
+  });
+
+  it("dispatches normally once outside working hours", () => {
+    const actions = plan(world([ticket({ number: 7 })]), {
+      maxWorkers: 3,
+      maxOpenPrs: 5,
+      withinWorkingHours: false,
+    });
+
+    expect(actions).toEqual([
+      { type: "claim", ticket: 7 },
+      { type: "spawn", ticket: 7, attempt: 1 },
+    ]);
+  });
+});
+
 describe("plan: PR upkeep", () => {
   it("plans no upkeep for a clean, current, non-draft PR", () => {
     const actions = plan(

--- a/tests/core/render.test.ts
+++ b/tests/core/render.test.ts
@@ -122,6 +122,40 @@ describe("buildPlanReport", () => {
     expect(report.paused).toEqual({ kind: "breaker" });
   });
 
+  it("reports a working-hours pause when a dispatchable ticket waits on the off-hours window", () => {
+    const report = buildPlanReport(config(), world, [], {
+      dryRun: false,
+      withinWorkingHours: true,
+    });
+
+    expect(report.paused).toEqual({ kind: "working-hours" });
+  });
+
+  it("does not report a working-hours pause when nothing is dispatchable", () => {
+    const noDispatch: WorldSnapshot = {
+      tickets: [ticket({ number: 4, title: "Done already", state: "closed" })],
+      openAgentPrs: [],
+      mergedAgentPrs: [],
+    };
+
+    const report = buildPlanReport(config(), noDispatch, [], {
+      dryRun: false,
+      withinWorkingHours: true,
+    });
+
+    expect(report.paused).toBeNull();
+  });
+
+  it("prefers the breaker pause over working hours when both apply", () => {
+    const report = buildPlanReport(config(), world, [], {
+      dryRun: false,
+      dispatchPaused: true,
+      withinWorkingHours: true,
+    });
+
+    expect(report.paused).toEqual({ kind: "breaker" });
+  });
+
   it("reports a max_open_prs pause when dispatchable tickets wait on headroom", () => {
     const throttled: WorldSnapshot = {
       ...world,
@@ -218,6 +252,29 @@ describe("buildPlanReport", () => {
 });
 
 describe("renderPlanReport", () => {
+  it("renders the working-hours pause notice, distinct from the breaker's", () => {
+    const report: PlanReport = {
+      scopeLabel: "sub-issues of #1",
+      totalTickets: 2,
+      openTickets: 1,
+      dispatchable: [2],
+      paused: { kind: "working-hours" },
+      maxWorkers: 3,
+      maxOpenPrs: 5,
+      actions: [],
+      dryRun: false,
+    };
+
+    expect(renderPlanReport(report)).toBe(
+      [
+        "Scope: sub-issues of #1 — 2 tickets (1 open)",
+        "Dispatchable: #2",
+        "Dispatch paused: within working hours — claims, spawns, and Conflict Workers wait for the off-hours window",
+        "Plan (max_workers=3, max_open_prs=5): nothing to do",
+      ].join("\n"),
+    );
+  });
+
   it("renders the familiar unadorned block: header lines, one line per action kind, the paused notice, the dry-run footer", () => {
     const report: PlanReport = {
       scopeLabel: "sub-issues of #1",

--- a/tests/core/work-hours.test.ts
+++ b/tests/core/work-hours.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  isValidTimeZone,
+  isWithinWorkingHours,
+  type WorkingHours,
+} from "../../src/core/work-hours.js";
+
+function utc(hour: number): number {
+  return Date.UTC(2026, 6, 15, hour, 0, 0);
+}
+
+describe("isWithinWorkingHours", () => {
+  it("is false when no window is configured", () => {
+    expect(isWithinWorkingHours(undefined, utc(12))).toBe(false);
+  });
+
+  const window: WorkingHours = {
+    timezone: "UTC",
+    startHour: 9,
+    endHour: 18,
+  };
+
+  it("is true at the start hour and false at the end hour (half-open)", () => {
+    expect(isWithinWorkingHours(window, utc(9))).toBe(true);
+    expect(isWithinWorkingHours(window, utc(18))).toBe(false);
+  });
+
+  it("is true in the middle of the window", () => {
+    expect(isWithinWorkingHours(window, utc(13))).toBe(true);
+  });
+
+  it("is false before the window starts and after it ends", () => {
+    expect(isWithinWorkingHours(window, utc(8))).toBe(false);
+    expect(isWithinWorkingHours(window, utc(19))).toBe(false);
+  });
+
+  const overnight: WorkingHours = {
+    timezone: "UTC",
+    startHour: 22,
+    endHour: 6,
+  };
+
+  it("wraps past midnight when startHour is greater than endHour", () => {
+    expect(isWithinWorkingHours(overnight, utc(23))).toBe(true);
+    expect(isWithinWorkingHours(overnight, utc(2))).toBe(true);
+    expect(isWithinWorkingHours(overnight, utc(12))).toBe(false);
+    expect(isWithinWorkingHours(overnight, utc(6))).toBe(false);
+    expect(isWithinWorkingHours(overnight, utc(22))).toBe(true);
+  });
+
+  it("reads the hour in the configured timezone, not the system's", () => {
+    // 09:00 UTC is 18:00 in Tokyo (UTC+9) — outside a 9-18 Tokyo window.
+    const tokyo: WorkingHours = {
+      timezone: "Asia/Tokyo",
+      startHour: 9,
+      endHour: 18,
+    };
+
+    expect(isWithinWorkingHours(tokyo, utc(9))).toBe(false);
+    // 00:00 UTC is 09:00 in Tokyo — right at the start of the window.
+    expect(isWithinWorkingHours(tokyo, utc(0))).toBe(true);
+  });
+});
+
+describe("isValidTimeZone", () => {
+  it("accepts a well-formed IANA time zone", () => {
+    expect(isValidTimeZone("Europe/London")).toBe(true);
+    expect(isValidTimeZone("UTC")).toBe(true);
+  });
+
+  it("rejects a made-up time zone name", () => {
+    expect(isValidTimeZone("Not/AZone")).toBe(false);
+  });
+});


### PR DESCRIPTION
Committed. Here's the PR description:

Confines dispatch to an off-hours window so the fleet works while the operator sleeps instead of competing for the quota the operator is using interactively.

## What changed

- **`src/core/work-hours.ts`** (new): a pure `WorkingHours` type (timezone + start/end hour) and `isWithinWorkingHours(workingHours, nowMs)`, resolved fresh against wall-clock time rather than encoded in a cron expression, so the window stays readable in the operator's own timezone. Handles overnight windows that wrap past midnight.
- **`src/core/config.ts`**: resolves the window from `border-collie.json` (`timezone`, `work_start_hour`, `work_end_hour` — all three or none; validated as a real IANA timezone and in-range hours).
- **`src/core/plan.ts`**: `plan()` takes a `withinWorkingHours` input and suppresses only claims, spawns, and Conflict Workers when it's true. Closures, releases, Escalations, mechanical branch updates, and the draft-to-ready flip are unaffected and keep the world current so the fleet wakes up to fresh state. Independent of `dispatchPaused` (the circuit breaker) — either or both can apply; the breaker still takes full precedence (only closes) when open.
- **`src/core/render.ts`**: the dispatch-plan report gets a `working-hours` paused reason, distinct from the breaker's.
- **`src/app/tick.ts`**: resolves `withinWorkingHours` once per Tick from `config.workingHours` and `now()`, and passes it into `plan()`/the report.
- **`CONTEXT.md`**: names the gate ("Working hours"), explicitly distinguishing it from the circuit breaker's dispatch pause.

## Why a run is never Stuck from this

`runStatus` already keys its Stuck judgment off `dispatchableSet(world)`, which has no notion of the working-hours gate — a ticket suppressed only by the gate stays in the dispatchable set, so the run keeps polling rather than exiting Stuck. Verified with a new test rather than requiring a code change to `run.ts`.

## Tests

New `tests/core/work-hours.test.ts` for the pure gate function, plus coverage added to `plan.test.ts` (suppression, non-suppression of other actions, independence from the breaker), `config.test.ts` (parsing/validation), `render.test.ts` (paused-reason precedence), and `run.test.ts` (never-Stuck). Full suite, typecheck, and lint all pass.

Closes #67