### PR TITLE
feat(cli): a Worker settles its own Attempt

### DIFF
--- a/src/adapters/tracker.ts
+++ b/src/adapters/tracker.ts
@@ -425,6 +425,24 @@ export async function readScope(
   return { tickets, openAgentPrs, mergedAgentPrs };
 }
 
+/**
+ * A single ticket's title, read directly rather than through `readScope`: the
+ * Worker entrypoint (issue #71) has no world snapshot of its own — just the
+ * ticket and Attempt it was told to run — so it fetches the one field its PR
+ * title needs.
+ */
+export async function readTicketTitle(
+  ticket: number,
+  exec: Exec = realExec,
+): Promise<string> {
+  const stdout = await exec("gh", [
+    "api",
+    `repos/{owner}/{repo}/issues/${ticket}`,
+  ]);
+  const issue = JSON.parse(stdout) as { title?: string };
+  return issue.title ?? `Ticket #${ticket}`;
+}
+
 const CLAIM_COMMENT = `${CLAIM_MARKER}\n🐕 Claimed by border-collie: a Worker will be dispatched against this ticket. This claim is agent-held — see CONTEXT.md "Claim".`;
 
 const RELEASE_COMMENT = `${RELEASE_MARKER}\n🐕 border-collie released an orphaned claim (no live Worker, no open agent PR). The ticket is dispatchable again.`;

--- a/src/app/settle.ts
+++ b/src/app/settle.ts
@@ -26,9 +26,9 @@ function describeOutcome(outcome: WorkerOutcome): string {
  * stays tellable apart from a sibling Attempt settling concurrently.
  *
  * A single per-outcome unit shareable by anything that finishes an Attempt
- * and needs the same write — today the act phase, once every Worker in a
- * Tick has settled and correlated failures are reclassified; later a Worker
- * settling its own Attempt in its own process (issue #71).
+ * and needs the same write — the act phase, once every Worker in a Tick has
+ * settled and correlated failures are reclassified, and a Worker settling
+ * its own Attempt in its own process (src/app/worker.ts, issue #71).
  */
 export async function settleAttempt(
   outcome: WorkerOutcome,

--- a/src/app/worker.ts
+++ b/src/app/worker.ts
@@ -1,0 +1,109 @@
+import { openPrForOutcome } from "../adapters/pr.js";
+import {
+  type Exec,
+  readTicketTitle,
+  realExec,
+  withDebugLogging,
+} from "../adapters/tracker.js";
+import { dispatchWorker, realSpawnWorkerProcess } from "../adapters/worker.js";
+import { modelForAttempt, type WorkerAttemptConfig } from "../core/config.js";
+import type { Log } from "../core/log.js";
+import type { WorkerOutcome } from "../core/types.js";
+import type { DispatchWorker, OpenPr } from "./act.js";
+import { settleAttempt } from "./settle.js";
+
+/**
+ * A Worker settling its own Attempt (issue #71): the same `DispatchWorker`
+ * and `OpenPr` seams the act phase spawns a batch of Workers through
+ * (src/app/act.ts), injectable so a fake dispatch/openPr exercises this unit
+ * without a real session.
+ */
+export interface WorkerAttemptDeps {
+  dispatch: DispatchWorker;
+  openPr: OpenPr;
+  exec: Exec;
+  log: Log;
+}
+
+/**
+ * Run one Worker session against one Ticket and Attempt, then settle it:
+ * open the draft PR on success, and either way hand the outcome to
+ * `settleAttempt` — the same unit the act phase's batch settles through once
+ * every Worker it spawned has finished (src/app/settle.ts) — so a Ticket
+ * failure's forensic release and an Infrastructure failure's void are never
+ * written twice. Unlike the act phase this has no fleet heartbeat and no
+ * cross-Worker correlation: both depend on seeing a batch of concurrent
+ * outcomes together, which a lone Worker settling itself never has. A PR
+ * opening failure after a successful Attempt is narrated and rethrown, after
+ * settling — mirroring the act phase's own treatment of the same failure.
+ */
+export async function runWorkerAttempt(
+  ticket: number,
+  attempt: number,
+  deps: WorkerAttemptDeps,
+): Promise<WorkerOutcome> {
+  const { dispatch, openPr, exec, log } = deps;
+  const outcome = await dispatch(ticket, attempt, () => {});
+  let prUrl: string | undefined;
+  let prFailure: unknown;
+  if (outcome.ok) {
+    try {
+      prUrl = await openPr(outcome);
+    } catch (error) {
+      prFailure = error;
+    }
+  }
+  await settleAttempt(outcome, prUrl, log, exec);
+  if (prFailure !== undefined) {
+    const reason =
+      prFailure instanceof Error ? prFailure.message : String(prFailure);
+    log({
+      kind: "pr-open-failed",
+      level: "error",
+      msg: `PR opening failed after a successful Attempt: ${reason}`,
+    });
+    throw prFailure;
+  }
+  return outcome;
+}
+
+/**
+ * The Worker entrypoint command's real wiring — today's collaborators,
+ * composed the same way the Tick's act phase composes them for a dispatched
+ * Worker (src/app/tick.ts), minus the concurrency that only a whole batch
+ * needs. A ticket's title is read directly (no world snapshot here) for the
+ * PR title `openPrForOutcome` wants.
+ */
+export async function workerAttemptOnce(
+  config: WorkerAttemptConfig,
+  ticket: number,
+  attempt: number,
+  deps: { log: Log },
+): Promise<WorkerOutcome> {
+  const exec = withDebugLogging(realExec, deps.log);
+  const workerLog = deps.log.child({ ticket, attempt });
+  return runWorkerAttempt(ticket, attempt, {
+    dispatch: (t, a, onActivity) =>
+      dispatchWorker(
+        t,
+        {
+          model: modelForAttempt(config, a),
+          attempt: a,
+          timeoutMs: config.timeoutMinutes * 60_000,
+          stallMs: config.stallMinutes * 60_000,
+          maxTurns: config.maxTurns,
+          maxCostUsd: config.maxCostUsd,
+        },
+        exec,
+        realSpawnWorkerProcess,
+        workerLog,
+        onActivity,
+      ),
+    openPr: async (workerOutcome) => {
+      const title = await readTicketTitle(workerOutcome.ticket, exec);
+      return openPrForOutcome(workerOutcome, title, exec);
+    },
+    exec,
+    log: workerLog,
+  });
+}

--- a/src/cli/app.ts
+++ b/src/cli/app.ts
@@ -9,9 +9,10 @@ import type { Context } from "./context.js";
 import { runCommand } from "./run-command.js";
 import { tickCommand } from "./tick-command.js";
 import { VERSION } from "./version.js";
+import { workerCommand } from "./worker-command.js";
 
 const routeMap = buildRouteMap({
-  routes: { tick: tickCommand, run: runCommand },
+  routes: { tick: tickCommand, run: runCommand, worker: workerCommand },
   docs: {
     brief:
       "an orchestration loop that herds a ticket DAG to Done with a fleet of Claude Code agents",

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -6,10 +6,13 @@ import { loadConfigFile } from "../adapters/config-file.js";
 import { probeEnvironment, RUN_DIR } from "../adapters/worker.js";
 import type { IntervalScheduler } from "../app/act.js";
 import { type TickResult, tickOnce } from "../app/tick.js";
+import { workerAttemptOnce } from "../app/worker.js";
 import {
   type Flags,
   type ResolvedConfig,
   resolveConfig,
+  resolveWorkerConfig,
+  type WorkerAttemptConfig,
 } from "../core/config.js";
 import {
   type Log,
@@ -17,17 +20,26 @@ import {
   type LogEvent,
   scrubCredentials,
 } from "../core/log.js";
+import type { WorkerOutcome } from "../core/types.js";
 import { reportBlockText } from "./console-report.js";
 
 /** Every effect a command handler needs, injected so handlers never import them directly. */
 export interface Context extends CommandContext {
   readonly process: StricliProcess;
   readonly loadConfig: (flags: Flags) => ResolvedConfig;
+  /** Config resolution for the worker command: no Scope required (issue #71); see `resolveWorkerConfig`. */
+  readonly loadWorkerConfig: (flags: Flags) => WorkerAttemptConfig;
   readonly tick: (
     config: ResolvedConfig,
     dryRun: boolean,
     dispatchPaused?: boolean,
   ) => Promise<TickResult>;
+  /** A Worker settling its own Attempt (issue #71); see src/app/worker.ts. */
+  readonly runWorker: (
+    config: WorkerAttemptConfig,
+    ticket: number,
+    attempt: number,
+  ) => Promise<WorkerOutcome>;
   readonly probe: (model: string) => Promise<boolean>;
   readonly now: () => number;
   readonly sleep: (ms: number) => Promise<void>;
@@ -181,8 +193,12 @@ export function buildRealContext(cwd: string = process.cwd()): Context {
   return {
     process: cliProcess,
     loadConfig: (flags) => resolveConfig(loadConfigFile(cwd), flags),
+    loadWorkerConfig: (flags) =>
+      resolveWorkerConfig(loadConfigFile(cwd), flags),
     tick: (config, dryRun, dispatchPaused) =>
       tickOnce(config, dryRun, dispatchPaused, { log, now, scheduleInterval }),
+    runWorker: (config, ticket, attempt) =>
+      workerAttemptOnce(config, ticket, attempt, { log }),
     probe: (model) => probeEnvironment(model),
     now,
     sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -53,9 +53,11 @@ export function resolveConfigFromFlags(
 
 /**
  * stricli's built-in number parser accepts floats; the flags below are
- * strictly digits-only, so they keep this custom parser instead.
+ * strictly digits-only, so they keep this custom parser instead. Exported
+ * for the worker command's ticket/attempt positional arguments, which want
+ * the same strictness.
  */
-function parseInteger(input: string): number {
+export function parseInteger(input: string): number {
   if (!/^\d+$/.test(input)) {
     throw new SyntaxError(`must be an integer, got "${input}"`);
   }

--- a/src/cli/worker-command.ts
+++ b/src/cli/worker-command.ts
@@ -1,0 +1,106 @@
+import { buildCommand } from "@stricli/core";
+import {
+  ConfigError,
+  type Flags,
+  type WorkerAttemptConfig,
+} from "../core/config.js";
+import type { Context } from "./context.js";
+import { WORKER_DEATH_PROSE } from "./docs.js";
+import { parseInteger, sharedFlags } from "./flags.js";
+
+/**
+ * The worker command's own flag surface: model overrides plus verbosity, the
+ * three `sharedFlags` entries that still mean something for one Worker
+ * running one Attempt. Scope and concurrency (`--parent`, `--all`,
+ * `--max-workers`, `--max-open-prs`, `--poll-seconds`) plan a Tick's dispatch
+ * — irrelevant here, so they're left off rather than accepted and ignored.
+ */
+export interface WorkerFlags {
+  model?: string;
+  retryModel?: string;
+  verbose: boolean;
+}
+
+const { model, retryModel, verbose } = sharedFlags;
+
+/**
+ * Config resolution's flag surface, narrowed the same way
+ * `resolveConfigFromFlags` narrows `CliFlags` in flags.ts — through
+ * `loadWorkerConfig`, which unlike `loadConfig` needs no Scope (issue #71).
+ */
+function resolveConfigFromWorkerFlags(
+  context: Context,
+  flags: WorkerFlags,
+): WorkerAttemptConfig | ConfigError {
+  const configFlags: Flags = {};
+  if (flags.model !== undefined) configFlags.model = flags.model;
+  if (flags.retryModel !== undefined) configFlags.retryModel = flags.retryModel;
+  try {
+    return context.loadWorkerConfig(configFlags);
+  } catch (error) {
+    if (error instanceof ConfigError) return error;
+    throw error;
+  }
+}
+
+async function workerHandler(
+  this: Context,
+  flags: WorkerFlags,
+  ticket: number,
+  attempt: number,
+): Promise<undefined | Error> {
+  this.setVerbose(flags.verbose);
+  const config = resolveConfigFromWorkerFlags(this, flags);
+  if (config instanceof Error) return config;
+
+  const outcome = await this.runWorker(config, ticket, attempt);
+  if (!outcome.ok) {
+    this.process.exitCode = 1;
+  }
+}
+
+export const workerCommand = buildCommand<
+  WorkerFlags,
+  [number, number],
+  Context
+>({
+  func: workerHandler,
+  parameters: {
+    positional: {
+      kind: "tuple",
+      parameters: [
+        {
+          brief: "ticket (issue) number to run this Attempt against",
+          parse: parseInteger,
+          placeholder: "ticket",
+        },
+        {
+          brief: "attempt number (1-based; binds the retry ladder's model)",
+          parse: parseInteger,
+          placeholder: "attempt",
+        },
+      ],
+    },
+    flags: { model, retryModel, verbose },
+  },
+  docs: {
+    brief:
+      "run one Worker session for a Ticket and Attempt, settling it itself",
+    fullDescription: `worker runs a single Worker session against one Ticket and Attempt in the
+current working directory — an isolated worktree on an agent branch, running
+headless claude against exactly that ticket — then settles the outcome
+itself instead of leaving it for a Tick to read back: a successful Attempt's
+branch is pushed and opened as a draft PR that closes its ticket on merge,
+its body taken from the Worker's final message (mechanical fallback: ticket
++ commit subjects).
+
+${WORKER_DEATH_PROSE} settling here means the same tracker write a Tick's
+act phase would perform, through the same shared unit — nothing is
+duplicated.
+
+The ticket is assumed already claimed (a Tick claims before dispatching);
+worker performs no claim of its own. It exits non-zero whenever the Attempt
+did not succeed — ticket failure or infrastructure failure alike — so a job
+runner can see it.`,
+  },
+});

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -130,15 +130,10 @@ function resolveWorkingHours(
   return { timezone: resolvedTimezone, startHour, endHour };
 }
 
-/**
- * Merge the target repo's config file with CLI flags. Flags win. Repo-wide
- * scope is never implicit: only the explicit `all` flag selects it, and it
- * refuses to combine with a `parent` flag.
- */
-export function resolveConfig(
-  fileConfig: unknown,
-  flags: Flags,
-): ResolvedConfig {
+/** The config fields a single Worker attempt needs — every field except `scope`, which only a Tick's dispatch (tick/run) ever consults. */
+export type WorkerAttemptConfig = Omit<ResolvedConfig, "scope">;
+
+function parseFileConfig(fileConfig: unknown): Record<string, unknown> {
   if (
     fileConfig !== undefined &&
     (typeof fileConfig !== "object" ||
@@ -147,8 +142,14 @@ export function resolveConfig(
   ) {
     throw new ConfigError(`${CONFIG_FILE} must contain a JSON object`);
   }
-  const file = (fileConfig ?? {}) as Record<string, unknown>;
+  return (fileConfig ?? {}) as Record<string, unknown>;
+}
 
+/** The scope-independent half of config resolution, shared by `resolveConfig` and `resolveWorkerConfig`. */
+function resolveSharedConfig(
+  file: Record<string, unknown>,
+  flags: Flags,
+): WorkerAttemptConfig {
   const maxWorkers = asPositiveInt(
     flags.maxWorkers ?? file.max_workers ?? DEFAULT_MAX_WORKERS,
     "max_workers",
@@ -186,7 +187,7 @@ export function resolveConfig(
     "worker_max_cost_usd",
   );
   const workingHours = resolveWorkingHours(file);
-  const shared: Omit<ResolvedConfig, "scope"> = {
+  const shared: WorkerAttemptConfig = {
     maxWorkers,
     maxOpenPrs,
     pollSeconds,
@@ -198,6 +199,20 @@ export function resolveConfig(
     maxCostUsd,
   };
   if (workingHours !== undefined) shared.workingHours = workingHours;
+  return shared;
+}
+
+/**
+ * Merge the target repo's config file with CLI flags. Flags win. Repo-wide
+ * scope is never implicit: only the explicit `all` flag selects it, and it
+ * refuses to combine with a `parent` flag.
+ */
+export function resolveConfig(
+  fileConfig: unknown,
+  flags: Flags,
+): ResolvedConfig {
+  const file = parseFileConfig(fileConfig);
+  const shared = resolveSharedConfig(file, flags);
 
   if (flags.all) {
     if (flags.parent !== undefined) {
@@ -218,9 +233,23 @@ export function resolveConfig(
   };
 }
 
+/**
+ * Config resolution for a single Worker attempt (issue #71): the same fields
+ * `resolveConfig` produces, minus Scope — a Worker is told exactly which
+ * Ticket and Attempt to run, so `resolveConfig`'s scope requirement (a
+ * `parent` in the config file or an explicit `--all`/`--parent` flag) does
+ * not apply, and does not need to be satisfied for the command to run.
+ */
+export function resolveWorkerConfig(
+  fileConfig: unknown,
+  flags: Flags,
+): WorkerAttemptConfig {
+  return resolveSharedConfig(parseFileConfig(fileConfig), flags);
+}
+
 /** The retry ladder's model binding: attempt two runs the stronger retry model. */
 export function modelForAttempt(
-  config: ResolvedConfig,
+  config: WorkerAttemptConfig,
   attempt: number,
 ): string {
   return attempt >= 2 ? config.retryModel : config.model;

--- a/tests/adapters/tracker.test.ts
+++ b/tests/adapters/tracker.test.ts
@@ -8,6 +8,7 @@ import {
   escalateTicket,
   markPrReady,
   readScope,
+  readTicketTitle,
   releaseFailedTicket,
   releaseTicket,
   updatePrBranch,
@@ -1054,6 +1055,29 @@ describe("commentConflictUnresolved", () => {
         expect.stringContaining(CONFLICT_UNRESOLVED_MARKER),
       ],
     ]);
+  });
+});
+
+describe("readTicketTitle", () => {
+  it("reads a single ticket's title directly, outside of Scope", async () => {
+    const { exec, calls } = fakeExec({
+      api: { "repos/{owner}/{repo}/issues/7": { title: "Walking skeleton" } },
+    });
+
+    const title = await readTicketTitle(7, exec);
+
+    expect(title).toBe("Walking skeleton");
+    expect(calls).toEqual([["gh", "api", "repos/{owner}/{repo}/issues/7"]]);
+  });
+
+  it("falls back to a generic title when the issue carries none", async () => {
+    const { exec } = fakeExec({
+      api: { "repos/{owner}/{repo}/issues/7": {} },
+    });
+
+    const title = await readTicketTitle(7, exec);
+
+    expect(title).toBe("Ticket #7");
   });
 });
 

--- a/tests/app/worker.test.ts
+++ b/tests/app/worker.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import type { Exec } from "../../src/adapters/tracker.js";
+import type { DispatchWorker, OpenPr } from "../../src/app/act.js";
+import { runWorkerAttempt } from "../../src/app/worker.js";
+import type { Log, LogBindings, LogEvent } from "../../src/core/log.js";
+import {
+  CLAIM_LABEL,
+  VOID_MARKER,
+  type WorkerOutcome,
+} from "../../src/core/types.js";
+
+function recordingExec(): { exec: Exec; calls: string[][] } {
+  const calls: string[][] = [];
+  const exec: Exec = async (cmd, args) => {
+    calls.push([cmd, ...args]);
+    return "";
+  };
+  return { exec, calls };
+}
+
+/** Merges the caller's sub-logger bindings onto every event, mirroring a real sink. */
+function recordingLog(): { log: Log; events: LogEvent[] } {
+  const events: LogEvent[] = [];
+  function make(bindings: LogBindings): Log {
+    const fn = ((event: LogEvent) => {
+      events.push({ ...bindings, ...event } as LogEvent);
+    }) as Log;
+    fn.child = (childBindings) => make({ ...bindings, ...childBindings });
+    return fn;
+  }
+  return { log: make({ ticket: 7, attempt: 1 }), events };
+}
+
+function msgs(events: LogEvent[]): string[] {
+  return events.map((e) => e.msg);
+}
+
+function outcome(overrides: Partial<WorkerOutcome> = {}): WorkerOutcome {
+  return {
+    ticket: 7,
+    attempt: 1,
+    branch: "border-collie/ticket-7",
+    base: "base-sha",
+    transcript: ".border-collie/transcripts/ticket-7.jsonl",
+    model: "sonnet",
+    exitCode: 0,
+    newCommits: 2,
+    failure: undefined,
+    infra: undefined,
+    costUsd: undefined,
+    turns: undefined,
+    costOverrun: false,
+    ok: true,
+    ...overrides,
+  };
+}
+
+describe("runWorkerAttempt", () => {
+  it("dispatches, opens a PR for a success, and settles through the shared unit", async () => {
+    const { exec, calls } = recordingExec();
+    const { log, events } = recordingLog();
+    const dispatched: [number, number][] = [];
+    const dispatch: DispatchWorker = async (ticket, attempt) => {
+      dispatched.push([ticket, attempt]);
+      return outcome({ newCommits: 3 });
+    };
+    const opened: number[] = [];
+    const openPr: OpenPr = async (o) => {
+      opened.push(o.ticket);
+      return "https://github.com/o/r/pull/70";
+    };
+
+    const result = await runWorkerAttempt(7, 1, {
+      dispatch,
+      openPr,
+      exec,
+      log,
+    });
+
+    expect(dispatched).toEqual([[7, 1]]);
+    expect(opened).toEqual([7]);
+    expect(result.ok).toBe(true);
+    expect(calls).toEqual([]); // a success writes nothing through the tracker
+    expect(events.map((e) => e.kind)).toEqual(["worker-outcome", "pr-opened"]);
+    expect(msgs(events)).toEqual([
+      "Worker succeeded: 3 new commits on border-collie/ticket-7 (transcript: .border-collie/transcripts/ticket-7.jsonl)",
+      "opened draft PR: https://github.com/o/r/pull/70",
+    ]);
+  });
+
+  it("skips PR opening and releases a Ticket failure with its forensic record", async () => {
+    const { exec, calls } = recordingExec();
+    const { log, events } = recordingLog();
+    let openPrCalled = false;
+    const dispatch: DispatchWorker = async () =>
+      outcome({
+        exitCode: 1,
+        newCommits: 0,
+        failure: "nonzero-exit",
+        ok: false,
+      });
+    const openPr: OpenPr = async () => {
+      openPrCalled = true;
+      return "unreachable";
+    };
+
+    const result = await runWorkerAttempt(7, 1, {
+      dispatch,
+      openPr,
+      exec,
+      log,
+    });
+
+    expect(openPrCalled).toBe(false);
+    expect(result.ok).toBe(false);
+    expect(calls).toEqual([
+      ["gh", "issue", "edit", "7", "--remove-label", CLAIM_LABEL],
+      expect.arrayContaining(["gh", "issue", "comment", "7"]),
+    ]);
+    expect(events.map((e) => e.kind)).toEqual([
+      "worker-outcome",
+      "attempt-released",
+    ]);
+  });
+
+  it("skips PR opening and voids an Infrastructure failure, holding the Claim", async () => {
+    const { exec, calls } = recordingExec();
+    const { log, events } = recordingLog();
+    let openPrCalled = false;
+    const dispatch: DispatchWorker = async () =>
+      outcome({ exitCode: 1, newCommits: 0, infra: "usage-limit", ok: false });
+    const openPr: OpenPr = async () => {
+      openPrCalled = true;
+      return "unreachable";
+    };
+
+    const result = await runWorkerAttempt(7, 1, {
+      dispatch,
+      openPr,
+      exec,
+      log,
+    });
+
+    expect(openPrCalled).toBe(false);
+    expect(result.ok).toBe(false);
+    // A void is a comment only: no claim-label removal, the claim stays held.
+    expect(calls).toEqual([
+      [
+        "gh",
+        "issue",
+        "comment",
+        "7",
+        "--body",
+        expect.stringContaining(VOID_MARKER),
+      ],
+    ]);
+    expect(events.map((e) => e.kind)).toEqual([
+      "worker-outcome",
+      "attempt-voided",
+    ]);
+  });
+
+  it("dispatches with the given ticket and attempt", async () => {
+    const { exec } = recordingExec();
+    const { log } = recordingLog();
+    const attempts: [number, number][] = [];
+    const dispatch: DispatchWorker = async (ticket, attempt) => {
+      attempts.push([ticket, attempt]);
+      return outcome({ ticket, attempt });
+    };
+    const openPr: OpenPr = async () => "https://github.com/o/r/pull/70";
+
+    await runWorkerAttempt(9, 2, { dispatch, openPr, exec, log });
+
+    expect(attempts).toEqual([[9, 2]]);
+  });
+
+  it("still settles the Attempt when PR opening fails, then rethrows, logging the failure at error", async () => {
+    const { exec } = recordingExec();
+    const { log, events } = recordingLog();
+    const dispatch: DispatchWorker = async () => outcome();
+    const openPr: OpenPr = async () => {
+      throw new Error("gh pr create exploded");
+    };
+
+    await expect(
+      runWorkerAttempt(7, 1, { dispatch, openPr, exec, log }),
+    ).rejects.toThrow("gh pr create exploded");
+
+    expect(msgs(events)).toContain(
+      "Worker succeeded: 2 new commits on border-collie/ticket-7 (transcript: .border-collie/transcripts/ticket-7.jsonl)",
+    );
+    const prOpenFailed = events.find((e) => e.kind === "pr-open-failed");
+    expect(prOpenFailed?.level).toBe("error");
+    expect(prOpenFailed?.msg).toBe(
+      "PR opening failed after a successful Attempt: gh pr create exploded",
+    );
+  });
+});

--- a/tests/cli/app.test.ts
+++ b/tests/cli/app.test.ts
@@ -6,9 +6,14 @@ import {
   ConfigError,
   type Flags,
   type ResolvedConfig,
+  type WorkerAttemptConfig,
 } from "../../src/core/config.js";
 import type { Log, LogEvent } from "../../src/core/log.js";
-import type { Ticket, WorldSnapshot } from "../../src/core/types.js";
+import type {
+  Ticket,
+  WorkerOutcome,
+  WorldSnapshot,
+} from "../../src/core/types.js";
 
 /** A `Log` recording every event into `events`; this fake context never derives a sub-logger, but the type requires `child`. */
 function recordingLog(events: LogEvent[]): Log {
@@ -42,6 +47,26 @@ function world(tickets: Ticket[]): WorldSnapshot {
 const CLOSED_WORLD = world([ticket({ number: 1, state: "closed" })]);
 const STUCK_WORLD = world([ticket({ number: 1, labels: ["ready-for-human"] })]);
 
+function workerOutcome(overrides: Partial<WorkerOutcome> = {}): WorkerOutcome {
+  return {
+    ticket: 7,
+    attempt: 1,
+    branch: "border-collie/ticket-7",
+    base: "base-sha",
+    transcript: ".border-collie/transcripts/ticket-7.jsonl",
+    model: "sonnet",
+    exitCode: 0,
+    newCommits: 2,
+    failure: undefined,
+    infra: undefined,
+    costUsd: undefined,
+    turns: undefined,
+    costOverrun: false,
+    ok: true,
+    ...overrides,
+  };
+}
+
 const FAKE_RESOLVED_CONFIG: ResolvedConfig = {
   scope: { kind: "parent", parent: 1 },
   maxWorkers: 3,
@@ -65,6 +90,11 @@ interface FakeContext {
     dryRun: boolean;
     dispatchPaused: boolean | undefined;
   }[];
+  runWorkerCalls: {
+    config: WorkerAttemptConfig;
+    ticket: number;
+    attempt: number;
+  }[];
   probeCalls: string[];
   events: LogEvent[];
   verbosityCalls: boolean[];
@@ -74,6 +104,7 @@ function fakeContext(
   overrides: {
     loadConfig?: (flags: Flags) => ResolvedConfig;
     tickResults?: { world: WorldSnapshot; infraFailures?: number }[];
+    runWorkerOutcome?: WorkerOutcome;
   } = {},
 ): FakeContext {
   const stdoutLines: string[] = [];
@@ -84,10 +115,16 @@ function fakeContext(
     dryRun: boolean;
     dispatchPaused: boolean | undefined;
   }[] = [];
+  const runWorkerCalls: {
+    config: WorkerAttemptConfig;
+    ticket: number;
+    attempt: number;
+  }[] = [];
   const probeCalls: string[] = [];
   const events: LogEvent[] = [];
   const verbosityCalls: boolean[] = [];
   const tickResults = overrides.tickResults ?? [{ world: CLOSED_WORLD }];
+  const runWorkerOutcome = overrides.runWorkerOutcome ?? workerOutcome();
 
   const context: Context = {
     process: {
@@ -96,6 +133,15 @@ function fakeContext(
       exitCode: null,
     },
     loadConfig: (flags) => {
+      loadConfigCalls.push(flags);
+      return overrides.loadConfig
+        ? overrides.loadConfig(flags)
+        : FAKE_RESOLVED_CONFIG;
+    },
+    // Same fake resolver as `loadConfig` (structurally a `ResolvedConfig`
+    // satisfies `WorkerAttemptConfig` too) — the worker command's config
+    // error test drives this through the same `overrides.loadConfig`.
+    loadWorkerConfig: (flags) => {
       loadConfigCalls.push(flags);
       return overrides.loadConfig
         ? overrides.loadConfig(flags)
@@ -112,6 +158,10 @@ function fakeContext(
         infraFailures: next.infraFailures ?? 0,
         dispatchPaused: dispatchPaused ?? false,
       };
+    },
+    runWorker: async (config, ticket, attempt) => {
+      runWorkerCalls.push({ config, ticket, attempt });
+      return runWorkerOutcome;
     },
     probe: async (model) => {
       probeCalls.push(model);
@@ -132,6 +182,7 @@ function fakeContext(
     stderr: () => stderrLines.join(""),
     loadConfigCalls,
     tickCalls,
+    runWorkerCalls,
     probeCalls,
     events,
     verbosityCalls,
@@ -288,6 +339,119 @@ describe("command routing", () => {
     expect(fake.stderr()).toContain("--dry-run only applies to tick");
     expect(fake.tickCalls).toHaveLength(0);
   });
+
+  it("routes `worker` with its ticket/attempt positional args to runWorker", async () => {
+    const fake = fakeContext();
+
+    await runCli(["worker", "7", "2"], fake.context);
+
+    expect(fake.runWorkerCalls).toEqual([
+      { config: FAKE_RESOLVED_CONFIG, ticket: 7, attempt: 2 },
+    ]);
+  });
+});
+
+describe("worker command", () => {
+  it("forwards --model and --retry-model overrides to config resolution", async () => {
+    const fake = fakeContext();
+
+    await runCli(
+      ["worker", "7", "1", "--model", "haiku", "--retry-model", "opus4"],
+      fake.context,
+    );
+
+    expect(fake.loadConfigCalls).toEqual([
+      { model: "haiku", retryModel: "opus4" },
+    ]);
+  });
+
+  it("omits unset flags from config resolution", async () => {
+    const fake = fakeContext();
+
+    await runCli(["worker", "7", "1"], fake.context);
+
+    expect(fake.loadConfigCalls).toEqual([{}]);
+  });
+
+  it("lowers the console's minimum level to debug when --verbose is passed", async () => {
+    const fake = fakeContext();
+
+    await runCli(["worker", "7", "1", "--verbose"], fake.context);
+
+    expect(fake.verbosityCalls).toEqual([true]);
+  });
+
+  it("rejects a non-integer ticket without calling runWorker", async () => {
+    const fake = fakeContext();
+
+    await runCli(["worker", "abc", "1"], fake.context);
+
+    expect(fake.context.process.exitCode).toBe(1);
+    expect(fake.runWorkerCalls).toHaveLength(0);
+  });
+
+  it("rejects a non-integer attempt without calling runWorker", async () => {
+    const fake = fakeContext();
+
+    await runCli(["worker", "7", "abc"], fake.context);
+
+    expect(fake.context.process.exitCode).toBe(1);
+    expect(fake.runWorkerCalls).toHaveLength(0);
+  });
+
+  it("exits 0 when the Attempt succeeded", async () => {
+    const fake = fakeContext({ runWorkerOutcome: workerOutcome({ ok: true }) });
+
+    await runCli(["worker", "7", "1"], fake.context);
+
+    expect(fake.context.process.exitCode).toBeFalsy();
+  });
+
+  it("exits non-zero when the Attempt failed on its ticket", async () => {
+    const fake = fakeContext({
+      runWorkerOutcome: workerOutcome({
+        ok: false,
+        failure: "nonzero-exit",
+        exitCode: 1,
+        newCommits: 0,
+      }),
+    });
+
+    await runCli(["worker", "7", "1"], fake.context);
+
+    expect(fake.context.process.exitCode).toBe(1);
+  });
+
+  it("exits non-zero when the Attempt was voided by an infrastructure failure", async () => {
+    const fake = fakeContext({
+      runWorkerOutcome: workerOutcome({
+        ok: false,
+        infra: "usage-limit",
+        exitCode: 1,
+        newCommits: 0,
+      }),
+    });
+
+    await runCli(["worker", "7", "1"], fake.context);
+
+    expect(fake.context.process.exitCode).toBe(1);
+  });
+
+  it("a config error prints a one-line message, exits 1, and never calls runWorker", async () => {
+    const fake = fakeContext({
+      loadConfig: () => {
+        throw new ConfigError("worker_max_turns must be a positive integer");
+      },
+    });
+
+    await runCli(["worker", "7", "1"], fake.context);
+
+    expect(fake.context.process.exitCode).toBe(1);
+    expect(fake.stderr().trim()).toBe(
+      "worker_max_turns must be a positive integer",
+    );
+    expect(fake.runWorkerCalls).toHaveLength(0);
+  });
 });
 
 describe("exit-code contract", () => {
@@ -353,6 +517,7 @@ describe("help", () => {
     expect(fake.stdout()).toContain("USAGE");
     expect(fake.stdout()).toContain("tick");
     expect(fake.stdout()).toContain("run");
+    expect(fake.stdout()).toContain("worker");
   });
 
   it("supports the -h alias", async () => {
@@ -379,6 +544,24 @@ describe("help", () => {
 
     expect(fake.stdout()).toContain("idempotent pass");
     expect(fake.stdout()).toContain("--max-workers");
+  });
+
+  it("documents --verbose and the shared worker-death prose in worker's per-command help", async () => {
+    const fake = fakeContext();
+
+    await runCli(["worker", "--help"], fake.context);
+
+    expect(fake.stdout()).toContain("--verbose");
+    expect(fake.stdout()).toContain("forensic attempt");
+  });
+
+  it("does not offer scope/concurrency flags on worker's per-command help", async () => {
+    const fake = fakeContext();
+
+    await runCli(["worker", "--help"], fake.context);
+
+    expect(fake.stdout()).not.toContain("--max-workers");
+    expect(fake.stdout()).not.toContain("--parent");
   });
 });
 

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -3,6 +3,7 @@ import {
   ConfigError,
   modelForAttempt,
   resolveConfig,
+  resolveWorkerConfig,
 } from "../../src/core/config.js";
 
 describe("resolveConfig", () => {
@@ -297,5 +298,77 @@ describe("resolveConfig", () => {
     expect(() => resolveConfig({ max_workers: "many" }, { all: true })).toThrow(
       ConfigError,
     );
+  });
+});
+
+describe("resolveWorkerConfig", () => {
+  it("resolves with no config file and no scope flags at all (issue #71: a Worker attempt needs no Scope)", () => {
+    const resolved = resolveWorkerConfig(undefined, {});
+
+    expect(resolved).toEqual({
+      maxWorkers: 3,
+      maxOpenPrs: 5,
+      pollSeconds: 30,
+      model: "sonnet",
+      retryModel: "opus",
+      timeoutMinutes: 45,
+      stallMinutes: 10,
+      maxTurns: 200,
+      maxCostUsd: 20,
+    });
+    expect(resolved).not.toHaveProperty("scope");
+  });
+
+  it("ignores a parent in the config file — no scope is ever resolved", () => {
+    const resolved = resolveWorkerConfig({ parent: 1 }, {});
+
+    expect(resolved).not.toHaveProperty("scope");
+  });
+
+  it("lets --model and --retry-model override the config file", () => {
+    const resolved = resolveWorkerConfig(
+      { worker_model: "haiku" },
+      { model: "opus", retryModel: "haiku" },
+    );
+
+    expect(resolved.model).toBe("opus");
+    expect(resolved.retryModel).toBe("haiku");
+  });
+
+  it("takes the Worker timeout, stall window, and budget backstops from the config file", () => {
+    const resolved = resolveWorkerConfig(
+      {
+        worker_timeout_minutes: 90,
+        worker_stall_minutes: 5,
+        worker_max_turns: 80,
+        worker_max_cost_usd: 7.5,
+      },
+      {},
+    );
+
+    expect(resolved.timeoutMinutes).toBe(90);
+    expect(resolved.stallMinutes).toBe(5);
+    expect(resolved.maxTurns).toBe(80);
+    expect(resolved.maxCostUsd).toBe(7.5);
+  });
+
+  it("rejects a malformed config file the same way resolveConfig does", () => {
+    expect(() => resolveWorkerConfig("not an object", {})).toThrow(ConfigError);
+    expect(() => resolveWorkerConfig({ worker_model: "" }, {})).toThrow(
+      ConfigError,
+    );
+  });
+
+  it("resolves the working-hours window the same way resolveConfig does", () => {
+    const resolved = resolveWorkerConfig(
+      { timezone: "Europe/London", work_start_hour: 9, work_end_hour: 18 },
+      {},
+    );
+
+    expect(resolved.workingHours).toEqual({
+      timezone: "Europe/London",
+      startHour: 9,
+      endHour: 18,
+    });
   });
 });


### PR DESCRIPTION
Committed cleanly. Now the final PR description, per the instructions (this must be the entire message, nothing else):

Add a `worker <ticket> <attempt>` CLI command that runs one Worker session and settles its own Attempt outcome, rather than leaving that to a Tick's act phase.

## What changed

- `border-collie worker <ticket> <attempt>` runs one Worker session against an already-claimed Ticket and Attempt: on success it opens the draft pull request itself; on a Ticket failure it posts the forensic release with the attempt record itself; on an Infrastructure failure it voids the Attempt itself, holding the Claim.
- The command shares `settleAttempt` (src/app/settle.ts) with the act phase — no write logic is duplicated. `src/app/worker.ts` adds `runWorkerAttempt` (dispatch → open PR on success → settle, injectable for tests) and `workerAttemptOnce` (real-adapter wiring, mirroring how `tickOnce` composes the act phase).
- Exits non-zero whenever the Attempt did not succeed (ticket failure or infrastructure failure alike), so a job runner can see it.
- Config resolution is split: `resolveWorkerConfig` (src/core/config.ts) produces every config field except `scope` — a Worker attempt is told exactly which ticket to run, so it no longer needs a `parent`/`--all` scope the way `tick`/`run` do. `resolveConfig` is unchanged in behavior, now built from the same shared, scope-independent half.
- `readTicketTitle` (src/adapters/tracker.ts) reads a single ticket's title directly, since the worker command has no world snapshot to source a PR title from.
- The command's own flag surface is `--model`/`--retry-model`/`--verbose` only; scope/concurrency flags (`--parent`, `--all`, `--max-workers`, `--max-open-prs`, `--poll-seconds`, `--dry-run`) are left off since they don't apply to running one Worker.

## Testing

- `tests/app/worker.test.ts`: dispatch → PR-open → settle wiring, per outcome shape (success, Ticket failure, Infrastructure failure, PR-open failure after a successful Attempt).
- `tests/core/config.test.ts`: `resolveWorkerConfig` resolves with no config file and no scope flags at all, ignores a `parent` in the config file, and otherwise validates identically to `resolveConfig`.
- `tests/cli/app.test.ts`: argument handling, flag mapping, exit-code contract, and delegation to `runWorker`/`loadWorkerConfig`.
- `tests/adapters/tracker.test.ts`: `readTicketTitle`, including its fallback title.

Verified locally: `worker --help` renders correctly, and a bad ticket/attempt argument is rejected before any dispatch.

Closes #71