### PR TITLE
feat(render): forensic comment carries readable Attempt evidence

### DIFF
--- a/src/adapters/pr.ts
+++ b/src/adapters/pr.ts
@@ -14,7 +14,7 @@ import { branchCommitSubjects, pushAgentBranch } from "./worker.js";
 /** File-read half of the transcript seam, injectable for tests. */
 export type ReadFile = (path: string) => Promise<string>;
 
-const realReadFile: ReadFile = (path) => readFile(path, "utf8");
+export const realReadFile: ReadFile = (path) => readFile(path, "utf8");
 
 /**
  * GitHub caps issue/PR bodies at 65536 characters; a Worker body beyond this

--- a/src/adapters/tracker.ts
+++ b/src/adapters/tracker.ts
@@ -536,11 +536,15 @@ export async function createDraftPr(
  * Act phase: release a ticket whose Attempt just failed, embedding the
  * attempt's forensic record in the release comment — the tracker is the only
  * state store, so this comment IS the attempt history that the next Tick's
- * retry ladder and a later Escalation read back.
+ * retry ladder and a later Escalation read back. `forensics` (the rendered
+ * result facts, tool histogram, and final turns — see `renderForensicReport`)
+ * is appended so the comment is triageable on its own, without the transcript
+ * path a runner may have already discarded.
  */
 export async function releaseFailedTicket(
   ticket: number,
   failure: AttemptFailure,
+  forensics: string,
   exec: Exec = realExec,
 ): Promise<void> {
   const body = [
@@ -548,6 +552,8 @@ export async function releaseFailedTicket(
     attemptMarker(failure),
     `🐕 Attempt ${failure.attempt} failed: ${FAILURE_DESCRIPTIONS[failure.reason]} (model ${failure.model}).`,
     `Worktree torn down; branch \`${failure.branch}\` abandoned; transcript at \`${failure.transcript}\`.`,
+    "",
+    forensics,
   ].join("\n");
   await release(ticket, body, exec);
 }

--- a/src/adapters/worker.ts
+++ b/src/adapters/worker.ts
@@ -386,6 +386,8 @@ export async function dispatchWorker(
       infra,
       costUsd: result?.totalCostUsd,
       turns: result?.numTurns,
+      durationMs: result?.durationMs,
+      subtype: result?.subtype,
       costOverrun:
         result?.totalCostUsd !== undefined &&
         result.totalCostUsd > config.maxCostUsd,

--- a/src/app/settle.ts
+++ b/src/app/settle.ts
@@ -1,9 +1,11 @@
+import { type ReadFile, realReadFile } from "../adapters/pr.js";
 import {
   type Exec,
   releaseFailedTicket,
   voidAttempt,
 } from "../adapters/tracker.js";
 import type { Log } from "../core/log.js";
+import { buildForensicReport, renderForensicReport } from "../core/render.js";
 import type { WorkerOutcome } from "../core/types.js";
 
 function describeOutcome(outcome: WorkerOutcome): string {
@@ -35,6 +37,7 @@ export async function settleAttempt(
   prUrl: string | undefined,
   log: Log,
   exec: Exec,
+  readTranscript: ReadFile = realReadFile,
 ): Promise<void> {
   log({
     kind: "worker-outcome",
@@ -76,6 +79,14 @@ export async function settleAttempt(
       reason: outcome.infra,
     });
   } else if (outcome.failure) {
+    // Read now, while the transcript still sits on this runner's disk — a
+    // later reader of the rendered comment may be on a machine where it
+    // never existed. An unreadable transcript still yields the outcome's own
+    // facts (see `buildForensicReport`), so this never blocks the release.
+    const transcript = await readTranscript(outcome.transcript).catch(() => "");
+    const forensics = renderForensicReport(
+      buildForensicReport(outcome, transcript),
+    );
     await releaseFailedTicket(
       outcome.ticket,
       {
@@ -85,6 +96,7 @@ export async function settleAttempt(
         branch: outcome.branch,
         transcript: outcome.transcript,
       },
+      forensics,
       exec,
     );
     log({

--- a/src/core/classify.ts
+++ b/src/core/classify.ts
@@ -61,6 +61,7 @@ export interface ResultEvent {
   subtype: string | undefined;
   totalCostUsd: number | undefined;
   numTurns: number | undefined;
+  durationMs: number | undefined;
 }
 
 /**
@@ -90,6 +91,8 @@ export function parseResultEvent(tail: string): ResultEvent | undefined {
     totalCostUsd:
       typeof last.total_cost_usd === "number" ? last.total_cost_usd : undefined,
     numTurns: typeof last.num_turns === "number" ? last.num_turns : undefined,
+    durationMs:
+      typeof last.duration_ms === "number" ? last.duration_ms : undefined,
   };
 }
 

--- a/src/core/render.ts
+++ b/src/core/render.ts
@@ -6,6 +6,7 @@ import {
   READY_FOR_AGENT,
   READY_FOR_HUMAN,
   type Ticket,
+  type WorkerOutcome,
   type WorldSnapshot,
 } from "./types.js";
 
@@ -367,4 +368,219 @@ export function renderCompleteReport(report: CompleteReport): string {
       return `  #${ticket.ticket} — ${ticket.title}${escalated}`;
     }),
   ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Forensic comment (failed Attempt evidence)
+// ---------------------------------------------------------------------------
+
+/** One tool name's whole-session call count, most-called first. */
+export interface ToolTally {
+  name: string;
+  count: number;
+}
+
+/** One assistant turn near the end of the session, rendered readable. */
+export interface ForensicTurn {
+  /** 1-based position among every assistant turn in the whole session. */
+  index: number;
+  text: string | undefined;
+  /** Rendered as `name(input summary)`, e.g. `Bash({"command":"npm test"})`. */
+  toolCalls: string[];
+}
+
+/** The result facts a survived transcript's result event carries, echoed from the outcome so the comment needs no re-parse. */
+export interface ForensicFacts {
+  turns: number | undefined;
+  costUsd: number | undefined;
+  durationMs: number | undefined;
+  subtype: string | undefined;
+}
+
+export interface ForensicReport {
+  facts: ForensicFacts;
+  /** Every tool call in the whole session, not just the tail — a Worker that burned its turn cap did so by looping, and only a whole-session view shows that. */
+  histogram: ToolTally[];
+  /** The session's last few assistant turns, readable rather than raw stream-json. */
+  finalTurns: ForensicTurn[];
+}
+
+/** How many of the session's final assistant turns are rendered in full. */
+export const FORENSIC_FINAL_TURNS = 8;
+
+/** How much of one turn's text survives before truncation. */
+const FORENSIC_TEXT_LIMIT = 600;
+
+/** How much of one tool call's input summary survives before truncation. */
+const FORENSIC_INPUT_LIMIT = 200;
+
+/**
+ * The forensic section's hard ceiling — comfortably under GitHub's
+ * 65536-character comment limit once the release marker and one-liner join
+ * it. The per-turn limits above already keep a normal comment far under this;
+ * it exists as a backstop against a pathological single turn, not the
+ * mechanism that makes a long session's comment fit.
+ */
+export const MAX_FORENSIC_LENGTH = 50_000;
+
+/** Truncates to at most `limit` characters total, ellipsis included. */
+function truncateText(text: string, limit: number): string {
+  return text.length <= limit ? text : `${text.slice(0, limit - 1)}…`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Every `text` content block's text, joined — empty for a tool-only turn. */
+function textOf(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter(isRecord)
+    .filter((block) => block.type === "text" && typeof block.text === "string")
+    .map((block) => block.text as string)
+    .join("\n");
+}
+
+/** Every `tool_use` content block, name plus raw input. */
+function toolCallsOf(content: unknown): { name: string; input: unknown }[] {
+  if (!Array.isArray(content)) return [];
+  return content
+    .filter(isRecord)
+    .filter(
+      (block) => block.type === "tool_use" && typeof block.name === "string",
+    )
+    .map((block) => ({ name: block.name as string, input: block.input }));
+}
+
+interface AssistantTurn {
+  text: string;
+  toolCalls: { name: string; input: unknown }[];
+}
+
+/**
+ * Every assistant turn in a transcript, in order. Tolerant of stray non-JSON
+ * lines and malformed events — the transcript is subprocess output, not a
+ * trusted document (mirrors `parseResultEvent`'s and `workerFinalMessage`'s
+ * tolerance).
+ */
+function assistantTurns(transcript: string): AssistantTurn[] {
+  const turns: AssistantTurn[] = [];
+  for (const line of transcript.split("\n")) {
+    if (line.trim() === "") continue;
+    let event: unknown;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!isRecord(event) || event.type !== "assistant") continue;
+    const content = isRecord(event.message) ? event.message.content : undefined;
+    turns.push({ text: textOf(content), toolCalls: toolCallsOf(content) });
+  }
+  return turns;
+}
+
+function buildToolHistogram(turns: AssistantTurn[]): ToolTally[] {
+  const counts = new Map<string, number>();
+  for (const turn of turns) {
+    for (const call of turn.toolCalls) {
+      counts.set(call.name, (counts.get(call.name) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([name, count]) => ({ name, count }));
+}
+
+function summarizeInput(input: unknown): string {
+  try {
+    return truncateText(
+      JSON.stringify(input) ?? "undefined",
+      FORENSIC_INPUT_LIMIT,
+    );
+  } catch {
+    return "(unrenderable input)";
+  }
+}
+
+/**
+ * Build the forensic comment's data: the result facts already captured on the
+ * outcome, a whole-session tool-call histogram, and the final turns readable
+ * rather than raw. Pure — `transcript` is whatever the caller read (the file
+ * may be gone by the time a human reads the rendered comment, which is the
+ * point of baking this in now); an empty or unparseable transcript still
+ * yields the outcome's own facts, with an empty histogram and no final turns.
+ */
+export function buildForensicReport(
+  outcome: WorkerOutcome,
+  transcript: string,
+): ForensicReport {
+  const turns = assistantTurns(transcript);
+  const sliceStart = Math.max(0, turns.length - FORENSIC_FINAL_TURNS);
+  const finalTurns: ForensicTurn[] = turns.slice(sliceStart).map((turn, i) => {
+    const text = turn.text.trim();
+    return {
+      index: sliceStart + i + 1,
+      text: text === "" ? undefined : truncateText(text, FORENSIC_TEXT_LIMIT),
+      toolCalls: turn.toolCalls.map(
+        (call) => `${call.name}(${summarizeInput(call.input)})`,
+      ),
+    };
+  });
+  return {
+    facts: {
+      turns: outcome.turns,
+      costUsd: outcome.costUsd,
+      durationMs: outcome.durationMs,
+      subtype: outcome.subtype,
+    },
+    histogram: buildToolHistogram(turns),
+    finalTurns,
+  };
+}
+
+function renderFacts(facts: ForensicFacts): string {
+  const turns = facts.turns !== undefined ? String(facts.turns) : "unknown";
+  const cost =
+    facts.costUsd !== undefined ? `$${facts.costUsd.toFixed(2)}` : "unknown";
+  const duration =
+    facts.durationMs !== undefined
+      ? formatDuration(facts.durationMs)
+      : "unknown";
+  const subtype = facts.subtype ?? "unknown";
+  return `${turns} turns, ${cost}, ${duration}, terminated \`${subtype}\``;
+}
+
+function renderHistogram(histogram: ToolTally[]): string {
+  if (histogram.length === 0) return "(no tool calls recorded)";
+  return histogram.map((tally) => `- ${tally.name}: ${tally.count}`).join("\n");
+}
+
+function renderTurn(turn: ForensicTurn): string {
+  const lines = [`Turn ${turn.index}:`];
+  if (turn.text !== undefined) lines.push(turn.text);
+  lines.push(...turn.toolCalls.map((call) => `→ ${call}`));
+  return lines.join("\n");
+}
+
+/**
+ * Render the forensic comment's body: result facts, the whole-session tool
+ * histogram, then the final turns — everything a failed Attempt's evidence
+ * needs, readable without downloading a transcript that a runner may have
+ * already discarded. Bounded to `MAX_FORENSIC_LENGTH` as a backstop. Pure.
+ */
+export function renderForensicReport(report: ForensicReport): string {
+  const body = [
+    `**Result:** ${renderFacts(report.facts)}`,
+    "",
+    "**Tool calls (whole session):**",
+    renderHistogram(report.histogram),
+    "",
+    report.finalTurns.length === 0
+      ? "**Final turns:** (none recorded)"
+      : `**Final turns:**\n\n${report.finalTurns.map(renderTurn).join("\n\n")}`,
+  ].join("\n");
+  return truncateText(body, MAX_FORENSIC_LENGTH);
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -98,6 +98,10 @@ export interface WorkerOutcome {
   costUsd: number | undefined;
   /** Agentic turns taken, from the transcript's result event when one survived. */
   turns: number | undefined;
+  /** Wall-clock duration of the whole session in ms, from the transcript's result event when one survived. */
+  durationMs: number | undefined;
+  /** How the session's result event says it ended ("success", "error_max_turns", ...), from the transcript's result event when one survived. */
+  subtype: string | undefined;
   /**
    * The Attempt spent past the cost cap. An alarm, not a failure: a finished
    * Attempt keeps its work and its PR — the overrun is surfaced so an

--- a/tests/adapters/pr.test.ts
+++ b/tests/adapters/pr.test.ts
@@ -134,6 +134,8 @@ const OUTCOME: WorkerOutcome = {
   infra: undefined,
   costUsd: undefined,
   turns: undefined,
+  durationMs: undefined,
+  subtype: undefined,
   costOverrun: false,
   ok: true,
 };

--- a/tests/adapters/tracker.test.ts
+++ b/tests/adapters/tracker.test.ts
@@ -907,10 +907,15 @@ describe("createDraftPr", () => {
 });
 
 describe("releaseFailedTicket", () => {
-  it("removes the claim label first, then posts a release comment carrying the attempt record", async () => {
+  it("removes the claim label first, then posts a release comment carrying the attempt record and forensics", async () => {
     const { exec, calls } = recordingExec();
 
-    await releaseFailedTicket(5, FAILURE, exec);
+    await releaseFailedTicket(
+      5,
+      FAILURE,
+      "**Result:** forensic evidence",
+      exec,
+    );
 
     expect(calls).toEqual([
       ["gh", "issue", "edit", "5", "--remove-label", CLAIM_LABEL],
@@ -927,6 +932,7 @@ describe("releaseFailedTicket", () => {
     expect(body).toContain(attemptMarker(FAILURE));
     expect(body).toContain("no output events");
     expect(body).toContain(FAILURE.transcript);
+    expect(body).toContain("**Result:** forensic evidence");
   });
 });
 

--- a/tests/adapters/worker.test.ts
+++ b/tests/adapters/worker.test.ts
@@ -332,7 +332,7 @@ describe("dispatchWorker", () => {
     const { exec } = fakeExec({ newCommits: "2" });
     const { spawn } = fakeSpawn(1, "exit", {
       stdoutTail:
-        '{"type":"result","subtype":"error_max_turns","total_cost_usd":3.2,"num_turns":200}',
+        '{"type":"result","subtype":"error_max_turns","total_cost_usd":3.2,"num_turns":200,"duration_ms":615000}',
     });
 
     const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
@@ -343,6 +343,8 @@ describe("dispatchWorker", () => {
       infra: undefined,
       costUsd: 3.2,
       turns: 200,
+      durationMs: 615000,
+      subtype: "error_max_turns",
     });
   });
 

--- a/tests/app/act.test.ts
+++ b/tests/app/act.test.ts
@@ -113,6 +113,8 @@ function outcome(
     infra: undefined,
     costUsd: undefined,
     turns: undefined,
+    durationMs: undefined,
+    subtype: undefined,
     costOverrun: false,
     ok: true,
     ...overrides,

--- a/tests/app/settle.test.ts
+++ b/tests/app/settle.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { ReadFile } from "../../src/adapters/pr.js";
 import type { Exec } from "../../src/adapters/tracker.js";
 import { settleAttempt } from "../../src/app/settle.js";
 import type { Log, LogBindings, LogEvent } from "../../src/core/log.js";
@@ -6,6 +7,7 @@ import {
   type AttemptFailure,
   attemptMarker,
   CLAIM_LABEL,
+  RELEASE_MARKER,
   VOID_MARKER,
   type WorkerOutcome,
 } from "../../src/core/types.js";
@@ -40,6 +42,14 @@ function msgs(events: LogEvent[]): string[] {
   return events.map((e) => e.msg);
 }
 
+function fakeRead(transcript: string): ReadFile {
+  return async () => transcript;
+}
+
+const rejectingRead: ReadFile = async () => {
+  throw new Error("ENOENT: transcript gone");
+};
+
 function outcome(overrides: Partial<WorkerOutcome> = {}): WorkerOutcome {
   return {
     ticket: 7,
@@ -54,6 +64,8 @@ function outcome(overrides: Partial<WorkerOutcome> = {}): WorkerOutcome {
     infra: undefined,
     costUsd: undefined,
     turns: undefined,
+    durationMs: undefined,
+    subtype: undefined,
     costOverrun: false,
     ok: true,
     ...overrides,
@@ -141,6 +153,122 @@ describe("settleAttempt", () => {
       "Worker failed attempt 2 (stall): exit null, 0 new commits on border-collie/ticket-7 (transcript: .border-collie/transcripts/ticket-7.jsonl)",
       "released with the attempt record (failed attempt 2)",
     ]);
+  });
+
+  it("embeds the transcript's forensic evidence in the release comment — readable, without downloading anything", async () => {
+    const { exec, calls } = recordingExec();
+    const { log } = recordingLog();
+    const transcript = [
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [
+            { type: "text", text: "Trying the tests once more." },
+            {
+              type: "tool_use",
+              id: "toolu_1",
+              name: "Bash",
+              input: { command: "npm test" },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({ type: "result", subtype: "error_max_turns" }),
+    ].join("\n");
+
+    await settleAttempt(
+      outcome({
+        failure: "budget",
+        subtype: "error_max_turns",
+        turns: 200,
+        costUsd: 9.5,
+        durationMs: 723_000,
+        exitCode: null,
+        newCommits: 0,
+        ok: false,
+      }),
+      undefined,
+      log,
+      exec,
+      fakeRead(transcript),
+    );
+
+    const body = calls[1]?.[5] ?? "";
+    expect(body).toContain("200 turns");
+    expect(body).toContain("$9.50");
+    expect(body).toContain("terminated `error_max_turns`");
+    expect(body).toContain("- Bash: 1");
+    expect(body).toContain("Trying the tests once more.");
+    expect(body).toContain('→ Bash({"command":"npm test"})');
+  });
+
+  it("keeps the whole posted release body within GitHub's comment size limit for a long session", async () => {
+    const { exec, calls } = recordingExec();
+    const { log } = recordingLog();
+    // 500 turns, each carrying a sizeable text block and a tool call — a long
+    // session's raw transcript would be megabytes; the composed comment body
+    // (marker + description + transcript line + forensics) must not be.
+    const transcript = Array.from({ length: 500 }, (_, i) =>
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [
+            { type: "text", text: `Turn ${i}: `.repeat(200) },
+            {
+              type: "tool_use",
+              id: `toolu_${i}`,
+              name: i % 2 === 0 ? "Bash" : "Edit",
+              input: { command: `step ${i}`.repeat(50) },
+            },
+          ],
+        },
+      }),
+    ).join("\n");
+
+    await settleAttempt(
+      outcome({
+        failure: "budget",
+        subtype: "error_max_turns",
+        turns: 500,
+        costUsd: 40,
+        durationMs: 3_600_000,
+        exitCode: null,
+        newCommits: 0,
+        ok: false,
+      }),
+      undefined,
+      log,
+      exec,
+      fakeRead(transcript),
+    );
+
+    const body = calls[1]?.[5] ?? "";
+    // GitHub's actual issue/PR comment cap.
+    expect(body.length).toBeLessThanOrEqual(65536);
+  });
+
+  it("still releases when the transcript is unreadable, falling back to the outcome's own facts", async () => {
+    const { exec, calls } = recordingExec();
+    const { log } = recordingLog();
+
+    await settleAttempt(
+      outcome({
+        failure: "timeout",
+        turns: undefined,
+        exitCode: null,
+        newCommits: 0,
+        ok: false,
+      }),
+      undefined,
+      log,
+      exec,
+      rejectingRead,
+    );
+
+    const body = calls[1]?.[5] ?? "";
+    expect(body).toContain(RELEASE_MARKER);
+    expect(body).toContain("unknown turns");
+    expect(body).toContain("(no tool calls recorded)");
   });
 
   it("voids an infrastructure-classified attempt: comment only, claim held, logged at warn", async () => {

--- a/tests/core/classify.test.ts
+++ b/tests/core/classify.test.ts
@@ -63,16 +63,17 @@ describe("classifyInfrastructure", () => {
 });
 
 describe("parseResultEvent", () => {
-  it("reads subtype, cost, and turns from the last result event", () => {
+  it("reads subtype, cost, turns, and duration from the last result event", () => {
     const tail = [
       '{"type":"assistant","message":{}}',
-      '{"type":"result","subtype":"success","total_cost_usd":1.25,"num_turns":40}',
+      '{"type":"result","subtype":"success","total_cost_usd":1.25,"num_turns":40,"duration_ms":54000}',
     ].join("\n");
 
     expect(parseResultEvent(tail)).toEqual({
       subtype: "success",
       totalCostUsd: 1.25,
       numTurns: 40,
+      durationMs: 54000,
     });
   });
 
@@ -98,6 +99,7 @@ describe("parseResultEvent", () => {
       subtype: undefined,
       totalCostUsd: undefined,
       numTurns: undefined,
+      durationMs: undefined,
     });
   });
 });
@@ -136,6 +138,8 @@ function outcome(
     infra: undefined,
     costUsd: undefined,
     turns: undefined,
+    durationMs: undefined,
+    subtype: undefined,
     costOverrun: false,
     ok: true,
     ...overrides,

--- a/tests/core/render.test.ts
+++ b/tests/core/render.test.ts
@@ -3,11 +3,16 @@ import type { ResolvedConfig } from "../../src/core/config.js";
 import type { WorkerHeartbeat } from "../../src/core/heartbeat.js";
 import {
   buildCompleteReport,
+  buildForensicReport,
   buildPlanReport,
   buildStuckReport,
   type CompleteReport,
+  FORENSIC_FINAL_TURNS,
+  type ForensicReport,
+  MAX_FORENSIC_LENGTH,
   type PlanReport,
   renderCompleteReport,
+  renderForensicReport,
   renderHeartbeat,
   renderPlanReport,
   renderStuckReport,
@@ -17,6 +22,7 @@ import type {
   Action,
   OpenAgentPr,
   Ticket,
+  WorkerOutcome,
   WorldSnapshot,
 } from "../../src/core/types.js";
 
@@ -559,6 +565,243 @@ describe("renderCompleteReport", () => {
         "  #2 — Walking skeleton",
         "  #7 — Hard one (closed by a human after Escalation)",
       ].join("\n"),
+    );
+  });
+});
+
+function outcome(overrides: Partial<WorkerOutcome> = {}): WorkerOutcome {
+  return {
+    ticket: 7,
+    attempt: 2,
+    branch: "border-collie/ticket-7-attempt-2",
+    base: "base-sha",
+    transcript: ".border-collie/transcripts/ticket-7-attempt-2.jsonl",
+    model: "sonnet",
+    exitCode: 1,
+    newCommits: 0,
+    failure: "budget",
+    infra: undefined,
+    costUsd: 9.5,
+    turns: 200,
+    durationMs: 723_000,
+    subtype: "error_max_turns",
+    costOverrun: false,
+    ok: false,
+    ...overrides,
+  };
+}
+
+const textBlock = (text: string) => ({ type: "text", text });
+const toolUseBlock = (name: string, input: unknown = {}) => ({
+  type: "tool_use",
+  id: `toolu_${name}_${Math.random()}`,
+  name,
+  input,
+});
+
+/** One assistant stream-json line, content blocks in order. */
+const assistantLine = (...content: unknown[]) =>
+  JSON.stringify({ type: "assistant", message: { content } });
+
+/** `count` assistant turns, each calling `toolName` once with `input` — a Worker stuck looping the same call. */
+function loopingTranscript(
+  count: number,
+  toolName: string,
+  input: unknown = { command: "pytest" },
+): string {
+  return Array.from({ length: count }, () =>
+    assistantLine(toolUseBlock(toolName, input)),
+  ).join("\n");
+}
+
+describe("buildForensicReport", () => {
+  it("carries the outcome's own result facts untouched, independent of the transcript", () => {
+    const report = buildForensicReport(outcome(), "");
+
+    expect(report.facts).toEqual({
+      turns: 200,
+      costUsd: 9.5,
+      durationMs: 723_000,
+      subtype: "error_max_turns",
+    });
+  });
+
+  it("yields empty evidence for an empty or unparseable transcript, without throwing", () => {
+    const report = buildForensicReport(outcome(), "not json\n{ broken\n\n");
+
+    expect(report.histogram).toEqual([]);
+    expect(report.finalTurns).toEqual([]);
+  });
+
+  it("tallies every tool call across the whole session, not just the final turns window", () => {
+    const transcript = [
+      ...Array.from({ length: 4 }, () => assistantLine(toolUseBlock("Read"))),
+      ...Array.from({ length: 6 }, () => assistantLine(toolUseBlock("Bash"))),
+      ...Array.from({ length: 2 }, () => assistantLine(toolUseBlock("Edit"))),
+    ].join("\n");
+
+    const report = buildForensicReport(outcome(), transcript);
+
+    expect(report.histogram).toEqual([
+      { name: "Bash", count: 6 },
+      { name: "Read", count: 4 },
+      { name: "Edit", count: 2 },
+    ]);
+    // Every turn beyond the final-turns window still counted: 12 turns total
+    // against an 8-turn window.
+    expect(report.histogram.reduce((sum, tally) => sum + tally.count, 0)).toBe(
+      12,
+    );
+  });
+
+  it("renders only the session's final turns, numbered against the whole session", () => {
+    const transcript = Array.from({ length: 10 }, (_, i) =>
+      assistantLine(textBlock(`turn ${i + 1}`)),
+    ).join("\n");
+
+    const report = buildForensicReport(outcome(), transcript);
+
+    expect(report.finalTurns).toHaveLength(FORENSIC_FINAL_TURNS);
+    expect(report.finalTurns[0]).toMatchObject({ index: 3, text: "turn 3" });
+    expect(report.finalTurns.at(-1)).toMatchObject({
+      index: 10,
+      text: "turn 10",
+    });
+  });
+
+  it("drops empty text, keeping a tool-only turn readable", () => {
+    const transcript = assistantLine(toolUseBlock("Bash", { command: "ls" }));
+
+    const report = buildForensicReport(outcome(), transcript);
+
+    expect(report.finalTurns).toEqual([
+      { index: 1, text: undefined, toolCalls: ['Bash({"command":"ls"})'] },
+    ]);
+  });
+
+  it("diagnoses a turn-cap breach from the whole-session histogram, where the final turns alone would not", () => {
+    // 200 turns, all the same looping Bash call — exactly what burns a turn
+    // cap. The rendered tail only ever shows the last FORENSIC_FINAL_TURNS.
+    const transcript = loopingTranscript(200, "Bash", {
+      command: "pytest -k flaky",
+    });
+
+    const report = buildForensicReport(
+      outcome({ failure: "budget", subtype: "error_max_turns", turns: 200 }),
+      transcript,
+    );
+
+    expect(report.histogram).toEqual([{ name: "Bash", count: 200 }]);
+    expect(report.finalTurns).toHaveLength(FORENSIC_FINAL_TURNS);
+    // The tail alone (8 identical-looking calls) is indistinguishable from
+    // ordinary progress; only the whole-session count proves the loop.
+    expect(report.histogram[0]?.count).toBeGreaterThan(FORENSIC_FINAL_TURNS);
+
+    // The rendered comment text itself must carry that proof, not just the
+    // intermediate report struct — this is what a human actually reads.
+    const rendered = renderForensicReport(report);
+    expect(rendered).toContain("- Bash: 200");
+    expect(rendered).toContain("terminated `error_max_turns`");
+    const renderedTurnCount = (rendered.match(/^Turn \d+:$/gm) ?? []).length;
+    expect(renderedTurnCount).toBe(FORENSIC_FINAL_TURNS);
+    expect(renderedTurnCount).toBeLessThan(200);
+  });
+});
+
+describe("renderForensicReport", () => {
+  function report(overrides: Partial<ForensicReport> = {}): ForensicReport {
+    return {
+      facts: {
+        turns: 200,
+        costUsd: 9.5,
+        durationMs: 723_000,
+        subtype: "error_max_turns",
+      },
+      histogram: [{ name: "Bash", count: 200 }],
+      finalTurns: [
+        {
+          index: 199,
+          text: "Running the tests again.",
+          toolCalls: ['Bash({"command":"pytest -k flaky"})'],
+        },
+      ],
+      ...overrides,
+    };
+  }
+
+  it("renders turns, cost, duration, and the terminating subtype", () => {
+    const rendered = renderForensicReport(report());
+
+    expect(rendered).toContain("200 turns");
+    expect(rendered).toContain("$9.50");
+    expect(rendered).toContain("12m3s");
+    expect(rendered).toContain("error_max_turns");
+  });
+
+  it("renders 'unknown' facts when no result event survived (e.g. a stall or timeout)", () => {
+    const rendered = renderForensicReport(
+      report({
+        facts: {
+          turns: undefined,
+          costUsd: undefined,
+          durationMs: undefined,
+          subtype: undefined,
+        },
+      }),
+    );
+
+    expect(rendered).toContain("unknown turns, unknown, unknown");
+    expect(rendered).toContain("terminated `unknown`");
+  });
+
+  it("renders the tool histogram as a readable list, not raw stream-json", () => {
+    const rendered = renderForensicReport(
+      report({
+        histogram: [
+          { name: "Bash", count: 6 },
+          { name: "Read", count: 4 },
+        ],
+      }),
+    );
+
+    expect(rendered).toContain("- Bash: 6");
+    expect(rendered).toContain("- Read: 4");
+    expect(rendered).not.toContain('"type"');
+  });
+
+  it("renders final turns readably, distinguishing narration from tool calls", () => {
+    const rendered = renderForensicReport(report());
+
+    expect(rendered).toContain("Turn 199:");
+    expect(rendered).toContain("Running the tests again.");
+    expect(rendered).toContain('→ Bash({"command":"pytest -k flaky"})');
+    expect(rendered).not.toContain('"type":"assistant"');
+  });
+
+  it("notes when no tool calls or final turns were recorded, rather than rendering nothing", () => {
+    const rendered = renderForensicReport(
+      report({ histogram: [], finalTurns: [] }),
+    );
+
+    expect(rendered).toContain("(no tool calls recorded)");
+    expect(rendered).toContain("(none recorded)");
+  });
+
+  it("stays within the hard size ceiling even for a pathological report", () => {
+    const huge = report({
+      histogram: Array.from({ length: 5000 }, (_, i) => ({
+        name: `tool-${i}`,
+        count: i,
+      })),
+      finalTurns: Array.from({ length: FORENSIC_FINAL_TURNS }, (_, i) => ({
+        index: i + 1,
+        text: "x".repeat(10_000),
+        toolCalls: [],
+      })),
+    });
+
+    expect(renderForensicReport(huge).length).toBeLessThanOrEqual(
+      MAX_FORENSIC_LENGTH,
     );
   });
 });


### PR DESCRIPTION
A failed Attempt's release comment cited only a transcript path — on a runner, that path points at a machine which no longer exists by the time anyone reads it, so an Escalation would hand a human a dead pointer.

This bakes the triage evidence into the comment itself, while the transcript still sits on the runner's own disk:

- **Result facts**: turns, cost, duration, and the terminating subtype, echoed straight from the outcome (no re-parsing).
- **A whole-session tool-call histogram**: every tool call across the entire transcript, not just the tail. This is what makes a turn-cap breach diagnosable — a Worker that burned its cap did so by looping, and only a whole-session count proves that; the last few turns alone look like ordinary progress.
- **A readable rendering of the final turns**: the session's last few assistant turns (narration plus tool calls), not raw stream-json.

`WorkerOutcome` gains `durationMs` and `subtype`, sourced from the transcript's result event alongside the existing `turns`/`costUsd`. `settleAttempt` now reads the transcript immediately after a Ticket failure — before the file can go stale — and renders the evidence through new pure functions in `src/core/render.ts` (`buildForensicReport`/`renderForensicReport`), which `releaseFailedTicket` appends to its comment body. The rendering is bounded well under GitHub's comment size limit even for a long, looping session.

Scope is deliberately narrow to `releaseFailedTicket` (Ticket failures, which feed the retry ladder and Escalation); `voidAttempt` (Infrastructure failures) is untouched, per its existing documented rationale that voided attempts need no preserved evidence since they never reach Escalation.

Closes #72.