### PR TITLE
feat(pr): bounded refinement loop for agent pull requests

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,6 +57,18 @@ _Avoid_: merge commit (every update is a rebase, keeping agent branches linear s
 The one Worker variant dispatched against a PR rather than a Ticket: a fresh-context session, isolated in a worktree on the conflicted PR's own branch, that completes an in-progress rebase of it onto the base. One per conflict — on failure the PR gets a marker comment asking for a human (the PR-level analogue of Escalation), which vetoes any further session. It is not an Attempt and counts toward no ticket's cap.
 _Avoid_: conflict attempt (Attempts are ticket-scoped; this is not one)
 
+**Refinement round**:
+A failing check, a formal PR review, or a foreign (non-border-collie) comment on an open agent PR not carrying the `operator-steered` label — a marker comment counts the round, then a Worker investigates and commits a fix, which the Orchestrator pushes straight to the PR's branch once the round settles. Bounded at three rounds per PR. Like the Conflict Worker, it is not an Attempt and counts toward no ticket's cap.
+_Avoid_: refinement attempt (Attempts are ticket-scoped; this is not one)
+
+**Refinement give-up**:
+The PR-scoped give-up when a PR's Refinement rounds are exhausted and it still needs one: swap its ticket's `ready-for-agent` → `ready-for-human`, leave forensic comments on both the ticket and the PR, and mark the PR so no further round is ever judged. Distinct from Escalation, which fires on a Ticket's own exhausted Attempts rather than a PR's exhausted rounds — a Ticket with an open agent PR never reaches Escalation (the open PR vetoes it), so the two never compete for the same ticket.
+_Avoid_: escalation (Ticket-scoped; this is PR-scoped)
+
+**Operator-steered**:
+The `operator-steered` label, added by hand to a PR the operator has attached a conversational cloud session to. The automatic Refinement loop skips any PR carrying it, so the two never write over each other; it does not affect Conflict Worker dispatch or the rest of PR upkeep.
+_Avoid_: claimed (that label is Ticket-scoped and agent-held — see "Claim")
+
 **Complete**:
 Terminal state of a run: every ticket in Scope merged and closed.
 

--- a/src/adapters/tracker.ts
+++ b/src/adapters/tracker.ts
@@ -13,13 +13,18 @@ import {
   INFRA_DESCRIPTIONS,
   type InfraReason,
   MAX_ATTEMPTS,
+  MAX_REFINEMENT_ROUNDS,
   type Mergeability,
   type MergedAgentPr,
+  OPERATOR_STEERED_LABEL,
   type OpenAgentPr,
   parseAttemptMarker,
   READY_FOR_AGENT,
   READY_FOR_HUMAN,
+  REFINEMENT_GIVE_UP_MARKER,
+  REFINEMENT_ROUND_MARKER,
   RELEASE_MARKER,
+  type RefinementSignal,
   type Ticket,
   ticketFromAgentBranch,
   VOID_MARKER,
@@ -217,6 +222,8 @@ interface GhPrListItem {
   /** GraphQL mergeability: MERGEABLE | CONFLICTING | UNKNOWN. Independent of the draft flag. */
   mergeable?: string;
   statusCheckRollup?: RollupCheck[];
+  labels?: { name: string }[];
+  createdAt?: string;
 }
 
 function mergeabilityOf(raw: string | undefined): Mergeability {
@@ -283,22 +290,124 @@ function ciFromRollup(rollup: RollupCheck[]): CiState {
   return pending ? "pending" : "passing";
 }
 
+/** What one pass over a PR's issue-comment thread decides for PR upkeep. */
+interface PrCommentSignals {
+  conflictWorkerAsked: boolean;
+  refinement: RefinementSignal;
+}
+
+/** The more recent of two possibly-absent timestamps. */
+function maxDefined(
+  a: number | undefined,
+  b: number | undefined,
+): number | undefined {
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  return Math.max(a, b);
+}
+
 /**
- * True when a conflict-resolution Worker already asked for human help on this
- * PR — the unresolved marker sits in its comment thread. Read only for
- * conflicted PRs, where it alone decides whether another Worker is dispatched.
+ * The latest formal PR-review activity — GitHub's Review flow, a distinct API
+ * surface from the Conversation-tab comments read below: inline review
+ * comments (`pulls/{pr}/comments`) and review submissions (`pulls/{pr}/reviews`)
+ * that either request changes or carry a body (an approval with no comment is
+ * not feedback needing a fix). Only called when it could still change the
+ * Refinement trigger verdict — `readPrCommentSignals` skips it otherwise, so
+ * this never runs for a conflicted, operator-steered, already-given-up, or
+ * already-failing-check PR.
  */
-async function readConflictWorkerAsked(
+async function readPrReviewActivity(
   pr: number,
   exec: Exec,
-): Promise<boolean> {
-  const comments = await readPages<{ body?: string }>(
+): Promise<number | undefined> {
+  const [reviewComments, reviews] = await Promise.all([
+    readPages<{ created_at?: string }>(
+      `repos/{owner}/{repo}/pulls/${pr}/comments?per_page=100`,
+      exec,
+    ),
+    readPages<{ state?: string; submitted_at?: string; body?: string | null }>(
+      `repos/{owner}/{repo}/pulls/${pr}/reviews?per_page=100`,
+      exec,
+    ),
+  ]);
+  const timestamps = [
+    ...reviewComments.map((c) => commentTimestamp(c.created_at)),
+    ...reviews
+      .filter(
+        (r) => r.state === "CHANGES_REQUESTED" || (r.body ?? "").trim() !== "",
+      )
+      .map((r) => commentTimestamp(r.submitted_at)),
+  ].filter((ms): ms is number => ms !== undefined);
+  return timestamps.length > 0 ? Math.max(...timestamps) : undefined;
+}
+
+/**
+ * One read of a PR's issue-comment thread, serving every PR-upkeep marker
+ * check that lives in its comments: whether a conflict Worker already asked
+ * for a human (CONTEXT.md "Conflict Worker"), and the Refinement round state
+ * (CONTEXT.md "Refinement round") — the round count, whether give-up already
+ * fired, and whether a fresh trigger warrants another round. A trigger is a
+ * failing check (independent of comments — passed in already computed), a
+ * formal PR review (`readPrReviewActivity`), or a foreign comment — one
+ * carrying none of border-collie's own markers — posted after the latest
+ * round comment, or after the PR opened when there has been none.
+ * `checkRefinementTrigger` is false for a conflicted PR (plan.ts's conflict
+ * handling is exclusive, so the verdict is never consulted) or an
+ * operator-steered one (CONTEXT.md "Operator-steered") — the round-marker
+ * scan still runs either way, since a conflicted PR's conflict-unresolved
+ * marker lives in the same thread and an operator-steered PR's round count
+ * must survive the label being lifted later, but the extra review-activity
+ * reads are skipped as dead weight.
+ */
+async function readPrCommentSignals(
+  pr: number,
+  createdAtMs: number,
+  ci: CiState,
+  checkRefinementTrigger: boolean,
+  exec: Exec,
+): Promise<PrCommentSignals> {
+  const comments = await readPages<{ body?: string; created_at?: string }>(
     `repos/{owner}/{repo}/issues/${pr}/comments?per_page=100`,
     exec,
   );
-  return comments.some((comment) =>
-    comment.body?.includes(CONFLICT_UNRESOLVED_MARKER),
+  let conflictWorkerAsked = false;
+  let rounds = 0;
+  let givenUp = false;
+  let latestRoundAtMs = createdAtMs;
+  let latestForeignCommentAtMs: number | undefined;
+  for (const comment of comments) {
+    const body = comment.body ?? "";
+    if (body.includes(CONFLICT_UNRESOLVED_MARKER)) {
+      conflictWorkerAsked = true;
+    } else if (body.includes(REFINEMENT_ROUND_MARKER)) {
+      rounds += 1;
+      latestRoundAtMs = commentTimestamp(comment.created_at) ?? latestRoundAtMs;
+    } else if (body.includes(REFINEMENT_GIVE_UP_MARKER)) {
+      givenUp = true;
+    } else {
+      latestForeignCommentAtMs =
+        commentTimestamp(comment.created_at) ?? latestForeignCommentAtMs;
+    }
+  }
+  if (!checkRefinementTrigger || givenUp) {
+    return {
+      conflictWorkerAsked,
+      refinement: { rounds, triggerDue: false, givenUp },
+    };
+  }
+  const latestReviewAtMs =
+    ci === "failing" ? undefined : await readPrReviewActivity(pr, exec);
+  const latestTriggerAtMs = maxDefined(
+    latestForeignCommentAtMs,
+    latestReviewAtMs,
   );
+  const triggerDue =
+    ci === "failing" ||
+    (latestTriggerAtMs !== undefined && latestTriggerAtMs > latestRoundAtMs);
+  return {
+    conflictWorkerAsked,
+    refinement: { rounds, triggerDue, givenUp: false },
+  };
 }
 
 /**
@@ -306,8 +415,9 @@ async function readConflictWorkerAsked(
  * CI rollup), read in one `gh pr list` call — capped at 100, far above the
  * max_open_prs the fleet throttles itself to. Non-agent branches are dropped.
  * Behind-ness is then read per cleanly-mergeable PR (a conflicted one is
- * handled before any update, an unknown one left for the next Tick), and a
- * conflicted PR's comments for the unresolved marker.
+ * handled before any update, an unknown one left for the next Tick), and
+ * every PR's comment thread once for the conflict and Refinement marker
+ * signals together (`readPrCommentSignals`).
  */
 async function listOpenAgentPrs(exec: Exec): Promise<OpenAgentPr[]> {
   const stdout = await exec("gh", [
@@ -318,7 +428,7 @@ async function listOpenAgentPrs(exec: Exec): Promise<OpenAgentPr[]> {
     "--limit",
     "100",
     "--json",
-    "number,headRefName,baseRefName,isDraft,mergeable,statusCheckRollup",
+    "number,headRefName,baseRefName,isDraft,mergeable,statusCheckRollup,labels,createdAt",
   ]);
   const items = JSON.parse(stdout) as GhPrListItem[];
   const prs: OpenAgentPr[] = [];
@@ -328,6 +438,18 @@ async function listOpenAgentPrs(exec: Exec): Promise<OpenAgentPr[]> {
     if (ticket === undefined) continue;
     const mergeable = mergeabilityOf(item.mergeable);
     const base = item.baseRefName ?? "";
+    const ci = ciFromRollup(item.statusCheckRollup ?? []);
+    const operatorSteered = (item.labels ?? []).some(
+      (label) => label.name === OPERATOR_STEERED_LABEL,
+    );
+    const createdAtMs = commentTimestamp(item.createdAt) ?? 0;
+    const signals = await readPrCommentSignals(
+      item.number,
+      createdAtMs,
+      ci,
+      !operatorSteered && mergeable !== "conflicted",
+      exec,
+    );
     prs.push({
       number: item.number,
       ticket,
@@ -338,11 +460,10 @@ async function listOpenAgentPrs(exec: Exec): Promise<OpenAgentPr[]> {
         mergeable === "mergeable" && base !== ""
           ? await prBehindBase(base, headRef, exec)
           : false,
-      ci: ciFromRollup(item.statusCheckRollup ?? []),
-      conflictWorkerAsked:
-        mergeable === "conflicted"
-          ? await readConflictWorkerAsked(item.number, exec)
-          : false,
+      ci,
+      conflictWorkerAsked: signals.conflictWorkerAsked,
+      operatorSteered,
+      refinement: signals.refinement,
     });
   }
   return prs;
@@ -663,5 +784,76 @@ export async function commentConflictUnresolved(
     String(pr),
     "--body",
     CONFLICT_UNRESOLVED_COMMENT,
+  ]);
+}
+
+const refinementRoundComment = (round: number) =>
+  `${REFINEMENT_ROUND_MARKER}\n🐕 Refinement round ${round} of ${MAX_REFINEMENT_ROUNDS}: a failing check or review feedback needs a fix — dispatching a Worker to investigate and commit one.`;
+
+/**
+ * Act phase: start a Refinement round (CONTEXT.md "Refinement round") — the
+ * marker comment first, before the round's Worker ever dispatches, so a
+ * crashed Worker still charges the round it was given rather than letting a
+ * retry-on-crash exceed MAX_REFINEMENT_ROUNDS uncounted (the same
+ * charge-before-spend shape as `claimTicket`'s Attempt count).
+ */
+export async function startRefinementRound(
+  pr: number,
+  round: number,
+  exec: Exec = realExec,
+): Promise<void> {
+  await exec("gh", [
+    "pr",
+    "comment",
+    String(pr),
+    "--body",
+    refinementRoundComment(round),
+  ]);
+}
+
+const refinementGiveUpTicketComment = (pr: number, rounds: number) =>
+  `🐕 Refinement give-up: pull request #${pr} exhausted ${rounds} round${rounds === 1 ? "" : "s"} of ${MAX_REFINEMENT_ROUNDS} without a clean check and review — this ticket needs a human. See #${pr} for the Refinement history.`;
+
+const refinementGiveUpPrComment = (rounds: number) =>
+  `${REFINEMENT_GIVE_UP_MARKER}\n🐕 border-collie gave up refining this pull request after ${rounds} round${rounds === 1 ? "" : "s"} of ${MAX_REFINEMENT_ROUNDS} — handing its ticket to a human. See the refinement-round comments above for what each round tried.`;
+
+/**
+ * Act phase: give up Refining a pull request whose rounds are exhausted but
+ * still needs one (CONTEXT.md "Refinement give-up") — the PR-scoped analogue
+ * of Escalation. The Ticket's forensic comment and label swap land first,
+ * the PR's give-up marker last: that marker is the sole thing
+ * `readPrCommentSignals` trusts to veto every further round, so posting it
+ * only once the Ticket side is durable means a crash mid-way retries the
+ * whole sequence next Tick (worst case a duplicate Ticket comment) rather
+ * than stranding the Ticket `ready-for-agent` with no round left to spend.
+ */
+export async function giveUpOnPr(
+  pr: number,
+  ticket: number,
+  rounds: number,
+  exec: Exec = realExec,
+): Promise<void> {
+  await exec("gh", [
+    "issue",
+    "comment",
+    String(ticket),
+    "--body",
+    refinementGiveUpTicketComment(pr, rounds),
+  ]);
+  await exec("gh", [
+    "issue",
+    "edit",
+    String(ticket),
+    "--remove-label",
+    READY_FOR_AGENT,
+    "--add-label",
+    READY_FOR_HUMAN,
+  ]);
+  await exec("gh", [
+    "pr",
+    "comment",
+    String(pr),
+    "--body",
+    refinementGiveUpPrComment(rounds),
   ]);
 }

--- a/src/adapters/worker.ts
+++ b/src/adapters/worker.ts
@@ -206,6 +206,20 @@ export function conflictWorkerPrompt(): string {
   ].join("\n");
 }
 
+/**
+ * The entire Refinement-round Worker prompt (CONTEXT.md "Refinement round"):
+ * investigate the pull request's own failing checks and review feedback,
+ * then commit a fix. The plain-English half stands in when a slash command
+ * is unavailable; pins the do-not-push contract the Orchestrator relies on —
+ * the Orchestrator judges whether anything changed and pushes it back
+ * itself, the same split as the conflict-resolution Worker.
+ */
+export function refinementWorkerPrompt(): string {
+  return [
+    "This pull request has a failing check or open review feedback. Look at its CI check runs and its review comments (for example `gh pr checks` and `gh pr view --comments`) to find what needs to change, then commit a fix addressing them. Change nothing beyond what the checks or the reviewer's feedback requires, and do not push — leave the fix committed on the current branch.",
+  ].join("\n");
+}
+
 /** Best-effort worktree removal: absent or stale worktrees are fine. */
 async function removeWorktree(worktree: string, exec: Exec): Promise<void> {
   await exec("git", ["worktree", "remove", "--force", worktree]).catch(
@@ -550,5 +564,100 @@ export async function dispatchConflictWorker(
       await exec("git", ["-C", worktree, "rebase", "--abort"]).catch(() => {});
       await removeWorktree(worktree, exec);
     });
+  }
+}
+
+/** One finished Refinement-round Worker session, as observed by the Orchestrator. */
+export interface RefinementOutcome {
+  pr: number;
+  ticket: number;
+  /** Head branch the Worker ran in; pushed back by the caller when it committed something. */
+  headRef: string;
+  /** Transcript file path, for post-mortems — namespaced per round, so a later round never clobbers an earlier one's evidence. */
+  transcript: string;
+  exitCode: number | null;
+  /** Commits the Worker added on top of the branch's tip when it started. */
+  newCommits: number;
+}
+
+/**
+ * Dispatch one Refinement-round Worker against one open agent PR (CONTEXT.md
+ * "Refinement round"): cut a worktree on the PR's own head branch (no rebase
+ * setup — a round investigates the PR as it stands, unlike the conflict
+ * Worker), run headless claude in it, then report whether it committed
+ * anything. The branch is the PR's existing head (checked out from origin),
+ * never a fresh one — a pushed fix has to land on the same branch the PR is
+ * already open from. `-B` and the up-front removal reset any leftover of a
+ * crashed round on the same branch. The Worker never pushes (the prompt
+ * pins that contract); the caller judges `newCommits` and pushes only when
+ * the round actually changed something, mirroring the conflict Worker's own
+ * split between judging and pushing.
+ */
+export async function dispatchRefinementWorker(
+  pr: number,
+  ticket: number,
+  headRef: string,
+  round: number,
+  config: ClaudeRunConfig,
+  exec: Exec = realExec,
+  spawnProcess: SpawnWorkerProcess = realSpawnWorkerProcess,
+  log: Log = noopLog,
+): Promise<RefinementOutcome> {
+  const worktree = join(RUN_DIR, "refinement-worktrees", `pr-${pr}`);
+  const transcript = join(
+    RUN_DIR,
+    "transcripts",
+    `pr-${pr}-refinement-round-${round}.jsonl`,
+  );
+  const stderrLog = join(
+    RUN_DIR,
+    "transcripts",
+    `pr-${pr}-refinement-round-${round}.stderr.log`,
+  );
+
+  const base = await withGitLock(async () => {
+    await removeWorktree(worktree, exec);
+    await exec("git", ["worktree", "prune"]);
+    await exec("git", ["fetch", "origin"]);
+    await exec("git", [
+      "worktree",
+      "add",
+      worktree,
+      "-B",
+      headRef,
+      `origin/${headRef}`,
+    ]);
+    return (await exec("git", ["rev-parse", headRef])).trim();
+  });
+  log({
+    kind: "refinement-worker-paths",
+    level: "debug",
+    msg: `Refinement Worker for PR #${pr} (round ${round}): worktree ${worktree}, transcript ${transcript}`,
+    pr,
+    round,
+    worktree,
+    transcript,
+  });
+
+  try {
+    const { exitCode } = await spawnProcess({
+      cmd: "claude",
+      args: claudeArgs(refinementWorkerPrompt(), config.model, config.maxTurns),
+      cwd: worktree,
+      transcriptPath: transcript,
+      stderrPath: stderrLog,
+      timeoutMs: config.timeoutMs,
+      stallMs: config.stallMs,
+    });
+    const newCommits = Number(
+      (
+        await withGitLock(() =>
+          exec("git", ["rev-list", "--count", `${base}..${headRef}`]),
+        )
+      ).trim(),
+    );
+    return { pr, ticket, headRef, transcript, exitCode, newCommits };
+  } finally {
+    await withGitLock(() => removeWorktree(worktree, exec));
   }
 }

--- a/src/app/act.ts
+++ b/src/app/act.ts
@@ -4,11 +4,17 @@ import {
   commentConflictUnresolved,
   type Exec,
   escalateTicket,
+  giveUpOnPr,
   markPrReady,
   releaseTicket,
+  startRefinementRound,
   updatePrBranch,
 } from "../adapters/tracker.js";
-import { type ConflictOutcome, pushAgentBranch } from "../adapters/worker.js";
+import {
+  type ConflictOutcome,
+  pushAgentBranch,
+  type RefinementOutcome,
+} from "../adapters/worker.js";
 import { reclassifyCorrelatedFailures } from "../core/classify.js";
 import { heartbeatSnapshot, type WorkerActivity } from "../core/heartbeat.js";
 import type { Log } from "../core/log.js";
@@ -53,6 +59,14 @@ export type DispatchConflictWorker = (
   headRef: string,
 ) => Promise<ConflictOutcome>;
 
+/** Dispatch one Refinement-round Worker against one open agent PR. */
+export type DispatchRefinementWorker = (
+  pr: number,
+  ticket: number,
+  headRef: string,
+  round: number,
+) => Promise<RefinementOutcome>;
+
 /** What one spawn action came to: the Attempt, and its PR when one was opened. */
 interface SpawnResult {
   outcome: WorkerOutcome;
@@ -69,6 +83,12 @@ interface ConflictSpawnResult {
   log: Log;
 }
 
+/** What one refine-pr action came to: the outcome, and its sub-logger to carry forward. */
+interface RefinementSpawnResult {
+  outcome: RefinementOutcome;
+  log: Log;
+}
+
 /** What one Tick's act phase reports back to the loop. */
 export interface ActReport {
   /** Infrastructure-voided Attempts this Tick — any at all trips the circuit breaker. */
@@ -80,6 +100,7 @@ export interface ActDeps {
   dispatch: DispatchWorker;
   openPr: OpenPr;
   dispatchConflict: DispatchConflictWorker;
+  dispatchRefinement: DispatchRefinementWorker;
   exec: Exec;
   log: Log;
   /** The heartbeat's clock, following the run loop's existing treatment of time. */
@@ -160,6 +181,12 @@ function describeConflict(outcome: ConflictOutcome): string {
     : `Conflict Worker could not resolve the conflicts (exit ${outcome.exitCode}) ${where}`;
 }
 
+function describeRefinement(outcome: RefinementOutcome): string {
+  const commits = `${outcome.newCommits} new commit${outcome.newCommits === 1 ? "" : "s"}`;
+  const where = `on ${outcome.headRef} (transcript: ${outcome.transcript})`;
+  return `Refinement Worker finished: ${commits} ${where}`;
+}
+
 /**
  * Act phase: perform the planned writes in plan order (releases first), one
  * at a time, narrating each as it lands. Spawns are the exception: each
@@ -178,7 +205,12 @@ function describeConflict(outcome: ConflictOutcome): string {
  * spawn, its resolved rebase pushed (or the PR handed to a human) once it
  * settles. While any dispatch Worker is in flight, a fleet heartbeat reports
  * all of them once a minute — elapsed time and time since last output,
- * independently — and stops the moment the last one settles.
+ * independently — and stops the moment the last one settles. A Refinement
+ * round (CONTEXT.md "Refinement round") runs the same shape as a conflict
+ * Worker — the round marker lands first (bounding the round even across a
+ * crash), then the Worker runs concurrently, its branch pushed back only
+ * when it actually committed a fix. Refinement give-up is an immediate
+ * tracker write, like an escalation.
  */
 export async function act(
   actions: Action[],
@@ -188,6 +220,7 @@ export async function act(
     dispatch,
     openPr,
     dispatchConflict,
+    dispatchRefinement,
     exec,
     log,
     now,
@@ -195,6 +228,7 @@ export async function act(
   } = deps;
   const workers: Promise<SpawnResult>[] = [];
   const conflicts: Promise<ConflictSpawnResult>[] = [];
+  const refinements: Promise<RefinementSpawnResult>[] = [];
   const heartbeat = createHeartbeat(now, scheduleInterval, log);
 
   for (const action of actions) {
@@ -269,6 +303,37 @@ export async function act(
         });
         break;
       }
+      case "refine-pr": {
+        await startRefinementRound(action.pr, action.round, exec);
+        const refinementLog = log.child({ pr: action.pr });
+        refinementLog({
+          kind: "refinement-round-started",
+          level: "info",
+          msg: `started Refinement round ${action.round} for PR #${action.pr} (ticket #${action.ticket})`,
+          ticket: action.ticket,
+          round: action.round,
+        });
+        refinements.push(
+          dispatchRefinement(
+            action.pr,
+            action.ticket,
+            action.headRef,
+            action.round,
+          ).then((outcome) => ({ outcome, log: refinementLog })),
+        );
+        break;
+      }
+      case "refinement-give-up":
+        await giveUpOnPr(action.pr, action.ticket, action.rounds, exec);
+        log({
+          kind: "refinement-give-up",
+          level: "warn",
+          msg: `gave up Refining PR #${action.pr} after ${action.rounds} rounds (ticket #${action.ticket} → ready-for-human)`,
+          pr: action.pr,
+          ticket: action.ticket,
+          rounds: action.rounds,
+        });
+        break;
       case "spawn": {
         const workerLog = log.child({
           ticket: action.ticket,
@@ -353,6 +418,28 @@ export async function act(
       });
     }
   }
+  // Refinement-round Workers settle the same way: the branch is pushed back
+  // only when the round actually committed a fix — a round that changed
+  // nothing leaves the PR as it was, for the next Tick to judge afresh.
+  const settledRefinements = await Promise.allSettled(refinements);
+  for (const result of settledRefinements) {
+    if (result.status !== "fulfilled") continue;
+    const { outcome, log: refinementLog } = result.value;
+    refinementLog({
+      kind: "refinement-outcome",
+      level: "info",
+      msg: describeRefinement(outcome),
+      newCommits: outcome.newCommits,
+    });
+    if (outcome.newCommits > 0) {
+      await pushAgentBranch(outcome.headRef, exec);
+      refinementLog({
+        kind: "refinement-pushed",
+        level: "info",
+        msg: "pushed the Refinement fix",
+      });
+    }
+  }
 
   const rejected = settled.find((result) => result.status === "rejected");
   if (rejected) throw rejected.reason;
@@ -360,6 +447,10 @@ export async function act(
     (result) => result.status === "rejected",
   );
   if (rejectedConflict) throw rejectedConflict.reason;
+  const rejectedRefinement = settledRefinements.find(
+    (result) => result.status === "rejected",
+  );
+  if (rejectedRefinement) throw rejectedRefinement.reason;
   for (const result of settled) {
     if (result.status === "fulfilled" && result.value.prFailure !== undefined) {
       const { prFailure, log: workerLog } = result.value;

--- a/src/app/tick.ts
+++ b/src/app/tick.ts
@@ -2,6 +2,7 @@ import { openPrForOutcome } from "../adapters/pr.js";
 import { readScope, realExec, withDebugLogging } from "../adapters/tracker.js";
 import {
   dispatchConflictWorker,
+  dispatchRefinementWorker,
   dispatchWorker,
   realSpawnWorkerProcess,
 } from "../adapters/worker.js";
@@ -107,6 +108,22 @@ export async function tickOnce(
           pr,
           ticket,
           headRef,
+          {
+            model: config.model,
+            timeoutMs: config.timeoutMinutes * 60_000,
+            stallMs: config.stallMinutes * 60_000,
+            maxTurns: config.maxTurns,
+          },
+          exec,
+          realSpawnWorkerProcess,
+          log,
+        ),
+      dispatchRefinement: (pr, ticket, headRef, round) =>
+        dispatchRefinementWorker(
+          pr,
+          ticket,
+          headRef,
+          round,
           {
             model: config.model,
             timeoutMs: config.timeoutMinutes * 60_000,

--- a/src/cli/tick-command.ts
+++ b/src/cli/tick-command.ts
@@ -40,6 +40,13 @@ merge, its body taken from the Worker's final message (mechanical fallback:
 ticket + commit subjects). Dispatch pauses while open agent PRs sit at
 max_open_prs and resumes as merges land.
 
+A failing check, a formal PR review, or a foreign comment on an open agent PR
+(not carrying the operator-steered label) starts a Refinement round: a
+marker comment counts it, then a Worker investigates and commits a fix,
+pushed once the round settles. Bounded at three rounds per PR — once
+exhausted and the PR still needs one, its ticket swaps to ready-for-human
+with a forensic comment on both, and no further round is ever judged.
+
 ${WORKER_DEATH_PROSE} the tick prints a notice so the operator knows to
 re-run once the environment recovers. A standalone tick keeps no memory of
 its own, but the circuit breaker it derives from the tracker's void markers

--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -37,6 +37,13 @@ export type LogEvent = LogEventBase &
     | { kind: "update-branch"; pr: number }
     | { kind: "mark-ready"; pr: number }
     | { kind: "conflict-dispatch"; ticket: number }
+    | { kind: "refinement-round-started"; ticket: number; round: number }
+    | {
+        kind: "refinement-give-up";
+        pr: number;
+        ticket: number;
+        rounds: number;
+      }
     | { kind: "spawn" }
     | { kind: "worker-outcome"; outcome: WorkerOutcome }
     | { kind: "heartbeat"; workers: WorkerHeartbeat[] }
@@ -48,6 +55,8 @@ export type LogEvent = LogEventBase &
     | { kind: "conflict-outcome"; resolved: boolean }
     | { kind: "conflict-pushed" }
     | { kind: "conflict-unresolved" }
+    | { kind: "refinement-outcome"; newCommits: number }
+    | { kind: "refinement-pushed" }
     | { kind: "breaker-closed" }
     | { kind: "breaker-still-open"; trips: number; nextProbeMs: number }
     | { kind: "breaker-open"; infraFailures: number; nextProbeMs: number }
@@ -72,6 +81,13 @@ export type LogEvent = LogEventBase &
     | {
         kind: "conflict-worker-paths";
         pr: number;
+        worktree: string;
+        transcript: string;
+      }
+    | {
+        kind: "refinement-worker-paths";
+        pr: number;
+        round: number;
         worktree: string;
         transcript: string;
       }

--- a/src/core/plan.ts
+++ b/src/core/plan.ts
@@ -2,6 +2,7 @@ import {
   type Action,
   CLAIM_LABEL,
   MAX_ATTEMPTS,
+  MAX_REFINEMENT_ROUNDS,
   type PlanConfig,
   READY_FOR_AGENT,
   type Ticket,
@@ -92,18 +93,30 @@ function isEscalationDue(ticket: Ticket, world: WorldSnapshot): boolean {
 
 /**
  * PR upkeep: after a merge advances the base, keep the remaining open agent
- * PRs current, one Action per PR at most. Conflict handling comes first and is
- * exclusive — a conflicted PR is neither updated nor readied until the merge is
+ * PRs current — mechanical writes plus the two Refinement actions, up to one
+ * of each kind per PR. Conflict handling comes first and is exclusive — a
+ * conflicted PR is neither updated, readied, nor Refined until the merge is
  * resolved: a one-shot conflict Worker unless one has already asked for a
  * human. A cleanly-mergeable PR that has fallen behind gets the mechanical
  * branch update, and its ready flip waits for the next Tick, judged against the
  * updated head (the update re-runs CI). Draft→ready is otherwise decided on CI
  * alone — a green draft, or one in a repo with no CI configured, flips to
  * ready-for-review — and independent of mergeability, so a fresh no-CI draft
- * surfaces even while GitHub is still computing whether it is behind. The
- * Conflict Worker is quota-consuming, so the working-hours gate (CONTEXT.md
- * "Working hours") suppresses it; the mechanical update and the ready flip
- * are not, and run regardless.
+ * surfaces even while GitHub is still computing whether it is behind.
+ *
+ * Refinement (CONTEXT.md "Refinement round") is judged independently of the
+ * ready flip — a failing check keeps `pr.draft && ci === "passing"` false
+ * regardless, so the two never collide — for every PR not carrying the
+ * operator-steered label and not already given up on: `triggerDue` false
+ * means nothing is due; `triggerDue` true with rounds already at
+ * MAX_REFINEMENT_ROUNDS means Refinement give-up (CONTEXT.md "Refinement
+ * give-up"), handing the Ticket to a human; otherwise a round is due.
+ *
+ * The Conflict Worker and a Refinement round are both quota-consuming, so the
+ * working-hours gate (CONTEXT.md "Working hours") suppresses them; the
+ * mechanical update, the ready flip, and Refinement give-up are not — give-up
+ * is mechanical bookkeeping, the same reasoning that keeps Escalation
+ * unsuppressed — and run regardless.
  */
 function prUpkeep(world: WorldSnapshot, withinWorkingHours: boolean): Action[] {
   const actions: Action[] = [];
@@ -127,6 +140,28 @@ function prUpkeep(world: WorldSnapshot, withinWorkingHours: boolean): Action[] {
     }
     if (pr.draft && (pr.ci === "passing" || pr.ci === "none")) {
       actions.push({ type: "mark-ready", pr: pr.number, ticket: pr.ticket });
+    }
+    if (
+      !pr.operatorSteered &&
+      !pr.refinement.givenUp &&
+      pr.refinement.triggerDue
+    ) {
+      if (pr.refinement.rounds >= MAX_REFINEMENT_ROUNDS) {
+        actions.push({
+          type: "refinement-give-up",
+          pr: pr.number,
+          ticket: pr.ticket,
+          rounds: pr.refinement.rounds,
+        });
+      } else if (!withinWorkingHours) {
+        actions.push({
+          type: "refine-pr",
+          pr: pr.number,
+          ticket: pr.ticket,
+          headRef: pr.headRef,
+          round: pr.refinement.rounds + 1,
+        });
+      }
     }
   }
   return actions;

--- a/src/core/render.ts
+++ b/src/core/render.ts
@@ -34,7 +34,9 @@ export type PlanActionLine =
   | { type: "close"; ticket: number; title: string; prUrl: string }
   | { type: "update-branch"; pr: number; title: string }
   | { type: "conflict-worker"; pr: number; title: string }
-  | { type: "mark-ready"; pr: number; title: string };
+  | { type: "mark-ready"; pr: number; title: string }
+  | { type: "refine-pr"; pr: number; title: string; round: number }
+  | { type: "refinement-give-up"; pr: number; title: string; rounds: number };
 
 export interface PlanReport {
   scopeLabel: string;
@@ -82,6 +84,15 @@ function toPlanActionLine(
       return { type: "conflict-worker", pr: action.pr, title };
     case "mark-ready":
       return { type: "mark-ready", pr: action.pr, title };
+    case "refine-pr":
+      return { type: "refine-pr", pr: action.pr, title, round: action.round };
+    case "refinement-give-up":
+      return {
+        type: "refinement-give-up",
+        pr: action.pr,
+        title,
+        rounds: action.rounds,
+      };
   }
 }
 
@@ -155,6 +166,10 @@ function renderPlanActionLine(line: PlanActionLine): string {
       return `  conflict Worker for PR #${line.pr} — ${line.title} (resolve merge conflicts)`;
     case "mark-ready":
       return `  mark PR #${line.pr} ready — ${line.title} (CI green)`;
+    case "refine-pr":
+      return `  Refine PR #${line.pr} — ${line.title} (round ${line.round}, failing check or review feedback)`;
+    case "refinement-give-up":
+      return `  give up Refining PR #${line.pr} — ${line.title} (${line.rounds} rounds exhausted → ready-for-human)`;
   }
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -167,6 +167,54 @@ export function parseAttemptMarker(body: string): AttemptFailure | undefined {
 }
 
 /**
+ * The label an operator adds by hand to a pull request they have attached a
+ * conversational cloud session to, taking over from the automatic loop
+ * (CONTEXT.md "Operator-steered"). Distinct from `CLAIM_LABEL`: that one is
+ * Ticket-scoped and agent-held, this one is PR-scoped and human-held.
+ */
+export const OPERATOR_STEERED_LABEL = "operator-steered";
+
+/**
+ * A pull request gets at most this many Refinement rounds before Refinement
+ * give-up (CONTEXT.md "Refinement round").
+ */
+export const MAX_REFINEMENT_ROUNDS = 3;
+
+/**
+ * Hidden HTML marker counting one Refinement round (CONTEXT.md "Refinement
+ * round"): posted before the round's Worker dispatches, so a crash never
+ * loses count of a round already spent — the same charge-before-spend shape
+ * as the claim marker's Attempt count.
+ */
+export const REFINEMENT_ROUND_MARKER =
+  "<!-- border-collie:refinement-round -->";
+
+/**
+ * Hidden HTML marker recording Refinement give-up (CONTEXT.md "Refinement
+ * give-up"): posted on the pull request once its Refinement rounds are
+ * exhausted and it still needs one — the PR-scoped analogue of Escalation.
+ * Its presence vetoes every future round.
+ */
+export const REFINEMENT_GIVE_UP_MARKER =
+  "<!-- border-collie:refinement-give-up -->";
+
+/**
+ * The Refinement round state of one open agent pull request, read from its
+ * comment thread (CONTEXT.md "Refinement round"). `rounds` counts
+ * REFINEMENT_ROUND_MARKER comments ever posted; `triggerDue` is true when a
+ * failing check or a foreign (non-border-collie) comment posted after the
+ * latest round — or after the pull request opened, if there has been none —
+ * means another round is warranted; `givenUp` is true once the give-up
+ * marker has already fired, which vetoes every further round regardless of
+ * `triggerDue`.
+ */
+export interface RefinementSignal {
+  rounds: number;
+  triggerDue: boolean;
+  givenUp: boolean;
+}
+
+/**
  * A Conflict Worker gave up on a PR and asked for a human: the marker that
  * makes the ask structural, so the next Tick never re-dispatches a second
  * Worker against a conflict a human now owns (the PR-level analogue of
@@ -300,6 +348,13 @@ export interface OpenAgentPr {
    * this PR (the unresolved marker is present) — vetoes dispatching another.
    */
   conflictWorkerAsked: boolean;
+  /**
+   * True when the PR carries the operator-steered label (CONTEXT.md
+   * "Operator-steered") — the automatic Refinement loop never writes here.
+   */
+  operatorSteered: boolean;
+  /** This PR's Refinement round state (CONTEXT.md "Refinement round"). */
+  refinement: RefinementSignal;
 }
 
 /** Everything the planner knows about the world, recomputed each Tick. */
@@ -343,7 +398,10 @@ export interface PlanConfig {
  * attempt number; the caller binds it to a model (the retry ladder). The
  * three PR-upkeep actions carry the PR number plus the ticket (for the
  * human-readable rendering) and, for the conflict Worker, the head branch it
- * works in and pushes back.
+ * works in and pushes back. The two Refinement actions likewise carry the PR
+ * and ticket: `refine-pr` the head branch to dispatch into and the round
+ * number it is charging, `refinement-give-up` the round count spent, for the
+ * forensic comment.
  */
 export type Action =
   | { type: "claim"; ticket: number }
@@ -353,4 +411,12 @@ export type Action =
   | { type: "close"; ticket: number; prUrl: string }
   | { type: "update-branch"; pr: number; ticket: number }
   | { type: "conflict-worker"; pr: number; ticket: number; headRef: string }
-  | { type: "mark-ready"; pr: number; ticket: number };
+  | { type: "mark-ready"; pr: number; ticket: number }
+  | {
+      type: "refine-pr";
+      pr: number;
+      ticket: number;
+      headRef: string;
+      round: number;
+    }
+  | { type: "refinement-give-up"; pr: number; ticket: number; rounds: number };

--- a/tests/adapters/tracker.test.ts
+++ b/tests/adapters/tracker.test.ts
@@ -6,10 +6,12 @@ import {
   createDraftPr,
   type Exec,
   escalateTicket,
+  giveUpOnPr,
   markPrReady,
   readScope,
   releaseFailedTicket,
   releaseTicket,
+  startRefinementRound,
   updatePrBranch,
   voidAttempt,
   withDebugLogging,
@@ -21,6 +23,10 @@ import {
   CLAIM_LABEL,
   CLAIM_MARKER,
   CONFLICT_UNRESOLVED_MARKER,
+  READY_FOR_AGENT,
+  READY_FOR_HUMAN,
+  REFINEMENT_GIVE_UP_MARKER,
+  REFINEMENT_ROUND_MARKER,
   RELEASE_MARKER,
   VOID_MARKER,
 } from "../../src/core/types.js";
@@ -95,6 +101,12 @@ const comments = (n: number) =>
   `repos/{owner}/{repo}/issues/${n}/comments?per_page=100`;
 const blockedBy = (n: number) =>
   `repos/{owner}/{repo}/issues/${n}/dependencies/blocked_by?per_page=100`;
+/** Inline PR review comments — GitHub's Review flow, distinct from `comments`. */
+const pullComments = (n: number) =>
+  `repos/{owner}/{repo}/pulls/${n}/comments?per_page=100`;
+/** PR review submissions (Approve/Request-changes/Comment). */
+const pullReviews = (n: number) =>
+  `repos/{owner}/{repo}/pulls/${n}/reviews?per_page=100`;
 const CLOSED_PULLS = "repos/{owner}/{repo}/pulls?state=closed&per_page=100";
 const compare = (base: string, head: string) =>
   `repos/{owner}/{repo}/compare/${base}...${head}`;
@@ -138,7 +150,7 @@ describe("readScope", () => {
       "--limit",
       "100",
       "--json",
-      "number,headRefName,baseRefName,isDraft,mergeable,statusCheckRollup",
+      "number,headRefName,baseRefName,isDraft,mergeable,statusCheckRollup,labels,createdAt",
     ]);
   });
 
@@ -558,6 +570,9 @@ describe("readScope", () => {
       api: {
         [SUB_ISSUES]: [[issue({ number: 5 })]],
         [comments(5)]: [[]],
+        [comments(50)]: [[]],
+        [pullComments(50)]: [[]],
+        [pullReviews(50)]: [[]],
         [CLOSED_PULLS]: [[]],
       },
       prList: [
@@ -578,6 +593,8 @@ describe("readScope", () => {
         behind: false,
         ci: "none",
         conflictWorkerAsked: false,
+        operatorSteered: false,
+        refinement: { rounds: 0, triggerDue: false, givenUp: false },
       },
     ]);
   });
@@ -588,6 +605,9 @@ describe("readScope", () => {
       api: {
         [SUB_ISSUES]: [[issue({ number: 5 })]],
         [comments(5)]: [[]],
+        [comments(50)]: [[]],
+        [pullComments(50)]: [[]],
+        [pullReviews(50)]: [[]],
         [CLOSED_PULLS]: [[]],
         // The head is two commits behind its base.
         [compare("main", head)]: { behind_by: 2 },
@@ -620,6 +640,9 @@ describe("readScope", () => {
         [comments(5)]: [[]],
         [comments(6)]: [[]],
         [comments(50)]: [[]],
+        [comments(60)]: [[]],
+        [pullComments(60)]: [[]],
+        [pullReviews(60)]: [[]],
         [CLOSED_PULLS]: [[]],
       },
       prList: [
@@ -641,7 +664,7 @@ describe("readScope", () => {
     ).toBe(false);
   });
 
-  it("reads a conflicted PR's comments for the unresolved marker, and skips that read otherwise", async () => {
+  it("reads every open PR's comments once, for the conflict-unresolved marker and the Refinement signal together", async () => {
     const { exec, calls } = fakeExec({
       api: {
         [SUB_ISSUES]: [[issue({ number: 5 })]],
@@ -650,6 +673,10 @@ describe("readScope", () => {
         [comments(50)]: [
           [{ body: `${CONFLICT_UNRESOLVED_MARKER}\n🐕 human, please` }],
         ],
+        // PR #60 is clean — no border-collie markers at all.
+        [comments(60)]: [[]],
+        [pullComments(60)]: [[]],
+        [pullReviews(60)]: [[]],
         [CLOSED_PULLS]: [[]],
       },
       prList: [
@@ -670,6 +697,8 @@ describe("readScope", () => {
         behind: false,
         ci: "none",
         conflictWorkerAsked: true,
+        operatorSteered: false,
+        refinement: { rounds: 0, triggerDue: false, givenUp: false },
       },
       {
         number: 60,
@@ -680,11 +709,14 @@ describe("readScope", () => {
         behind: false,
         ci: "none",
         conflictWorkerAsked: false,
+        operatorSteered: false,
+        refinement: { rounds: 0, triggerDue: false, givenUp: false },
       },
     ]);
-    // The clean PR #60's comments are never read.
+    // Both PRs' comments are read — the single pass serves the conflict check
+    // and the Refinement signal at once.
     expect(calls.map(op)).toContain(comments(50));
-    expect(calls.map(op)).not.toContain(comments(60));
+    expect(calls.map(op)).toContain(comments(60));
   });
 
   it("classifies a pending check rollup as pending and a failing one as failing", async () => {
@@ -693,6 +725,13 @@ describe("readScope", () => {
         [SUB_ISSUES]: [[issue({ number: 5 }), issue({ number: 6 })]],
         [comments(5)]: [[]],
         [comments(6)]: [[]],
+        [comments(50)]: [[]],
+        [comments(60)]: [[]],
+        // PR #50 is pending, not failing, so its Refinement trigger still
+        // consults formal review activity; PR #60 is already failing, which
+        // short-circuits that read.
+        [pullComments(50)]: [[]],
+        [pullReviews(50)]: [[]],
         [CLOSED_PULLS]: [[]],
       },
       prList: [
@@ -724,6 +763,9 @@ describe("readScope", () => {
       api: {
         [SUB_ISSUES]: [[issue({ number: 5 })]],
         [comments(5)]: [[]],
+        [comments(50)]: [[]],
+        [pullComments(50)]: [[]],
+        [pullReviews(50)]: [[]],
         [CLOSED_PULLS]: [[]],
       },
       prList: [prItem({ number: 50, mergeable: "UNKNOWN" })],
@@ -799,6 +841,305 @@ describe("readScope", () => {
     expect(world.mergedAgentPrs).toEqual([
       { ticket: 5, url: "https://github.com/o/r/pull/52" },
     ]);
+  });
+});
+
+describe("readScope: Refinement signal", () => {
+  it("counts Refinement rounds from round marker comments", async () => {
+    const { exec } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [[]],
+        [comments(50)]: [
+          [
+            {
+              body: REFINEMENT_ROUND_MARKER,
+              created_at: "2026-07-20T10:00:00Z",
+            },
+            {
+              body: REFINEMENT_ROUND_MARKER,
+              created_at: "2026-07-21T10:00:00Z",
+            },
+          ],
+        ],
+        [pullComments(50)]: [[]],
+        [pullReviews(50)]: [[]],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [prItem({ number: 50 })],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.openAgentPrs[0]?.refinement).toEqual({
+      rounds: 2,
+      triggerDue: false,
+      givenUp: false,
+    });
+  });
+
+  it("is due when a foreign comment lands after the latest round", async () => {
+    const { exec } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [[]],
+        [comments(50)]: [
+          [
+            {
+              body: REFINEMENT_ROUND_MARKER,
+              created_at: "2026-07-20T10:00:00Z",
+            },
+            {
+              body: "please also fix the typo",
+              created_at: "2026-07-21T10:00:00Z",
+            },
+          ],
+        ],
+        [pullComments(50)]: [[]],
+        [pullReviews(50)]: [[]],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [prItem({ number: 50 })],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.openAgentPrs[0]?.refinement).toEqual({
+      rounds: 1,
+      triggerDue: true,
+      givenUp: false,
+    });
+  });
+
+  it("is not due when the only foreign comment predates the latest round", async () => {
+    const { exec } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [[]],
+        [comments(50)]: [
+          [
+            { body: "please fix the typo", created_at: "2026-07-19T10:00:00Z" },
+            {
+              body: REFINEMENT_ROUND_MARKER,
+              created_at: "2026-07-20T10:00:00Z",
+            },
+          ],
+        ],
+        [pullComments(50)]: [[]],
+        [pullReviews(50)]: [[]],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [prItem({ number: 50 })],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.openAgentPrs[0]?.refinement.triggerDue).toBe(false);
+  });
+
+  it("is due when an inline review comment lands after the latest round (GitHub's Review flow, not the Conversation tab)", async () => {
+    const { exec } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [[]],
+        [comments(50)]: [
+          [
+            {
+              body: REFINEMENT_ROUND_MARKER,
+              created_at: "2026-07-20T10:00:00Z",
+            },
+          ],
+        ],
+        [pullComments(50)]: [[{ created_at: "2026-07-21T10:00:00Z" }]],
+        [pullReviews(50)]: [[]],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [prItem({ number: 50 })],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.openAgentPrs[0]?.refinement).toEqual({
+      rounds: 1,
+      triggerDue: true,
+      givenUp: false,
+    });
+  });
+
+  it("is due on a Request-changes review with no body, and on a Comment review with one", async () => {
+    const { exec } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [[]],
+        [comments(50)]: [[]],
+        [pullComments(50)]: [[]],
+        [pullReviews(50)]: [
+          [
+            {
+              state: "CHANGES_REQUESTED",
+              body: "",
+              submitted_at: "2026-07-19T10:00:00Z",
+            },
+          ],
+        ],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [prItem({ number: 50 })],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.openAgentPrs[0]?.refinement.triggerDue).toBe(true);
+  });
+
+  it("ignores an approving review with no comment — not feedback needing a fix", async () => {
+    const { exec } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [[]],
+        [comments(50)]: [[]],
+        [pullComments(50)]: [[]],
+        [pullReviews(50)]: [
+          [
+            {
+              state: "APPROVED",
+              body: "",
+              submitted_at: "2026-07-19T10:00:00Z",
+            },
+          ],
+        ],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [prItem({ number: 50 })],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.openAgentPrs[0]?.refinement.triggerDue).toBe(false);
+  });
+
+  it("never reads formal review activity for a conflicted PR — the read would be dead weight", async () => {
+    const { exec, calls } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [[]],
+        [comments(50)]: [[]],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [prItem({ number: 50, mergeable: "CONFLICTING" })],
+    });
+
+    await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(calls.map(op)).not.toContain(pullComments(50));
+    expect(calls.map(op)).not.toContain(pullReviews(50));
+  });
+
+  it("is due on a fresh PR the moment a foreign comment lands, with no round yet", async () => {
+    const { exec } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [[]],
+        [comments(50)]: [
+          [{ body: "please fix the typo", created_at: "2026-07-19T10:00:00Z" }],
+        ],
+        [pullComments(50)]: [[]],
+        [pullReviews(50)]: [[]],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [prItem({ number: 50, createdAt: "2026-07-18T10:00:00Z" })],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.openAgentPrs[0]?.refinement).toEqual({
+      rounds: 0,
+      triggerDue: true,
+      givenUp: false,
+    });
+  });
+
+  it("is due on a failing check regardless of comments, without reading formal review activity", async () => {
+    const { exec, calls } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [[]],
+        [comments(50)]: [[]],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [
+        prItem({
+          number: 50,
+          statusCheckRollup: [{ status: "COMPLETED", conclusion: "FAILURE" }],
+        }),
+      ],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.openAgentPrs[0]?.refinement.triggerDue).toBe(true);
+    // A failing check already settles the verdict — the extra reads would be dead weight.
+    expect(calls.map(op)).not.toContain(pullComments(50));
+    expect(calls.map(op)).not.toContain(pullReviews(50));
+  });
+
+  it("never triggers once the give-up marker has posted, even on a failing check", async () => {
+    const { exec } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [[]],
+        [comments(50)]: [[{ body: REFINEMENT_GIVE_UP_MARKER }]],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [
+        prItem({
+          number: 50,
+          statusCheckRollup: [{ status: "COMPLETED", conclusion: "FAILURE" }],
+        }),
+      ],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.openAgentPrs[0]?.refinement).toEqual({
+      rounds: 0,
+      triggerDue: false,
+      givenUp: true,
+    });
+  });
+
+  it("reads the operator-steered label and forces triggerDue false, without hiding the round count", async () => {
+    const { exec } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [[]],
+        [comments(50)]: [
+          [
+            {
+              body: REFINEMENT_ROUND_MARKER,
+              created_at: "2026-07-20T10:00:00Z",
+            },
+          ],
+        ],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [
+        prItem({
+          number: 50,
+          labels: [{ name: "operator-steered" }],
+          statusCheckRollup: [{ status: "COMPLETED", conclusion: "FAILURE" }],
+        }),
+      ],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.openAgentPrs[0]?.operatorSteered).toBe(true);
+    expect(world.openAgentPrs[0]?.refinement).toEqual({
+      rounds: 1,
+      triggerDue: false,
+      givenUp: false,
+    });
   });
 });
 
@@ -1054,6 +1395,69 @@ describe("commentConflictUnresolved", () => {
         expect.stringContaining(CONFLICT_UNRESOLVED_MARKER),
       ],
     ]);
+  });
+});
+
+describe("startRefinementRound", () => {
+  it("comments the round marker, naming the round", async () => {
+    const { exec, calls } = recordingExec();
+
+    await startRefinementRound(30, 2, exec);
+
+    expect(calls).toEqual([
+      [
+        "gh",
+        "pr",
+        "comment",
+        "30",
+        "--body",
+        expect.stringContaining(REFINEMENT_ROUND_MARKER),
+      ],
+    ]);
+    const body = calls[0]?.[5] ?? "";
+    expect(body).toContain("round 2");
+  });
+});
+
+describe("giveUpOnPr", () => {
+  it("comments the Ticket and swaps its labels first, then marks the PR given up last", async () => {
+    const { exec, calls } = recordingExec();
+
+    await giveUpOnPr(30, 5, 3, exec);
+
+    expect(calls).toEqual([
+      [
+        "gh",
+        "issue",
+        "comment",
+        "5",
+        "--body",
+        expect.stringContaining("Refinement give-up"),
+      ],
+      [
+        "gh",
+        "issue",
+        "edit",
+        "5",
+        "--remove-label",
+        READY_FOR_AGENT,
+        "--add-label",
+        READY_FOR_HUMAN,
+      ],
+      [
+        "gh",
+        "pr",
+        "comment",
+        "30",
+        "--body",
+        expect.stringContaining(REFINEMENT_GIVE_UP_MARKER),
+      ],
+    ]);
+    const ticketBody = calls[0]?.[5] ?? "";
+    expect(ticketBody).toContain("#30");
+    expect(ticketBody).toContain("3 rounds");
+    const prBody = calls[2]?.[5] ?? "";
+    expect(prBody).toContain("3 rounds");
   });
 });
 

--- a/tests/adapters/worker.test.ts
+++ b/tests/adapters/worker.test.ts
@@ -5,13 +5,16 @@ import { describe, expect, it } from "vitest";
 import type { Exec } from "../../src/adapters/tracker.js";
 import {
   branchCommitSubjects,
+  type ClaudeRunConfig,
   type ConflictWorkerConfig,
   conflictWorkerPrompt,
   dispatchConflictWorker,
+  dispatchRefinementWorker,
   dispatchWorker,
   probeEnvironment,
   pushAgentBranch,
   realSpawnWorkerProcess,
+  refinementWorkerPrompt,
   type SpawnWorkerProcess,
   type WorkerConfig,
   type WorkerProcessExit,
@@ -735,6 +738,182 @@ describe("dispatchConflictWorker", () => {
     expect(calls.slice(-2)).toEqual([
       ["git", "-C", CONFLICT_WT, "rebase", "--abort"],
       ["git", "worktree", "remove", "--force", CONFLICT_WT],
+    ]);
+  });
+});
+
+const REFINEMENT_WT = ".border-collie/refinement-worktrees/pr-30";
+const REFINEMENT_TRANSCRIPT =
+  ".border-collie/transcripts/pr-30-refinement-round-1.jsonl";
+const REFINEMENT_CONFIG: ClaudeRunConfig = {
+  model: "sonnet",
+  timeoutMs: 60_000,
+  stallMs: 30_000,
+  maxTurns: 200,
+};
+
+describe("refinementWorkerPrompt", () => {
+  it("investigates checks and review feedback, and pins the do-not-push contract", () => {
+    const prompt = refinementWorkerPrompt();
+
+    expect(prompt).toContain("failing check");
+    expect(prompt).toContain("review");
+    expect(prompt).toContain("do not push");
+  });
+});
+
+describe("dispatchRefinementWorker", () => {
+  it("checks out the PR's head branch (no rebase), runs claude, and cleans up", async () => {
+    const { exec, calls } = fakeExec({ newCommits: "1" });
+    const { spawn, requests } = fakeSpawn(0);
+
+    await dispatchRefinementWorker(
+      30,
+      3,
+      HEAD_REF,
+      1,
+      REFINEMENT_CONFIG,
+      exec,
+      spawn,
+    );
+
+    expect(calls).toEqual([
+      ["git", "worktree", "remove", "--force", REFINEMENT_WT],
+      ["git", "worktree", "prune"],
+      ["git", "fetch", "origin"],
+      [
+        "git",
+        "worktree",
+        "add",
+        REFINEMENT_WT,
+        "-B",
+        HEAD_REF,
+        `origin/${HEAD_REF}`,
+      ],
+      ["git", "rev-parse", HEAD_REF],
+      ["git", "rev-list", "--count", `base-sha..${HEAD_REF}`],
+      ["git", "worktree", "remove", "--force", REFINEMENT_WT],
+    ]);
+    expect(requests[0]).toMatchObject({
+      cmd: "claude",
+      cwd: REFINEMENT_WT,
+      transcriptPath: REFINEMENT_TRANSCRIPT,
+    });
+    expect(requests[0]?.args).toContain(refinementWorkerPrompt());
+    expect(requests[0]?.args).toContain("sonnet");
+  });
+
+  it("namespaces the transcript per round, so a later round never clobbers an earlier one's evidence", async () => {
+    const { exec } = fakeExec({ newCommits: "1" });
+    const { spawn, requests } = fakeSpawn(0);
+
+    await dispatchRefinementWorker(
+      30,
+      3,
+      HEAD_REF,
+      2,
+      REFINEMENT_CONFIG,
+      exec,
+      spawn,
+    );
+
+    expect(requests[0]?.transcriptPath).toBe(
+      ".border-collie/transcripts/pr-30-refinement-round-2.jsonl",
+    );
+  });
+
+  it("logs the worktree and transcript paths at debug once the worktree exists, before spawning", async () => {
+    const { exec } = fakeExec({ newCommits: "1" });
+    const { spawn } = fakeSpawn(0);
+    const { log, events } = recordingLog();
+
+    await dispatchRefinementWorker(
+      30,
+      3,
+      HEAD_REF,
+      1,
+      REFINEMENT_CONFIG,
+      exec,
+      spawn,
+      log,
+    );
+
+    expect(events).toEqual([
+      {
+        kind: "refinement-worker-paths",
+        level: "debug",
+        msg: `Refinement Worker for PR #30 (round 1): worktree ${REFINEMENT_WT}, transcript ${REFINEMENT_TRANSCRIPT}`,
+        pr: 30,
+        round: 1,
+        worktree: REFINEMENT_WT,
+        transcript: REFINEMENT_TRANSCRIPT,
+      },
+    ]);
+  });
+
+  it("reports the commits the Worker added, for the caller to judge whether to push", async () => {
+    const { exec } = fakeExec({ newCommits: "2" });
+    const { spawn } = fakeSpawn(0);
+
+    const outcome = await dispatchRefinementWorker(
+      30,
+      3,
+      HEAD_REF,
+      1,
+      REFINEMENT_CONFIG,
+      exec,
+      spawn,
+    );
+
+    expect(outcome).toEqual({
+      pr: 30,
+      ticket: 3,
+      headRef: HEAD_REF,
+      transcript: REFINEMENT_TRANSCRIPT,
+      exitCode: 0,
+      newCommits: 2,
+    });
+  });
+
+  it("reports zero commits when the Worker changed nothing", async () => {
+    const { exec } = fakeExec({ newCommits: "0" });
+    const { spawn } = fakeSpawn(0);
+
+    const outcome = await dispatchRefinementWorker(
+      30,
+      3,
+      HEAD_REF,
+      1,
+      REFINEMENT_CONFIG,
+      exec,
+      spawn,
+    );
+
+    expect(outcome.newCommits).toBe(0);
+  });
+
+  it("still removes the worktree when spawning throws, then rethrows", async () => {
+    const { exec, calls } = fakeExec({ newCommits: "0" });
+    const { spawn } = fakeSpawn(new Error("spawn claude ENOENT"));
+
+    await expect(
+      dispatchRefinementWorker(
+        30,
+        3,
+        HEAD_REF,
+        1,
+        REFINEMENT_CONFIG,
+        exec,
+        spawn,
+      ),
+    ).rejects.toThrow("ENOENT");
+
+    expect(calls.at(-1)).toEqual([
+      "git",
+      "worktree",
+      "remove",
+      "--force",
+      REFINEMENT_WT,
     ]);
   });
 });

--- a/tests/app/act.test.ts
+++ b/tests/app/act.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { Exec } from "../../src/adapters/tracker.js";
-import type { ConflictOutcome } from "../../src/adapters/worker.js";
+import type {
+  ConflictOutcome,
+  RefinementOutcome,
+} from "../../src/adapters/worker.js";
 import {
   act,
   type DispatchConflictWorker,
+  type DispatchRefinementWorker,
   type DispatchWorker,
   type IntervalScheduler,
   type OpenPr,
@@ -14,6 +18,10 @@ import {
   CLAIM_LABEL,
   CLAIM_MARKER,
   CONFLICT_UNRESOLVED_MARKER,
+  READY_FOR_AGENT,
+  READY_FOR_HUMAN,
+  REFINEMENT_GIVE_UP_MARKER,
+  REFINEMENT_ROUND_MARKER,
   RELEASE_MARKER,
   VOID_MARKER,
   type WorkerOutcome,
@@ -86,6 +94,10 @@ const noConflict: DispatchConflictWorker = async (pr) => {
   throw new Error(`unexpected conflict dispatch of PR #${pr}`);
 };
 
+const noRefinement: DispatchRefinementWorker = async (pr) => {
+  throw new Error(`unexpected Refinement dispatch of PR #${pr}`);
+};
+
 /** Records which outcomes reach PR opening; answers with a predictable URL. */
 function recordingOpenPr(): { openPr: OpenPr; opened: number[] } {
   const opened: number[] = [];
@@ -134,6 +146,21 @@ function conflictOutcome(
   };
 }
 
+function refinementOutcome(
+  pr: number,
+  overrides: Partial<RefinementOutcome> = {},
+): RefinementOutcome {
+  return {
+    pr,
+    ticket: pr,
+    headRef: `border-collie/ticket-${pr}-attempt-1`,
+    transcript: `.border-collie/transcripts/pr-${pr}-refinement-round-1.jsonl`,
+    exitCode: 0,
+    newCommits: 1,
+    ...overrides,
+  };
+}
+
 describe("act", () => {
   it("executes releases and claims in plan order via the tracker", async () => {
     const { exec, calls } = recordingExec();
@@ -149,6 +176,7 @@ describe("act", () => {
         dispatch: noDispatch,
         openPr,
         dispatchConflict: noConflict,
+        dispatchRefinement: noRefinement,
         exec,
         now,
         scheduleInterval,
@@ -195,6 +223,7 @@ describe("act", () => {
         dispatch: noDispatch,
         openPr,
         dispatchConflict: noConflict,
+        dispatchRefinement: noRefinement,
         exec,
         now,
         scheduleInterval,
@@ -231,6 +260,7 @@ describe("act", () => {
       dispatch: noDispatch,
       openPr,
       dispatchConflict: noConflict,
+      dispatchRefinement: noRefinement,
       exec,
       now,
       scheduleInterval,
@@ -275,6 +305,7 @@ describe("act", () => {
         dispatch,
         openPr,
         dispatchConflict: noConflict,
+        dispatchRefinement: noRefinement,
         exec,
         now,
         scheduleInterval,
@@ -377,6 +408,7 @@ describe("act", () => {
       dispatch,
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
+      dispatchRefinement: noRefinement,
       exec,
       now,
       scheduleInterval,
@@ -403,6 +435,7 @@ describe("act", () => {
       dispatch: noDispatch,
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
+      dispatchRefinement: noRefinement,
       exec,
       now,
       scheduleInterval,
@@ -449,6 +482,7 @@ describe("act", () => {
       dispatch,
       openPr,
       dispatchConflict: noConflict,
+      dispatchRefinement: noRefinement,
       exec,
       now,
       scheduleInterval,
@@ -473,6 +507,7 @@ describe("act", () => {
       dispatch,
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
+      dispatchRefinement: noRefinement,
       exec,
       now,
       scheduleInterval,
@@ -514,6 +549,7 @@ describe("act", () => {
         dispatch,
         openPr: recordingOpenPr().openPr,
         dispatchConflict: noConflict,
+        dispatchRefinement: noRefinement,
         exec,
         now,
         scheduleInterval,
@@ -541,6 +577,7 @@ describe("act", () => {
       dispatch,
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
+      dispatchRefinement: noRefinement,
       exec,
       now,
       scheduleInterval,
@@ -569,6 +606,7 @@ describe("act", () => {
           dispatch,
           openPr,
           dispatchConflict: noConflict,
+          dispatchRefinement: noRefinement,
           exec,
           now,
           scheduleInterval,
@@ -595,6 +633,7 @@ describe("act", () => {
         dispatch,
         openPr,
         dispatchConflict: noConflict,
+        dispatchRefinement: noRefinement,
         exec,
         now,
         scheduleInterval,
@@ -625,6 +664,7 @@ describe("act: heartbeat", () => {
       dispatch: noDispatch,
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
+      dispatchRefinement: noRefinement,
       exec,
       now,
       scheduleInterval: scheduler.scheduleInterval,
@@ -652,6 +692,7 @@ describe("act: heartbeat", () => {
       dispatch,
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
+      dispatchRefinement: noRefinement,
       exec,
       now,
       scheduleInterval: scheduler.scheduleInterval,
@@ -695,6 +736,7 @@ describe("act: heartbeat", () => {
       dispatch,
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
+      dispatchRefinement: noRefinement,
       exec,
       now: () => clock.ms,
       scheduleInterval: scheduler.scheduleInterval,
@@ -751,6 +793,7 @@ describe("act: heartbeat", () => {
         dispatch,
         openPr,
         dispatchConflict: noConflict,
+        dispatchRefinement: noRefinement,
         exec,
         now,
         scheduleInterval: scheduler.scheduleInterval,
@@ -787,6 +830,7 @@ describe("act: heartbeat", () => {
         dispatch,
         openPr: recordingOpenPr().openPr,
         dispatchConflict: noConflict,
+        dispatchRefinement: noRefinement,
         exec,
         now,
         scheduleInterval: scheduler.scheduleInterval,
@@ -807,6 +851,7 @@ describe("act: PR upkeep", () => {
       dispatch: noDispatch,
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
+      dispatchRefinement: noRefinement,
       exec,
       now,
       scheduleInterval,
@@ -832,6 +877,7 @@ describe("act: PR upkeep", () => {
       dispatch: noDispatch,
       openPr: recordingOpenPr().openPr,
       dispatchConflict: noConflict,
+      dispatchRefinement: noRefinement,
       exec,
       now,
       scheduleInterval,
@@ -871,6 +917,7 @@ describe("act: PR upkeep", () => {
         dispatch: noDispatch,
         openPr: recordingOpenPr().openPr,
         dispatchConflict,
+        dispatchRefinement: noRefinement,
         exec,
         now,
         scheduleInterval,
@@ -918,6 +965,7 @@ describe("act: PR upkeep", () => {
         dispatch: noDispatch,
         openPr: recordingOpenPr().openPr,
         dispatchConflict,
+        dispatchRefinement: noRefinement,
         exec,
         now,
         scheduleInterval,
@@ -989,6 +1037,7 @@ describe("act: PR upkeep", () => {
         dispatch,
         openPr: recordingOpenPr().openPr,
         dispatchConflict,
+        dispatchRefinement: noRefinement,
         exec,
         now,
         scheduleInterval,
@@ -1026,6 +1075,293 @@ describe("act: PR upkeep", () => {
           dispatch,
           openPr: recordingOpenPr().openPr,
           dispatchConflict,
+          dispatchRefinement: noRefinement,
+          exec,
+          now,
+          scheduleInterval,
+          log,
+        },
+      ),
+    ).rejects.toThrow("claude ENOENT");
+
+    expect(msgs(events)).toContain(
+      "Worker succeeded: 2 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
+    );
+  });
+});
+
+describe("act: Refinement", () => {
+  it("posts the round marker before dispatching the Refinement Worker", async () => {
+    const { exec, calls } = recordingExec();
+    const { log, events } = recordingLog();
+    let commentedBeforeDispatch = false;
+    const dispatchRefinement: DispatchRefinementWorker = async (
+      pr,
+      ticket,
+      headRef,
+    ) => {
+      commentedBeforeDispatch = calls.length === 1;
+      return refinementOutcome(pr, { ticket, headRef, newCommits: 0 });
+    };
+
+    await act(
+      [
+        {
+          type: "refine-pr",
+          pr: 30,
+          ticket: 3,
+          headRef: "border-collie/ticket-3-attempt-1",
+          round: 1,
+        },
+      ],
+      {
+        dispatch: noDispatch,
+        openPr: recordingOpenPr().openPr,
+        dispatchConflict: noConflict,
+        dispatchRefinement,
+        exec,
+        now,
+        scheduleInterval,
+        log,
+      },
+    );
+
+    expect(commentedBeforeDispatch).toBe(true);
+    expect(calls).toEqual([
+      [
+        "gh",
+        "pr",
+        "comment",
+        "30",
+        "--body",
+        expect.stringContaining(REFINEMENT_ROUND_MARKER),
+      ],
+    ]);
+    expect(events.map((e) => e.kind)).toEqual([
+      "refinement-round-started",
+      "refinement-outcome",
+    ]);
+    expect(msgs(events)).toEqual([
+      "started Refinement round 1 for PR #30 (ticket #3)",
+      "Refinement Worker finished: 0 new commits on border-collie/ticket-3-attempt-1 (transcript: .border-collie/transcripts/pr-30-refinement-round-1.jsonl)",
+    ]);
+  });
+
+  it("pushes the branch when the Refinement round commits a fix", async () => {
+    const { exec, calls } = recordingExec();
+    const { log, events } = recordingLog();
+    const dispatchRefinement: DispatchRefinementWorker = async (
+      pr,
+      ticket,
+      headRef,
+    ) => refinementOutcome(pr, { ticket, headRef, newCommits: 2 });
+
+    await act(
+      [
+        {
+          type: "refine-pr",
+          pr: 30,
+          ticket: 3,
+          headRef: "border-collie/ticket-3-attempt-1",
+          round: 1,
+        },
+      ],
+      {
+        dispatch: noDispatch,
+        openPr: recordingOpenPr().openPr,
+        dispatchConflict: noConflict,
+        dispatchRefinement,
+        exec,
+        now,
+        scheduleInterval,
+        log,
+      },
+    );
+
+    expect(calls.at(-1)).toEqual([
+      "git",
+      "push",
+      "--force",
+      "origin",
+      "border-collie/ticket-3-attempt-1",
+    ]);
+    expect(events.map((e) => e.kind)).toEqual([
+      "refinement-round-started",
+      "refinement-outcome",
+      "refinement-pushed",
+    ]);
+  });
+
+  it("does not push when the Refinement round committed nothing", async () => {
+    const { exec, calls } = recordingExec();
+    const { log, events } = recordingLog();
+    const dispatchRefinement: DispatchRefinementWorker = async (
+      pr,
+      ticket,
+      headRef,
+    ) => refinementOutcome(pr, { ticket, headRef, newCommits: 0 });
+
+    await act(
+      [
+        {
+          type: "refine-pr",
+          pr: 30,
+          ticket: 3,
+          headRef: "border-collie/ticket-3-attempt-1",
+          round: 1,
+        },
+      ],
+      {
+        dispatch: noDispatch,
+        openPr: recordingOpenPr().openPr,
+        dispatchConflict: noConflict,
+        dispatchRefinement,
+        exec,
+        now,
+        scheduleInterval,
+        log,
+      },
+    );
+
+    expect(calls.some((c) => c[1] === "push")).toBe(false);
+    expect(events.map((e) => e.kind)).not.toContain("refinement-pushed");
+  });
+
+  it("gives up Refining via the tracker: Ticket comment, label swap, then the PR's give-up marker", async () => {
+    const { exec, calls } = recordingExec();
+    const { log, events } = recordingLog();
+
+    await act([{ type: "refinement-give-up", pr: 30, ticket: 3, rounds: 3 }], {
+      dispatch: noDispatch,
+      openPr: recordingOpenPr().openPr,
+      dispatchConflict: noConflict,
+      dispatchRefinement: noRefinement,
+      exec,
+      now,
+      scheduleInterval,
+      log,
+    });
+
+    expect(calls).toEqual([
+      [
+        "gh",
+        "issue",
+        "comment",
+        "3",
+        "--body",
+        expect.stringContaining("Refinement give-up"),
+      ],
+      [
+        "gh",
+        "issue",
+        "edit",
+        "3",
+        "--remove-label",
+        READY_FOR_AGENT,
+        "--add-label",
+        READY_FOR_HUMAN,
+      ],
+      [
+        "gh",
+        "pr",
+        "comment",
+        "30",
+        "--body",
+        expect.stringContaining(REFINEMENT_GIVE_UP_MARKER),
+      ],
+    ]);
+    expect(events).toEqual([
+      {
+        kind: "refinement-give-up",
+        level: "warn",
+        msg: "gave up Refining PR #30 after 3 rounds (ticket #3 → ready-for-human)",
+        pr: 30,
+        ticket: 3,
+        rounds: 3,
+      },
+    ]);
+  });
+
+  it("runs Refinement Workers concurrently with dispatch Workers and reports both", async () => {
+    const { exec } = recordingExec();
+    const { log, events } = recordingLog();
+    const inFlight: string[] = [];
+    let bothInFlight!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      bothInFlight = resolve;
+    });
+    const dispatch: DispatchWorker = async (ticket) => {
+      inFlight.push(`worker-${ticket}`);
+      if (inFlight.length === 2) bothInFlight();
+      await gate;
+      return outcome(ticket);
+    };
+    const dispatchRefinement: DispatchRefinementWorker = async (
+      pr,
+      ticket,
+      headRef,
+    ) => {
+      inFlight.push(`refine-${pr}`);
+      if (inFlight.length === 2) bothInFlight();
+      await gate;
+      return refinementOutcome(pr, { ticket, headRef, newCommits: 1 });
+    };
+
+    await act(
+      [
+        {
+          type: "refine-pr",
+          pr: 40,
+          ticket: 4,
+          headRef: "border-collie/ticket-4-attempt-1",
+          round: 1,
+        },
+        { type: "spawn", ticket: 2, attempt: 1 },
+      ],
+      {
+        dispatch,
+        openPr: recordingOpenPr().openPr,
+        dispatchConflict: noConflict,
+        dispatchRefinement,
+        exec,
+        now,
+        scheduleInterval,
+        log,
+      },
+    );
+
+    expect(inFlight.sort()).toEqual(["refine-40", "worker-2"]);
+    expect(msgs(events)).toContain("pushed the Refinement fix");
+    expect(msgs(events)).toContain(
+      "Worker succeeded: 2 new commits on border-collie/ticket-2 (transcript: .border-collie/transcripts/ticket-2.jsonl)",
+    );
+  });
+
+  it("reports settled Workers before rethrowing a Refinement Worker's infrastructure failure", async () => {
+    const { exec } = recordingExec();
+    const { log, events } = recordingLog();
+    const dispatch: DispatchWorker = async (ticket) => outcome(ticket);
+    const dispatchRefinement: DispatchRefinementWorker = async () => {
+      throw new Error("claude ENOENT");
+    };
+
+    await expect(
+      act(
+        [
+          {
+            type: "refine-pr",
+            pr: 40,
+            ticket: 4,
+            headRef: "border-collie/ticket-4-attempt-1",
+            round: 1,
+          },
+          { type: "spawn", ticket: 2, attempt: 1 },
+        ],
+        {
+          dispatch,
+          openPr: recordingOpenPr().openPr,
+          dispatchConflict: noConflict,
+          dispatchRefinement,
           exec,
           now,
           scheduleInterval,

--- a/tests/app/run.test.ts
+++ b/tests/app/run.test.ts
@@ -37,6 +37,8 @@ function openPr(ticket: number): OpenAgentPr {
     behind: false,
     ci: "passing",
     conflictWorkerAsked: false,
+    operatorSteered: false,
+    refinement: { rounds: 0, triggerDue: false, givenUp: false },
   };
 }
 

--- a/tests/core/plan.test.ts
+++ b/tests/core/plan.test.ts
@@ -3,6 +3,7 @@ import { plan } from "../../src/core/plan.js";
 import {
   type AttemptFailure,
   CLAIM_LABEL,
+  MAX_REFINEMENT_ROUNDS,
   type MergedAgentPr,
   type OpenAgentPr,
   type Ticket,
@@ -49,6 +50,8 @@ function openPr(
     behind: false,
     ci: "passing",
     conflictWorkerAsked: false,
+    operatorSteered: false,
+    refinement: { rounds: 0, triggerDue: false, givenUp: false },
     ...overrides,
   };
 }
@@ -925,7 +928,7 @@ describe("plan: PR upkeep", () => {
     expect(actions).toEqual([{ type: "mark-ready", pr: 30, ticket: 3 }]);
   });
 
-  it("does not flip a draft while CI is pending or failing", () => {
+  it("does not flip a draft while CI is pending or failing (a failing one is Refined instead)", () => {
     const actions = plan(
       worldWithPrs(
         [
@@ -942,13 +945,26 @@ describe("plan: PR upkeep", () => {
         ],
         [
           openPr(3, { number: 30, draft: true, ci: "pending" }),
-          openPr(4, { number: 40, draft: true, ci: "failing" }),
+          openPr(4, {
+            number: 40,
+            draft: true,
+            ci: "failing",
+            refinement: { rounds: 0, triggerDue: true, givenUp: false },
+          }),
         ],
       ),
       { maxWorkers: 3, maxOpenPrs: 5 },
     );
 
-    expect(actions).toEqual([]);
+    expect(actions).toEqual([
+      {
+        type: "refine-pr",
+        pr: 40,
+        ticket: 4,
+        headRef: "border-collie/ticket-4-attempt-1",
+        round: 1,
+      },
+    ]);
   });
 
   it("updates a behind draft this tick and defers the ready flip to the next", () => {
@@ -1020,6 +1036,271 @@ describe("plan: PR upkeep", () => {
       { type: "close", ticket: 2, prUrl: "https://github.com/o/r/pull/20" },
       { type: "mark-ready", pr: 50, ticket: 5 },
       { type: "update-branch", pr: 70, ticket: 7 },
+    ]);
+  });
+});
+
+describe("plan: Refinement", () => {
+  /** A claimed ticket with an open agent PR — the backdrop every Refinement case needs. */
+  function claimedTicket(number: number): Ticket {
+    return ticket({
+      number,
+      labels: ["ready-for-agent", CLAIM_LABEL],
+      hasAgentClaim: true,
+    });
+  }
+
+  it("starts round 1 when a fresh trigger is due and no round has run yet", () => {
+    const actions = plan(
+      worldWithPrs(
+        [claimedTicket(3)],
+        [
+          openPr(3, {
+            number: 30,
+            refinement: { rounds: 0, triggerDue: true, givenUp: false },
+          }),
+        ],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([
+      {
+        type: "refine-pr",
+        pr: 30,
+        ticket: 3,
+        headRef: "border-collie/ticket-3-attempt-1",
+        round: 1,
+      },
+    ]);
+  });
+
+  it("charges the next round number when rounds have already run", () => {
+    const actions = plan(
+      worldWithPrs(
+        [claimedTicket(3)],
+        [
+          openPr(3, {
+            number: 30,
+            refinement: { rounds: 2, triggerDue: true, givenUp: false },
+          }),
+        ],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([
+      {
+        type: "refine-pr",
+        pr: 30,
+        ticket: 3,
+        headRef: "border-collie/ticket-3-attempt-1",
+        round: 3,
+      },
+    ]);
+  });
+
+  it("plans nothing when no trigger is due, whatever the round count", () => {
+    const actions = plan(
+      worldWithPrs(
+        [claimedTicket(3)],
+        [
+          openPr(3, {
+            number: 30,
+            refinement: { rounds: 1, triggerDue: false, givenUp: false },
+          }),
+        ],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it("gives up once rounds are exhausted and a trigger is still due", () => {
+    const actions = plan(
+      worldWithPrs(
+        [claimedTicket(3)],
+        [
+          openPr(3, {
+            number: 30,
+            refinement: {
+              rounds: MAX_REFINEMENT_ROUNDS,
+              triggerDue: true,
+              givenUp: false,
+            },
+          }),
+        ],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([
+      {
+        type: "refinement-give-up",
+        pr: 30,
+        ticket: 3,
+        rounds: MAX_REFINEMENT_ROUNDS,
+      },
+    ]);
+  });
+
+  it("never starts a round once Refinement has already given up, even if flagged due", () => {
+    const actions = plan(
+      worldWithPrs(
+        [claimedTicket(3)],
+        [
+          openPr(3, {
+            number: 30,
+            refinement: {
+              rounds: MAX_REFINEMENT_ROUNDS,
+              triggerDue: true,
+              givenUp: true,
+            },
+          }),
+        ],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it("skips a PR carrying the operator-steered label entirely", () => {
+    const actions = plan(
+      worldWithPrs(
+        [claimedTicket(3)],
+        [
+          openPr(3, {
+            number: 30,
+            operatorSteered: true,
+            refinement: {
+              rounds: MAX_REFINEMENT_ROUNDS,
+              triggerDue: true,
+              givenUp: false,
+            },
+          }),
+        ],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it("never Refines a conflicted PR — conflict handling is exclusive", () => {
+    const actions = plan(
+      worldWithPrs(
+        [claimedTicket(3)],
+        [
+          openPr(3, {
+            number: 30,
+            mergeable: "conflicted",
+            conflictWorkerAsked: true,
+            refinement: { rounds: 0, triggerDue: true, givenUp: false },
+          }),
+        ],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it("suppresses a due round within working hours", () => {
+    const actions = plan(
+      worldWithPrs(
+        [claimedTicket(3)],
+        [
+          openPr(3, {
+            number: 30,
+            refinement: { rounds: 0, triggerDue: true, givenUp: false },
+          }),
+        ],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5, withinWorkingHours: true },
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it("still gives up within working hours — mechanical, like Escalation", () => {
+    const actions = plan(
+      worldWithPrs(
+        [claimedTicket(3)],
+        [
+          openPr(3, {
+            number: 30,
+            refinement: {
+              rounds: MAX_REFINEMENT_ROUNDS,
+              triggerDue: true,
+              givenUp: false,
+            },
+          }),
+        ],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5, withinWorkingHours: true },
+    );
+
+    expect(actions).toEqual([
+      {
+        type: "refinement-give-up",
+        pr: 30,
+        ticket: 3,
+        rounds: MAX_REFINEMENT_ROUNDS,
+      },
+    ]);
+  });
+
+  it("does not give up within the circuit breaker's pause either — PR upkeep is suppressed wholesale", () => {
+    const actions = plan(
+      worldWithPrs(
+        [claimedTicket(3)],
+        [
+          openPr(3, {
+            number: 30,
+            refinement: {
+              rounds: MAX_REFINEMENT_ROUNDS,
+              triggerDue: true,
+              givenUp: false,
+            },
+          }),
+        ],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5, dispatchPaused: true },
+    );
+
+    expect(actions).toEqual([]);
+  });
+
+  it("Refines instead of escalating a ticket whose Attempts are already exhausted: Refinement rounds count toward no ticket's Attempt cap", () => {
+    const exhausted = ticket({
+      number: 3,
+      labels: ["ready-for-agent", CLAIM_LABEL],
+      hasAgentClaim: true,
+      agentClaimCount: 2,
+    });
+    const actions = plan(
+      worldWithPrs(
+        [exhausted],
+        [
+          openPr(3, {
+            number: 30,
+            refinement: { rounds: 0, triggerDue: true, givenUp: false },
+          }),
+        ],
+      ),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([
+      {
+        type: "refine-pr",
+        pr: 30,
+        ticket: 3,
+        headRef: "border-collie/ticket-3-attempt-1",
+        round: 1,
+      },
     ]);
   });
 });

--- a/tests/core/render.test.ts
+++ b/tests/core/render.test.ts
@@ -47,6 +47,8 @@ function openPr(ticket: number): OpenAgentPr {
     behind: false,
     ci: "passing",
     conflictWorkerAsked: false,
+    operatorSteered: false,
+    refinement: { rounds: 0, triggerDue: false, givenUp: false },
   };
 }
 
@@ -193,6 +195,8 @@ describe("buildPlanReport", () => {
         ticket({ number: 5, title: "Merged but open" }),
         ticket({ number: 6, title: "Behind base" }),
         ticket({ number: 7, title: "Green draft" }),
+        ticket({ number: 8, title: "Refining" }),
+        ticket({ number: 9, title: "Refinement exhausted" }),
       ],
       openAgentPrs: [],
       mergedAgentPrs: [],
@@ -211,6 +215,14 @@ describe("buildPlanReport", () => {
         headRef: "border-collie/ticket-6-attempt-1",
       },
       { type: "mark-ready", pr: 70, ticket: 7 },
+      {
+        type: "refine-pr",
+        pr: 80,
+        ticket: 8,
+        headRef: "border-collie/ticket-8-attempt-1",
+        round: 2,
+      },
+      { type: "refinement-give-up", pr: 90, ticket: 9, rounds: 3 },
     ];
 
     const report = buildPlanReport(config(), actionWorld, actions, {
@@ -237,6 +249,13 @@ describe("buildPlanReport", () => {
       { type: "update-branch", pr: 60, title: "Behind base" },
       { type: "conflict-worker", pr: 61, title: "Behind base" },
       { type: "mark-ready", pr: 70, title: "Green draft" },
+      { type: "refine-pr", pr: 80, title: "Refining", round: 2 },
+      {
+        type: "refinement-give-up",
+        pr: 90,
+        title: "Refinement exhausted",
+        rounds: 3,
+      },
     ]);
   });
 
@@ -305,6 +324,13 @@ describe("renderPlanReport", () => {
         { type: "update-branch", pr: 50, title: "Behind base" },
         { type: "conflict-worker", pr: 60, title: "Conflicted" },
         { type: "mark-ready", pr: 70, title: "Green draft" },
+        { type: "refine-pr", pr: 80, title: "Refining", round: 2 },
+        {
+          type: "refinement-give-up",
+          pr: 90,
+          title: "Refinement exhausted",
+          rounds: 3,
+        },
       ],
       dryRun: true,
     };
@@ -323,6 +349,8 @@ describe("renderPlanReport", () => {
         "  update PR #50 — Behind base (behind base, mechanical rebase)",
         "  conflict Worker for PR #60 — Conflicted (resolve merge conflicts)",
         "  mark PR #70 ready — Green draft (CI green)",
+        "  Refine PR #80 — Refining (round 2, failing check or review feedback)",
+        "  give up Refining PR #90 — Refinement exhausted (3 rounds exhausted → ready-for-human)",
         "Dry run: no writes performed.",
       ].join("\n"),
     );


### PR DESCRIPTION
Bounded refinement loop for agent pull requests, closing the last unplanned PR state and giving review feedback an automatic response path.

## What changed

- A failing check, a formal PR review (inline comments or a review submission), or a plain foreign comment on an open agent pull request now starts a **Refinement round**: a marker comment counts it (charged before the round's Worker dispatches, so a crash never loses the count), then a Worker runs in an isolated worktree on the PR's own branch, investigates, and commits a fix — the Orchestrator pushes it back once the round settles.
- Rounds are bounded at three per PR. Once exhausted and the PR still needs one, **Refinement give-up** fires: the ticket swaps `ready-for-agent` → `ready-for-human` with a forensic comment, and the PR gets a marker comment that vetoes every further round — the PR-scoped analogue of Escalation, kept distinct from it since a ticket with an open agent PR never reaches Escalation itself.
- A PR carrying the `operator-steered` label is skipped by the automatic loop entirely, so a human who has attached a conversational session to a PR never races it.
- This closes the hole described in the parent epic: a draft PR whose CI is failing previously matched no planned action at all (not conflicted, not behind, not green) and sat forever with no Attempt charged and no Escalation.
- Refinement rounds are not Attempts and never touch a ticket's Attempt cap or claim history.
- CONTEXT.md gains three new glossary entries: Refinement round, Refinement give-up, and Operator-steered.

## Implementation notes

- Mirrors the existing Conflict Worker pattern (a locally-dispatched headless-Claude Worker in its own worktree) rather than an external `claude-code-action` workflow, consistent with this repo's current local-only orchestrator — the cloud/Actions migration is separate, unimplemented sibling work in the parent epic.
- "Review comment" is read from two independent triggers: GitHub's formal Review flow (`pulls/{pr}/comments` and `pulls/{pr}/reviews`, checked only when it could still change the verdict — skipped once a failing check already settles it) and any foreign (non-border-collie) comment on the PR's Conversation tab, so both a literal GitHub review and a plain comment count.
- One read of a PR's comment thread now serves both the conflict-unresolved check and the Refinement signal together.

## Testing

`tsc --noEmit`, `biome check .`, and the full `vitest` suite (394 tests) all pass, plus a production build. New coverage spans `plan.ts` (round/give-up gating, working-hours and circuit-breaker suppression, Attempt-cap independence), `tracker.ts` (round counting, trigger detection from both comment sources, give-up write ordering), `worker.ts` (the Refinement Worker's dispatch shape), and `act.ts` (marker-before-dispatch ordering, conditional push, concurrent execution).

Closes #70