### PR TITLE
refactor(breaker): derive the circuit breaker from the tracker

### DIFF
--- a/src/adapters/tracker.ts
+++ b/src/adapters/tracker.ts
@@ -120,7 +120,15 @@ function toTicket(issue: GithubIssue): Ticket {
     hasAgentClaim: false,
     agentClaimCount: 0,
     attemptFailures: [],
+    voidedAtMs: undefined,
   };
+}
+
+/** A comment's `created_at`, parsed to epoch ms — undefined when absent or unparseable. */
+function commentTimestamp(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const ms = Date.parse(raw);
+  return Number.isNaN(ms) ? undefined : ms;
 }
 
 async function readPages<T>(endpoint: string, exec: Exec): Promise<T[]> {
@@ -133,6 +141,7 @@ interface ClaimHistory {
   hasAgentClaim: boolean;
   agentClaimCount: number;
   attemptFailures: AttemptFailure[];
+  voidedAtMs: number | undefined;
 }
 
 /**
@@ -143,13 +152,16 @@ interface ClaimHistory {
  * marker uncounts the claim it follows (an infrastructure death burns
  * nothing) while leaving the claim held, and release comments carry the
  * failed attempts' forensic records. All append-only, so history stays
- * auditable and attempt state needs no local store.
+ * auditable and attempt state needs no local store. `voidedAtMs` tracks
+ * whether a void marker is still the latest one — a later claim or release
+ * resolves it — so the circuit breaker can be derived from it fresh each Tick
+ * (CONTEXT.md "Infrastructure failure").
  */
 async function readClaimHistory(
   ticket: number,
   exec: Exec,
 ): Promise<ClaimHistory> {
-  const comments = await readPages<{ body?: string }>(
+  const comments = await readPages<{ body?: string; created_at?: string }>(
     `repos/{owner}/{repo}/issues/${ticket}/comments?per_page=100`,
     exec,
   );
@@ -157,15 +169,19 @@ async function readClaimHistory(
     hasAgentClaim: false,
     agentClaimCount: 0,
     attemptFailures: [],
+    voidedAtMs: undefined,
   };
   for (const comment of comments) {
     if (comment.body?.includes(CLAIM_MARKER)) {
       history.hasAgentClaim = true;
       history.agentClaimCount += 1;
+      history.voidedAtMs = undefined;
     } else if (comment.body?.includes(VOID_MARKER)) {
       history.agentClaimCount = Math.max(0, history.agentClaimCount - 1);
+      history.voidedAtMs = commentTimestamp(comment.created_at);
     } else if (comment.body?.includes(RELEASE_MARKER)) {
       history.hasAgentClaim = false;
+      history.voidedAtMs = undefined;
       const failure = parseAttemptMarker(comment.body);
       if (failure) history.attemptFailures.push(failure);
     }
@@ -388,6 +404,7 @@ export async function readScope(
       ticket.hasAgentClaim = history.hasAgentClaim;
       ticket.agentClaimCount = history.agentClaimCount;
       ticket.attemptFailures = history.attemptFailures;
+      ticket.voidedAtMs = history.voidedAtMs;
     }
     if (ticket.openBlockers > 0) {
       ticket.blockedBy = await readOpenBlockers(ticket.number, exec);

--- a/src/app/run.ts
+++ b/src/app/run.ts
@@ -16,7 +16,11 @@ import type { Action, Ticket, WorldSnapshot } from "../core/types.js";
  * the circuit breaker — the one piece of state that is genuinely about this
  * process's environment, not the world, so it lives here in memory and not
  * on the tracker (ADR 0001). Killing a run and re-running later loses
- * nothing: a lost breaker merely re-trips at worst one voided Attempt later.
+ * nothing: a lost breaker merely re-trips at worst one voided Attempt later
+ * — and even that gap is narrow, since the Tick itself also derives a
+ * breaker from the tracker's void markers (`core/breaker.ts`), so a fresh
+ * loop still plans (and reports Stuck) correctly against an outage it never
+ * saw happen.
  */
 
 export type RunStatus =
@@ -69,6 +73,13 @@ export interface RunDeps {
     world: WorldSnapshot;
     actions: Action[];
     infraFailures: number;
+    /**
+     * Whether the Tick actually planned with dispatch paused — the passed-in
+     * flag OR'd with the tracker-derived breaker, so a fresh loop (or one
+     * whose in-memory breaker hasn't caught up yet) still judges Stuck
+     * against what the Tick really planned, not just its own memory.
+     */
+    dispatchPaused: boolean;
   }>;
   /** The circuit breaker's recovery probe: true when the environment answers. */
   probe: () => Promise<boolean>;
@@ -103,9 +114,12 @@ export async function run(
         });
       }
     }
-    const { world, actions, infraFailures } = await deps.tick(
-      breaker !== undefined,
-    );
+    const {
+      world,
+      actions,
+      infraFailures,
+      dispatchPaused: tickDispatchPaused,
+    } = await deps.tick(breaker !== undefined);
     if (infraFailures > 0) {
       breaker = tripBreaker(breaker, deps.now());
       const nextProbeMs = breakerCooldownMs(breaker.trips);
@@ -117,7 +131,16 @@ export async function run(
         nextProbeMs,
       });
     }
-    const status = runStatus(world, actions, breaker !== undefined);
+    // Either source suppresses Stuck: this Tick's own fresh infra failure
+    // (just folded into `breaker`, above, but too late for the Tick's own
+    // plan to have known it) or the Tick's tracker-derived verdict (which
+    // catches an outage this loop's memory hasn't — or no longer — knows
+    // about).
+    const status = runStatus(
+      world,
+      actions,
+      breaker !== undefined || tickDispatchPaused,
+    );
     if (status.state === "complete") {
       const completeReport = buildCompleteReport(world.tickets);
       deps.log({

--- a/src/app/run.ts
+++ b/src/app/run.ts
@@ -8,6 +8,7 @@ import type { Log } from "../core/log.js";
 import { dispatchableSet } from "../core/plan.js";
 import { buildCompleteReport, buildStuckReport } from "../core/render.js";
 import type { Action, Ticket, WorldSnapshot } from "../core/types.js";
+import type { TickResult } from "./tick.js";
 
 /**
  * The resident loop: Tick, judge the world, sleep the poll interval, Tick
@@ -69,18 +70,7 @@ export type RunOutcome = "complete" | "stuck";
 
 /** The loop's effects, injectable for tests; `tick` is one full observe → plan → act pass. */
 export interface RunDeps {
-  tick: (dispatchPaused: boolean) => Promise<{
-    world: WorldSnapshot;
-    actions: Action[];
-    infraFailures: number;
-    /**
-     * Whether the Tick actually planned with dispatch paused — the passed-in
-     * flag OR'd with the tracker-derived breaker, so a fresh loop (or one
-     * whose in-memory breaker hasn't caught up yet) still judges Stuck
-     * against what the Tick really planned, not just its own memory.
-     */
-    dispatchPaused: boolean;
-  }>;
+  tick: (dispatchPaused: boolean) => Promise<TickResult>;
   /** The circuit breaker's recovery probe: true when the environment answers. */
   probe: () => Promise<boolean>;
   now: () => number;

--- a/src/app/tick.ts
+++ b/src/app/tick.ts
@@ -21,24 +21,28 @@ export interface TickDeps {
   scheduleInterval: IntervalScheduler;
 }
 
+/**
+ * What one Tick came to, returned to both the standalone command and the
+ * resident loop. `dispatchPaused` is what this Tick actually planned with —
+ * the caller's own `dispatchPaused` OR'd with the tracker-derived breaker
+ * (see `tickOnce` below) — so a caller with no breaker memory of its own, or
+ * one that hasn't caught up yet, can still judge Stuck against what was
+ * really planned rather than against its own memory alone.
+ */
+export interface TickResult {
+  world: WorldSnapshot;
+  actions: Action[];
+  infraFailures: number;
+  dispatchPaused: boolean;
+}
+
 /** One full observe → plan → act pass — the single Tick both commands share. */
 export async function tickOnce(
   config: ResolvedConfig,
   dryRun: boolean,
   dispatchPaused = false,
   deps: TickDeps,
-): Promise<{
-  world: WorldSnapshot;
-  actions: Action[];
-  infraFailures: number;
-  /**
-   * Whether THIS Tick actually planned with dispatch paused — the caller's
-   * `dispatchPaused` OR'd with the tracker-derived breaker, so a caller with
-   * no breaker memory of its own (or one that hasn't caught up yet) can
-   * still judge Stuck correctly against what was really planned.
-   */
-  dispatchPaused: boolean;
-}> {
+): Promise<TickResult> {
   const { log, now, scheduleInterval } = deps;
   // Every command this Tick issues through the adapters — gh and git alike
   // — plus its exit code, is narrated at debug through the same seam:
@@ -49,11 +53,8 @@ export async function tickOnce(
   // Resolved fresh against wall-clock time each Tick (CONTEXT.md "Working
   // hours") — not encoded in a cron expression.
   const withinWorkingHours = isWithinWorkingHours(config.workingHours, now());
-  // The caller's dispatchPaused carries a resident loop's in-memory breaker,
-  // when it has one; the tracker-derived breaker is recomputed fresh every
-  // Tick regardless, so a one-Tick-per-process runner (with no such memory)
-  // still holds dispatch paused across an outage (CONTEXT.md "Infrastructure
-  // failure").
+  // Always derived, regardless of what the caller already knows (see
+  // `deriveBreaker`'s own doc for why this reaches the same verdict either way).
   const derivedBreaker = deriveBreaker(world);
   const derivedPause =
     derivedBreaker !== undefined && !probeDue(derivedBreaker, now());

--- a/src/app/tick.ts
+++ b/src/app/tick.ts
@@ -5,6 +5,7 @@ import {
   dispatchWorker,
   realSpawnWorkerProcess,
 } from "../adapters/worker.js";
+import { deriveBreaker, probeDue } from "../core/breaker.js";
 import { modelForAttempt, type ResolvedConfig } from "../core/config.js";
 import type { Log } from "../core/log.js";
 import { plan } from "../core/plan.js";
@@ -26,7 +27,18 @@ export async function tickOnce(
   dryRun: boolean,
   dispatchPaused = false,
   deps: TickDeps,
-): Promise<{ world: WorldSnapshot; actions: Action[]; infraFailures: number }> {
+): Promise<{
+  world: WorldSnapshot;
+  actions: Action[];
+  infraFailures: number;
+  /**
+   * Whether THIS Tick actually planned with dispatch paused — the caller's
+   * `dispatchPaused` OR'd with the tracker-derived breaker, so a caller with
+   * no breaker memory of its own (or one that hasn't caught up yet) can
+   * still judge Stuck correctly against what was really planned.
+   */
+  dispatchPaused: boolean;
+}> {
   const { log, now, scheduleInterval } = deps;
   // Every command this Tick issues through the adapters — gh and git alike
   // — plus its exit code, is narrated at debug through the same seam:
@@ -37,15 +49,24 @@ export async function tickOnce(
   // Resolved fresh against wall-clock time each Tick (CONTEXT.md "Working
   // hours") — not encoded in a cron expression.
   const withinWorkingHours = isWithinWorkingHours(config.workingHours, now());
+  // The caller's dispatchPaused carries a resident loop's in-memory breaker,
+  // when it has one; the tracker-derived breaker is recomputed fresh every
+  // Tick regardless, so a one-Tick-per-process runner (with no such memory)
+  // still holds dispatch paused across an outage (CONTEXT.md "Infrastructure
+  // failure").
+  const derivedBreaker = deriveBreaker(world);
+  const derivedPause =
+    derivedBreaker !== undefined && !probeDue(derivedBreaker, now());
+  const effectiveDispatchPaused = dispatchPaused || derivedPause;
   const actions = plan(world, {
     maxWorkers: config.maxWorkers,
     maxOpenPrs: config.maxOpenPrs,
-    dispatchPaused,
+    dispatchPaused: effectiveDispatchPaused,
     withinWorkingHours,
   });
   const planReport = buildPlanReport(config, world, actions, {
     dryRun,
-    dispatchPaused,
+    dispatchPaused: effectiveDispatchPaused,
     withinWorkingHours,
   });
   log({
@@ -102,5 +123,10 @@ export async function tickOnce(
     });
     infraFailures = report.infraFailures;
   }
-  return { world, actions, infraFailures };
+  return {
+    world,
+    actions,
+    infraFailures,
+    dispatchPaused: effectiveDispatchPaused,
+  };
 }

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -5,7 +5,7 @@ import { fileTransport } from "tslog/transports/file";
 import { loadConfigFile } from "../adapters/config-file.js";
 import { probeEnvironment, RUN_DIR } from "../adapters/worker.js";
 import type { IntervalScheduler } from "../app/act.js";
-import { tickOnce } from "../app/tick.js";
+import { type TickResult, tickOnce } from "../app/tick.js";
 import {
   type Flags,
   type ResolvedConfig,
@@ -17,7 +17,6 @@ import {
   type LogEvent,
   scrubCredentials,
 } from "../core/log.js";
-import type { Action, WorldSnapshot } from "../core/types.js";
 import { reportBlockText } from "./console-report.js";
 
 /** Every effect a command handler needs, injected so handlers never import them directly. */
@@ -28,12 +27,7 @@ export interface Context extends CommandContext {
     config: ResolvedConfig,
     dryRun: boolean,
     dispatchPaused?: boolean,
-  ) => Promise<{
-    world: WorldSnapshot;
-    actions: Action[];
-    infraFailures: number;
-    dispatchPaused: boolean;
-  }>;
+  ) => Promise<TickResult>;
   readonly probe: (model: string) => Promise<boolean>;
   readonly now: () => number;
   readonly sleep: (ms: number) => Promise<void>;

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -32,6 +32,7 @@ export interface Context extends CommandContext {
     world: WorldSnapshot;
     actions: Action[];
     infraFailures: number;
+    dispatchPaused: boolean;
   }>;
   readonly probe: (model: string) => Promise<boolean>;
   readonly now: () => number;

--- a/src/cli/tick-command.ts
+++ b/src/cli/tick-command.ts
@@ -13,8 +13,9 @@ async function tickHandler(
 
   const { infraFailures } = await this.tick(config, flags.dryRun);
   if (infraFailures > 0) {
-    // A standalone tick has no resident breaker to hold open; the voided
-    // claims stay held on the tracker, so the operator just re-ticks later.
+    // A standalone tick has no resident breaker of its own, but the next one
+    // derives the same paused verdict from the void markers this Tick just
+    // left on the tracker — so the operator can simply re-tick later.
     this.process.stdout.write(
       "Infrastructure failure detected: attempts voided, claims held. Re-run tick when the environment recovers.\n",
     );
@@ -40,6 +41,9 @@ ticket + commit subjects). Dispatch pauses while open agent PRs sit at
 max_open_prs and resumes as merges land.
 
 ${WORKER_DEATH_PROSE} the tick prints a notice so the operator knows to
-re-run once the environment recovers.`,
+re-run once the environment recovers. A standalone tick keeps no memory of
+its own, but the circuit breaker it derives from the tracker's void markers
+still holds dispatch paused across separate ticks, probing on the same
+backoff, until the environment recovers.`,
   },
 });

--- a/src/cli/tick-command.ts
+++ b/src/cli/tick-command.ts
@@ -43,7 +43,7 @@ max_open_prs and resumes as merges land.
 ${WORKER_DEATH_PROSE} the tick prints a notice so the operator knows to
 re-run once the environment recovers. A standalone tick keeps no memory of
 its own, but the circuit breaker it derives from the tracker's void markers
-still holds dispatch paused across separate ticks, probing on the same
-backoff, until the environment recovers.`,
+still holds dispatch paused across separate ticks on the same cooldown,
+resuming once it elapses.`,
   },
 });

--- a/src/core/breaker.ts
+++ b/src/core/breaker.ts
@@ -1,10 +1,13 @@
+import type { WorldSnapshot } from "./types.js";
+
 /**
  * The circuit breaker (CONTEXT.md "Infrastructure failure"): pause dispatch
  * while the environment is down, resume when it recovers. Pure state
- * machine; the run loop owns the instance and the probe. Breaker state is
- * deliberately in-memory only — losing it to a crash is safe (the next run
- * dispatches immediately and re-trips at worst one voided Attempt later),
- * so it never belongs in the tracker (ADR 0001).
+ * machine. The resident run loop still owns its own instance in memory
+ * across Ticks (losing it to a crash is safe there — the next run dispatches
+ * immediately and re-trips at worst one voided Attempt later). A one-Tick-
+ * per-process runner has no such memory, so `deriveBreaker` below
+ * reconstructs the same state fresh from the tracker every Tick instead.
  */
 
 /** Open breaker: dispatch is paused since `openedAtMs`, after `trips` consecutive trips. */
@@ -39,4 +42,24 @@ export function breakerCooldownMs(trips: number): number {
 /** Whether the cooldown has elapsed and the environment should be probed. */
 export function probeDue(breaker: OpenBreaker, nowMs: number): boolean {
   return nowMs - breaker.openedAtMs >= breakerCooldownMs(breaker.trips);
+}
+
+/**
+ * Derive the breaker fresh from the world snapshot: every in-Scope ticket's
+ * still-held void marker (`Ticket.voidedAtMs`, undefined once a later claim
+ * or release resolves it) is one trip, folded through `tripBreaker` in
+ * chronological order — exactly the sequence a live process would have
+ * applied as each void landed. A fresh process therefore reaches the same
+ * verdict as one that watched the failures happen, with no store beyond the
+ * tracker's own comments.
+ */
+export function deriveBreaker(world: WorldSnapshot): Breaker {
+  const voidTimestampsMs = world.tickets
+    .map((ticket) => ticket.voidedAtMs)
+    .filter((ms): ms is number => ms !== undefined)
+    .sort((a, b) => a - b);
+  return voidTimestampsMs.reduce<Breaker>(
+    (breaker, ms) => tripBreaker(breaker, ms),
+    undefined,
+  );
 }

--- a/src/core/breaker.ts
+++ b/src/core/breaker.ts
@@ -45,20 +45,46 @@ export function probeDue(breaker: OpenBreaker, nowMs: number): boolean {
 }
 
 /**
+ * Void markers this close together are read as one Tick's worth: the live
+ * loop trips once per Tick no matter how many Workers died the same way
+ * (CONTEXT.md "Infrastructure failure" — correlated), and every void comment
+ * for one Tick posts back-to-back right after its Workers settle. Ticks
+ * themselves are always spaced by at least the base cooldown once the
+ * breaker is open, so this window can't merge two genuinely separate trips.
+ */
+const CORRELATED_VOID_WINDOW_MS = 60_000;
+
+/**
  * Derive the breaker fresh from the world snapshot: every in-Scope ticket's
  * still-held void marker (`Ticket.voidedAtMs`, undefined once a later claim
- * or release resolves it) is one trip, folded through `tripBreaker` in
- * chronological order — exactly the sequence a live process would have
- * applied as each void landed. A fresh process therefore reaches the same
- * verdict as one that watched the failures happen, with no store beyond the
- * tracker's own comments.
+ * or release resolves it) contributes its timestamp; timestamps within
+ * `CORRELATED_VOID_WINDOW_MS` of each other collapse to the one Tick that
+ * produced them. Each surviving timestamp is one trip, folded through
+ * `tripBreaker` in chronological order — the same sequence a live process
+ * would have applied as each Tick's voids landed. A fresh process therefore
+ * reaches the same verdict as one that watched the failures happen, with no
+ * store beyond the tracker's own comments.
  */
 export function deriveBreaker(world: WorldSnapshot): Breaker {
   const voidTimestampsMs = world.tickets
     .map((ticket) => ticket.voidedAtMs)
     .filter((ms): ms is number => ms !== undefined)
     .sort((a, b) => a - b);
-  return voidTimestampsMs.reduce<Breaker>(
+
+  const tripTimestampsMs: number[] = [];
+  for (const ms of voidTimestampsMs) {
+    const lastIndex = tripTimestampsMs.length - 1;
+    if (
+      lastIndex >= 0 &&
+      ms - (tripTimestampsMs[lastIndex] as number) <= CORRELATED_VOID_WINDOW_MS
+    ) {
+      tripTimestampsMs[lastIndex] = ms;
+    } else {
+      tripTimestampsMs.push(ms);
+    }
+  }
+
+  return tripTimestampsMs.reduce<Breaker>(
     (breaker, ms) => tripBreaker(breaker, ms),
     undefined,
   );

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -239,6 +239,15 @@ export interface Ticket {
   agentClaimCount: number;
   /** Attempt records parsed from release comments, in comment order. */
   attemptFailures: AttemptFailure[];
+  /**
+   * Timestamp (ms) of the ticket's most recent void marker, when it is still
+   * the latest border-collie marker on the ticket — an infrastructure
+   * failure voided the claim and it has not yet been reclaimed or released.
+   * Undefined once superseded by a later claim or release, or when the
+   * ticket was never voided. The circuit breaker derives its state from
+   * these across in-Scope tickets (CONTEXT.md "Infrastructure failure").
+   */
+  voidedAtMs: number | undefined;
 }
 
 /**

--- a/tests/adapters/tracker.test.ts
+++ b/tests/adapters/tracker.test.ts
@@ -452,6 +452,7 @@ describe("readScope", () => {
             { body: `${CLAIM_MARKER}\n🐕 claimed` },
             {
               body: `${VOID_MARKER}\n🐕 Attempt 1 voided: the account usage limit was reached`,
+              created_at: "2026-01-01T00:05:00.000Z",
             },
           ],
         ],
@@ -466,17 +467,47 @@ describe("readScope", () => {
       hasAgentClaim: true,
       agentClaimCount: 0,
       attemptFailures: [],
+      voidedAtMs: Date.parse("2026-01-01T00:05:00.000Z"),
     });
   });
 
-  it("counts a fresh claim after a voided one as the first Attempt again", async () => {
+  it("resolves the held void once a later release lands, even without a reclaim yet", async () => {
     const { exec } = fakeExec({
       api: {
         [SUB_ISSUES]: [[issue({ number: 5 })]],
         [comments(5)]: [
           [
             { body: `${CLAIM_MARKER}\n🐕 claimed` },
-            { body: `${VOID_MARKER}\n🐕 Attempt 1 voided` },
+            {
+              body: `${VOID_MARKER}\n🐕 Attempt 1 voided`,
+              created_at: "2026-01-01T00:05:00.000Z",
+            },
+            {
+              body: `${RELEASE_MARKER}\n🐕 released (orphaned after the outage)`,
+            },
+          ],
+        ],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.tickets[0]).toMatchObject({ voidedAtMs: undefined });
+  });
+
+  it("counts a fresh claim after a voided one as the first Attempt again, and resolves the void", async () => {
+    const { exec } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [
+          [
+            { body: `${CLAIM_MARKER}\n🐕 claimed` },
+            {
+              body: `${VOID_MARKER}\n🐕 Attempt 1 voided`,
+              created_at: "2026-01-01T00:05:00.000Z",
+            },
             {
               body: `${RELEASE_MARKER}\n🐕 released (orphaned after the outage)`,
             },
@@ -493,7 +524,33 @@ describe("readScope", () => {
     expect(world.tickets[0]).toMatchObject({
       hasAgentClaim: true,
       agentClaimCount: 1,
+      voidedAtMs: undefined,
     });
+  });
+
+  it("leaves voidedAtMs undefined when the void comment's timestamp is missing or unparseable", async () => {
+    const { exec } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [
+          [issue({ number: 5, assignees: [{ login: "operator" }] })],
+        ],
+        [comments(5)]: [
+          [
+            { body: `${CLAIM_MARKER}\n🐕 claimed` },
+            {
+              body: `${VOID_MARKER}\n🐕 Attempt 1 voided`,
+              created_at: "not-a-date",
+            },
+          ],
+        ],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.tickets[0]).toMatchObject({ voidedAtMs: undefined });
   });
 
   it("maps open agent-branch PRs with their upkeep signals, ignoring other branches", async () => {

--- a/tests/app/run.test.ts
+++ b/tests/app/run.test.ts
@@ -22,6 +22,7 @@ function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
     hasAgentClaim: false,
     agentClaimCount: 0,
     attemptFailures: [],
+    voidedAtMs: undefined,
     ...overrides,
   };
 }
@@ -148,7 +149,13 @@ describe("runStatus", () => {
  * exercised in fake time; probe answers shift off `probeAnswers`.
  */
 function scriptedDeps(
-  script: { world: WorldSnapshot; actions: Action[]; infraFailures?: number }[],
+  script: {
+    world: WorldSnapshot;
+    actions: Action[];
+    infraFailures?: number;
+    /** Overrides the echoed dispatchPaused — a Tick's own tracker-derived verdict, independent of the flag it was called with. */
+    dispatchPaused?: boolean;
+  }[],
   opts: { probeAnswers?: boolean[]; msPerSleep?: number } = {},
 ): {
   deps: RunDeps;
@@ -174,7 +181,7 @@ function scriptedDeps(
         throw new Error("tick called past the end of the script");
       state.ticks += 1;
       state.pausedFlags.push(dispatchPaused);
-      return { infraFailures: 0, ...next };
+      return { infraFailures: 0, dispatchPaused, ...next };
     },
     probe: async () => {
       state.probes += 1;
@@ -336,6 +343,28 @@ describe("run", () => {
     const stillOpen = state.events.find((e) => e.kind === "breaker-still-open");
     expect(stillOpen?.level).toBe("warn");
     expect(stillOpen).toMatchObject({ trips: 2 });
+  });
+
+  it("is never stuck on a freshly started loop that has no memory of an outage the tick derives from the tracker", async () => {
+    // This loop's own in-memory breaker never trips (infraFailures stays 0,
+    // so it never calls probe) — as a fresh process would look right after
+    // restarting mid-outage. The Tick still reports dispatchPaused: true,
+    // derived from void markers already on the tracker (CONTEXT.md
+    // "Infrastructure failure"), and that alone must be enough to keep the
+    // loop running rather than declaring Stuck.
+    const held = world([
+      ticket({ number: 2, assignees: ["operator"], hasAgentClaim: true }),
+    ]);
+    const state = scriptedDeps([
+      { world: held, actions: [], dispatchPaused: true },
+      { world: held, actions: [], dispatchPaused: true },
+      { world: world([ticket({ number: 2, state: "closed" })]), actions: [] },
+    ]);
+
+    const outcome = await run(30, state.deps);
+
+    expect(outcome).toBe("complete");
+    expect(state.probes).toBe(0);
   });
 
   it("exits stuck with a report naming the open tickets, at warn", async () => {

--- a/tests/cli/app.test.ts
+++ b/tests/cli/app.test.ts
@@ -30,6 +30,7 @@ function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
     hasAgentClaim: false,
     agentClaimCount: 0,
     attemptFailures: [],
+    voidedAtMs: undefined,
     ...overrides,
   };
 }
@@ -109,6 +110,7 @@ function fakeContext(
         world: next.world,
         actions: [],
         infraFailures: next.infraFailures ?? 0,
+        dispatchPaused: dispatchPaused ?? false,
       };
     },
     probe: async (model) => {

--- a/tests/core/breaker.test.ts
+++ b/tests/core/breaker.test.ts
@@ -99,19 +99,43 @@ describe("deriveBreaker", () => {
     expect(deriveBreaker(w)).toBeUndefined();
   });
 
-  it("reaches the same verdict as a live process folding the same voids in order", () => {
+  it("collapses several tickets voided the same way in one Tick into a single trip", () => {
+    // A correlated failure: three Workers die to the same outage within one
+    // Tick's act phase, each voiding its own ticket a moment apart. The live
+    // loop trips once per Tick regardless (CONTEXT.md "Infrastructure
+    // failure" — correlated), so the derivation must match, not one trip per
+    // voided ticket.
     const w = world([
-      ticket({ number: 4, voidedAtMs: 5_000 }),
-      ticket({ number: 7, voidedAtMs: 1_000 }),
-      ticket({ number: 9, voidedAtMs: 9_000 }),
+      ticket({ number: 4, voidedAtMs: 1_000 }),
+      ticket({ number: 7, voidedAtMs: 1_500 }),
+      ticket({ number: 9, voidedAtMs: 2_000 }),
+    ]);
+
+    expect(deriveBreaker(w)).toEqual(tripBreaker(undefined, 2_000));
+  });
+
+  it("reaches the same verdict as a live process folding one trip per separate Tick", () => {
+    // Three genuinely separate outage episodes, spaced well beyond both the
+    // correlated-void window and the base cooldown — as distinct Ticks that
+    // each independently re-tripped the breaker would be.
+    const w = world([
+      ticket({ number: 4, voidedAtMs: 5 * BREAKER_BASE_COOLDOWN_MS }),
+      ticket({ number: 7, voidedAtMs: 1 * BREAKER_BASE_COOLDOWN_MS }),
+      ticket({ number: 9, voidedAtMs: 9 * BREAKER_BASE_COOLDOWN_MS }),
     ]);
 
     const live = tripBreaker(
-      tripBreaker(tripBreaker(undefined, 1_000), 5_000),
-      9_000,
+      tripBreaker(
+        tripBreaker(undefined, 1 * BREAKER_BASE_COOLDOWN_MS),
+        5 * BREAKER_BASE_COOLDOWN_MS,
+      ),
+      9 * BREAKER_BASE_COOLDOWN_MS,
     );
     expect(deriveBreaker(w)).toEqual(live);
-    expect(deriveBreaker(w)).toEqual({ openedAtMs: 9_000, trips: 3 });
+    expect(deriveBreaker(w)).toEqual({
+      openedAtMs: 9 * BREAKER_BASE_COOLDOWN_MS,
+      trips: 3,
+    });
   });
 
   it("a fresh process reaches the same paused verdict as one that watched the void happen", () => {

--- a/tests/core/breaker.test.ts
+++ b/tests/core/breaker.test.ts
@@ -3,9 +3,31 @@ import {
   BREAKER_BASE_COOLDOWN_MS,
   BREAKER_MAX_COOLDOWN_MS,
   breakerCooldownMs,
+  deriveBreaker,
   probeDue,
   tripBreaker,
 } from "../../src/core/breaker.js";
+import type { Ticket, WorldSnapshot } from "../../src/core/types.js";
+
+function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
+  return {
+    title: `Ticket #${overrides.number}`,
+    state: "open",
+    assignees: [],
+    labels: ["ready-for-agent"],
+    openBlockers: 0,
+    blockedBy: [],
+    hasAgentClaim: false,
+    agentClaimCount: 0,
+    attemptFailures: [],
+    voidedAtMs: undefined,
+    ...overrides,
+  };
+}
+
+function world(tickets: Ticket[]): WorldSnapshot {
+  return { tickets, openAgentPrs: [], mergedAgentPrs: [] };
+}
 
 describe("tripBreaker", () => {
   it("opens a closed breaker with one trip", () => {
@@ -52,5 +74,55 @@ describe("probeDue", () => {
 
     expect(probeDue(breaker, 1_000 + BREAKER_BASE_COOLDOWN_MS)).toBe(false);
     expect(probeDue(breaker, 1_000 + 2 * BREAKER_BASE_COOLDOWN_MS)).toBe(true);
+  });
+});
+
+describe("deriveBreaker", () => {
+  it("stays closed when no in-Scope ticket carries a held void", () => {
+    const w = world([ticket({ number: 1 }), ticket({ number: 2 })]);
+
+    expect(deriveBreaker(w)).toBeUndefined();
+  });
+
+  it("opens from a single held void, matching one live trip", () => {
+    const w = world([ticket({ number: 4, voidedAtMs: 1_000 })]);
+
+    expect(deriveBreaker(w)).toEqual(tripBreaker(undefined, 1_000));
+  });
+
+  it("ignores a ticket whose void was superseded by a later claim or release", () => {
+    const w = world([
+      ticket({ number: 4, voidedAtMs: undefined }),
+      ticket({ number: 5 }),
+    ]);
+
+    expect(deriveBreaker(w)).toBeUndefined();
+  });
+
+  it("reaches the same verdict as a live process folding the same voids in order", () => {
+    const w = world([
+      ticket({ number: 4, voidedAtMs: 5_000 }),
+      ticket({ number: 7, voidedAtMs: 1_000 }),
+      ticket({ number: 9, voidedAtMs: 9_000 }),
+    ]);
+
+    const live = tripBreaker(
+      tripBreaker(tripBreaker(undefined, 1_000), 5_000),
+      9_000,
+    );
+    expect(deriveBreaker(w)).toEqual(live);
+    expect(deriveBreaker(w)).toEqual({ openedAtMs: 9_000, trips: 3 });
+  });
+
+  it("a fresh process reaches the same paused verdict as one that watched the void happen", () => {
+    const w = world([ticket({ number: 4, voidedAtMs: 0 })]);
+
+    expect(deriveBreaker(w)).toEqual({ openedAtMs: 0, trips: 1 });
+    expect(
+      probeDue({ openedAtMs: 0, trips: 1 }, BREAKER_BASE_COOLDOWN_MS - 1),
+    ).toBe(false);
+    expect(
+      probeDue({ openedAtMs: 0, trips: 1 }, BREAKER_BASE_COOLDOWN_MS),
+    ).toBe(true);
   });
 });

--- a/tests/core/plan.test.ts
+++ b/tests/core/plan.test.ts
@@ -20,6 +20,7 @@ function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
     hasAgentClaim: false,
     agentClaimCount: 0,
     attemptFailures: [],
+    voidedAtMs: undefined,
     ...overrides,
   };
 }

--- a/tests/core/render.test.ts
+++ b/tests/core/render.test.ts
@@ -32,6 +32,7 @@ function ticket(
     hasAgentClaim: false,
     agentClaimCount: 0,
     attemptFailures: [],
+    voidedAtMs: undefined,
     ...overrides,
   };
 }


### PR DESCRIPTION
refactor(breaker): derive the circuit breaker from the tracker

## Summary

- Derives circuit-breaker state from the tracker instead of resident-process memory, so a Tick that becomes its own process (#64) no longer rediscovers an outage from scratch and burns a voided Attempt each time it runs.
- Adds `Ticket.voidedAtMs`: the timestamp of a ticket's still-held void marker comment (undefined once a later claim or release resolves it), populated by widening `readClaimHistory` to read each comment's `created_at`.
- Adds `deriveBreaker(world)` (`src/core/breaker.ts`), a pure function that folds every in-Scope ticket's still-held void timestamp through the existing `tripBreaker` state machine — clustering void markers posted within one Tick's own comment-posting window into a single trip, matching the live loop's one-trip-per-correlated-Tick semantics (CONTEXT.md "Infrastructure failure").
- Wires the derivation into `tickOnce`: it now always derives a breaker from the freshly-read world and ORs it with the caller's own `dispatchPaused`, returning the effective value as part of a new shared `TickResult` type.
- Updates the resident run loop (`src/app/run.ts`) to fold the Tick's own derived verdict into its Stuck judgment too, so a freshly restarted resident process — itself a "fresh process" relative to an outage it never watched happen — no longer misreports Stuck.
- Updates the standalone `tick` command's docs/messaging to reflect that dispatch now stays correctly paused across separate invocations.

Closes #68

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (316 tests, including new coverage for `deriveBreaker`, the tracker's `voidedAtMs` parsing, and a resident-loop restart-mid-outage regression test)
- [x] `npm run lint`