### PR TITLE
fix(logging): keep credentials out of captured logs and artifacts

### DIFF
--- a/src/adapters/tracker.ts
+++ b/src/adapters/tracker.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { Scope } from "../core/config.js";
-import type { Log } from "../core/log.js";
+import { type Log, scrubCredentials } from "../core/log.js";
 import {
   type AttemptFailure,
   attemptMarker,
@@ -61,20 +61,25 @@ function exitCodeOf(error: unknown): number | null {
  * Decorates an `Exec` with a `debug` event per call, carrying the command and
  * its exit code — detail that does not exist today, so an operator can see
  * every `gh`/`git` command the Orchestrator actually issued, and how it
- * exited, without reproducing the run. Neither `cmd`/`args` nor an exit code
- * ever carries a credential: `gh` and `git` read auth from the environment,
- * never argv.
+ * exited, without reproducing the run. `gh` and `git` read auth from the
+ * environment, never argv, so `cmd`/`args` never carry a credential in
+ * practice — but the logged form is scrubbed defensively anyway (see
+ * `scrubCredentials`, verified by the "withDebugLogging" tests below) rather
+ * than resting on that as an unverified claim. The real `exec` call below
+ * still receives the unscrubbed `args`, so scrubbing never changes what
+ * actually runs.
  */
 export function withDebugLogging(exec: Exec, log: Log): Exec {
   return async (cmd, args) => {
+    const safeArgs = args.map(scrubCredentials);
     try {
       const stdout = await exec(cmd, args);
       log({
         kind: "tracker-command",
         level: "debug",
-        msg: `${cmd} ${args.join(" ")} (exit 0)`,
+        msg: `${cmd} ${safeArgs.join(" ")} (exit 0)`,
         cmd,
-        args,
+        args: safeArgs,
         exitCode: 0,
       });
       return stdout;
@@ -83,9 +88,9 @@ export function withDebugLogging(exec: Exec, log: Log): Exec {
       log({
         kind: "tracker-command",
         level: "debug",
-        msg: `${cmd} ${args.join(" ")} (exit ${exitCode ?? "unknown"})`,
+        msg: `${cmd} ${safeArgs.join(" ")} (exit ${exitCode ?? "unknown"})`,
         cmd,
-        args,
+        args: safeArgs,
         exitCode,
       });
       throw error;

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -11,7 +11,12 @@ import {
   type ResolvedConfig,
   resolveConfig,
 } from "../core/config.js";
-import type { Log, LogBindings, LogEvent } from "../core/log.js";
+import {
+  type Log,
+  type LogBindings,
+  type LogEvent,
+  scrubCredentials,
+} from "../core/log.js";
 import type { Action, WorldSnapshot } from "../core/types.js";
 import { reportBlockText } from "./console-report.js";
 
@@ -89,7 +94,11 @@ function tagFor(bindings: LogBindings): string {
  *   append mode; a sink failure (permissions, full disk) is contained and
  *   reported rather than fatal; the buffered tail is flushed on normal exit
  *   and on crash. Records use tslog's native shape, not its pino-compatible
- *   preset.
+ *   preset. Every formatted line is scrubbed for credential-shaped content
+ *   (`scrubCredentials`) before it reaches disk — the console isn't, since
+ *   GitHub Actions already masks registered secrets in the workflow log,
+ *   but nothing masks a file this process writes itself, and this file is
+ *   the artifact a Worker job uploads.
  *
  * The root logger binds a run identifier matching the file's name, so every
  * record — console or file — carries it.
@@ -130,13 +139,15 @@ function buildLog(
       cliProcess.stdout.write(`${line}\n`);
     },
   });
-  rootLogger.attachTransport(
-    fileTransport({
-      path: join(cwd, RUN_DIR, "logs", `${runId}.jsonl`),
-      format: "json",
-      minLevel: "DEBUG",
-    }),
-  );
+  const fileSink = fileTransport({
+    path: join(cwd, RUN_DIR, "logs", `${runId}.jsonl`),
+    format: "json",
+    minLevel: "DEBUG",
+  });
+  rootLogger.attachTransport({
+    ...fileSink,
+    write: (record, line) => fileSink.write(record, scrubCredentials(line)),
+  });
   function wrap(logger: typeof rootLogger): Log {
     const log = ((event: LogEvent): void => {
       const block = reportBlockText(event);

--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -77,6 +77,31 @@ export type LogEvent = LogEventBase &
       }
   );
 
+/**
+ * Credential-shaped substrings redacted from anything that might reach a log:
+ * a GitHub token (classic or fine-grained), or the userinfo segment of a URL
+ * (`https://token@host` or `https://user:token@host` — the common CI pattern
+ * of authenticating `git`/`gh` through a remote URL rather than the
+ * environment). A plain `git@github.com:owner/repo.git` SSH remote has no
+ * `://` and is left alone, since `git` there is a fixed username, not a
+ * credential.
+ */
+const CREDENTIAL_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/gh[pousr]_[A-Za-z0-9]{36,}/g, "<redacted>"],
+  [/github_pat_[A-Za-z0-9_]{22,}/g, "<redacted>"],
+  [/:\/\/[^/\s@]+@/g, "://<redacted>@"],
+  [/\bBearer\s+[A-Za-z0-9\-._~+/]+=*/gi, "Bearer <redacted>"],
+];
+
+/** Redacts credential-shaped content from `text`, defensively — the last line of defense before a log reaches a file. */
+export function scrubCredentials(text: string): string {
+  return CREDENTIAL_PATTERNS.reduce(
+    (scrubbed, [pattern, replacement]) =>
+      scrubbed.replace(pattern, replacement),
+    text,
+  );
+}
+
 /** Fields a Worker's (or Conflict Worker's) sub-logger binds onto every event it emits. */
 export interface LogBindings {
   ticket?: number;

--- a/tests/adapters/tracker.test.ts
+++ b/tests/adapters/tracker.test.ts
@@ -1069,4 +1069,24 @@ describe("withDebugLogging", () => {
     expect(events[0]).toMatchObject({ exitCode: null });
     expect(events[0]?.msg).toContain("exit unknown");
   });
+
+  it("scrubs credential-shaped content out of the captured command log", async () => {
+    const token = `ghp_${"A".repeat(36)}`;
+    const secretUrl = `https://x-access-token:${token}@github.com/o/r.git`;
+    const exec: Exec = async (_cmd, actualArgs) => {
+      // The real subprocess call must still see the unscrubbed URL: scrubbing
+      // is a logging concern only, never a behavior change.
+      expect(actualArgs).toContain(secretUrl);
+      return "";
+    };
+    const { log, events } = recordingLog();
+
+    await withDebugLogging(exec, log)("git", ["push", secretUrl]);
+
+    const event = events[0];
+    expect(event?.msg).not.toContain(token);
+    expect(event).toMatchObject({
+      args: ["push", "https://<redacted>@github.com/o/r.git"],
+    });
+  });
 });

--- a/tests/cli/context.test.ts
+++ b/tests/cli/context.test.ts
@@ -39,4 +39,35 @@ describe("buildRealContext's durable log file", () => {
     const record = JSON.parse(String(line));
     expect(record).toMatchObject({ message: "claimed #1", level: "DEBUG" });
   });
+
+  it("scrubs credential-shaped content out of the durable log file", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "border-collie-context-test-"));
+    const token = `ghp_${"A".repeat(36)}`;
+    const secretUrl = `https://x-access-token:${token}@github.com/o/r.git`;
+
+    const context = buildRealContext(dir);
+    context.log({
+      kind: "claim",
+      level: "debug",
+      ticket: 1,
+      msg: `git push ${secretUrl}`,
+    });
+
+    const logsDir = join(dir, ".border-collie", "logs");
+    await vi.waitFor(() => {
+      expect(existsSync(logsDir)).toBe(true);
+    });
+    const [fileName] = readdirSync(logsDir);
+    const logPath = join(logsDir, String(fileName));
+
+    await vi.waitFor(() => {
+      const contents = readFileSync(logPath, "utf8").trim();
+      expect(contents.length).toBeGreaterThan(0);
+    });
+
+    const contents = readFileSync(logPath, "utf8");
+    expect(contents).not.toContain(token);
+    expect(contents).not.toContain("x-access-token");
+    expect(contents).toContain("https://<redacted>@github.com/o/r.git");
+  });
 });

--- a/tests/core/log.test.ts
+++ b/tests/core/log.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { scrubCredentials } from "../../src/core/log.js";
+
+describe("scrubCredentials", () => {
+  it("leaves ordinary text untouched", () => {
+    const text = "gh issue view 5 (exit 0)";
+
+    expect(scrubCredentials(text)).toBe(text);
+  });
+
+  it("leaves a plain https remote untouched", () => {
+    const text = "git fetch https://github.com/lyeyixian/border-collie.git";
+
+    expect(scrubCredentials(text)).toBe(text);
+  });
+
+  it("leaves an SSH remote untouched (no credential, `git` is a fixed username)", () => {
+    const text = "git push git@github.com:lyeyixian/border-collie.git";
+
+    expect(scrubCredentials(text)).toBe(text);
+  });
+
+  it("redacts a classic GitHub PAT", () => {
+    const token = `ghp_${"A".repeat(36)}`;
+
+    expect(scrubCredentials(`token: ${token}`)).toBe("token: <redacted>");
+  });
+
+  it("redacts a fine-grained GitHub PAT", () => {
+    const token = `github_pat_${"A".repeat(30)}`;
+
+    expect(scrubCredentials(`token: ${token}`)).toBe("token: <redacted>");
+  });
+
+  it("redacts a token embedded as a URL's userinfo segment", () => {
+    const token = `ghp_${"A".repeat(36)}`;
+    const url = `https://x-access-token:${token}@github.com/lyeyixian/border-collie.git`;
+
+    expect(scrubCredentials(url)).toBe(
+      "https://<redacted>@github.com/lyeyixian/border-collie.git",
+    );
+  });
+
+  it("redacts a bare token embedded as a URL's userinfo segment, no username", () => {
+    const token = `ghp_${"A".repeat(36)}`;
+
+    expect(scrubCredentials(`https://${token}@github.com/o/r.git`)).toBe(
+      "https://<redacted>@github.com/o/r.git",
+    );
+  });
+
+  it("redacts a Bearer authorization header", () => {
+    expect(scrubCredentials("Authorization: Bearer abc123.def-456_ghi")).toBe(
+      "Authorization: Bearer <redacted>",
+    );
+  });
+});


### PR DESCRIPTION
Committed. Here's the PR description:

## Summary

The debug instrumentation that logs every `gh`/`git` command previously only asserted in prose that credentials never reach a command line — true for environment-based authentication but not for the common CI pattern of embedding a token in a remote URL. Since these logs are becoming uploaded artifacts, and GitHub only masks registered secrets in the workflow log (never in files a process writes itself), this makes that assertion executable.

- Adds a pure `scrubCredentials` function (`src/core/log.ts`) that redacts credential-shaped content: GitHub tokens (classic and fine-grained PATs), a URL's userinfo segment (`https://token@host` / `https://user:token@host`), and `Bearer` auth headers. A plain SSH remote (`git@github.com:owner/repo.git`) is left alone since it carries no credential.
- `withDebugLogging` (`src/adapters/tracker.ts`) now scrubs the command/args it logs, while the real `exec` call still receives the unscrubbed args — logging changes, behavior doesn't.
- The durable log file sink (`src/cli/context.ts`) scrubs every formatted line before it hits disk, as a defensive last line before that file becomes a Worker job's uploaded artifact. The console sink is left unscrubbed since GitHub Actions already masks registered secrets there.
- Verified no token currently appears in argv or a remote URL anywhere in the codebase (`gh`/`git` already authenticate from the environment; remotes are plain `origin`).

## Test plan

- [x] `tests/core/log.test.ts` (new) — unit coverage of `scrubCredentials` across token shapes and negative cases (plain HTTPS/SSH remotes untouched)
- [x] `tests/adapters/tracker.test.ts` — `withDebugLogging` scrubs a credential-shaped arg from the logged event while the real exec call still receives it unscrubbed
- [x] `tests/cli/context.test.ts` — integration test writing to a real temp file, asserting the token never lands on disk
- [x] `npx tsc --noEmit`, `npx biome check .`, `npx vitest run` all pass (317/317 tests)

Closes #69