### PR TITLE
feat(ci): run a Worker as its own job

### DIFF
--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -1,0 +1,129 @@
+# A Worker as its own job (issue #75): one job per Ticket, taking the Ticket
+# and Attempt as explicit inputs rather than inferring them from a label or
+# an assignee event — the Orchestrator already knows what it decided to
+# dispatch, and inferring it back out would couple two systems through a
+# side effect.
+#
+# One job means one checkout with nothing shared, so the Worker runs
+# `--in-place`: no worktree, no repo-level git lock, no worktree pruning —
+# all of that exists only to isolate concurrent local Workers sharing one
+# checkout, which a dedicated job never has.
+name: Worker
+
+on:
+  workflow_dispatch:
+    inputs:
+      ticket:
+        description: Ticket (issue) number to run this Attempt against
+        required: true
+        type: string
+      attempt:
+        description: Attempt number (1-based; binds the retry ladder's model)
+        required: true
+        type: string
+      timeout_minutes:
+        description: >-
+          Wall-clock ceiling in minutes for the Worker's own watchdog
+          (mirrors worker_timeout_minutes in border-collie.json)
+        required: false
+        default: "45"
+      job_timeout_minutes:
+        description: >-
+          Wall-clock ceiling in minutes for the job itself. GitHub Actions
+          expressions cannot add a margin onto timeout_minutes at dispatch
+          time, so this is its own input — keep it a few minutes above
+          timeout_minutes, covering setup (checkout, install, build, skills)
+          before the watchdog starts and settlement (the tracker write)
+          after it fires, so GitHub Actions never races the watchdog that
+          kills the claude subprocess and settles the Attempt
+        required: false
+        default: "55"
+
+# The built-in token authenticates nothing here — checkout, the branch push,
+# and every `gh` call run under the GitHub App installation token minted
+# below, scoped to whatever the App itself was granted (contents, issues,
+# pull requests; never workflow modification, so a Worker can never rewrite
+# the workflow that runs it). Read-only so it is not a second usable
+# credential sitting alongside the session.
+permissions:
+  contents: read
+
+jobs:
+  worker:
+    name: "Worker #${{ inputs.ticket }} attempt ${{ inputs.attempt }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ fromJSON(inputs.job_timeout_minutes) }}
+    steps:
+      - name: Validate wall-clock ceilings
+        # The relationship between the two timeout inputs is load-bearing
+        # (see job_timeout_minutes above) but GitHub Actions expressions
+        # can't enforce it structurally, so it's checked here, first and
+        # cheaply, before any credential is minted or anything is installed.
+        env:
+          TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
+          JOB_TIMEOUT_MINUTES: ${{ inputs.job_timeout_minutes }}
+        run: |
+          if [ "$JOB_TIMEOUT_MINUTES" -le "$TIMEOUT_MINUTES" ]; then
+            echo "::error::job_timeout_minutes ($JOB_TIMEOUT_MINUTES) must be greater than timeout_minutes ($TIMEOUT_MINUTES) — otherwise GitHub Actions can kill the whole job before the Worker's own watchdog gets a chance to settle the Attempt"
+            exit 1
+          fi
+
+      - name: Mint a GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.BORDER_COLLIE_APP_ID }}
+          private-key: ${{ secrets.BORDER_COLLIE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm run build
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code@latest
+
+      - name: Install Worker skills
+        # The Worker prompt invokes a skill (/implement) by name with no
+        # fallback: on a runner without it, the Worker receives unhandled
+        # text and improvises rather than erroring, which surfaces as an
+        # oddly-shaped pull request instead of a clean failure.
+        run: |
+          claude plugin marketplace add mattpocock/skills
+          claude plugin install mattpocock-skills@mattpocock
+
+      - name: Run Worker
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # The uploaded log artifact's file name is set from this job's own
+          # run identifier, so an operator reading a log file name can get
+          # straight to the job that produced it.
+          BORDER_COLLIE_RUN_ID: ${{ github.run_id }}
+          # Dispatch inputs arrive as environment, never interpolated into
+          # the script body: `${{ }}` inside `run:` is textual substitution.
+          TICKET: ${{ inputs.ticket }}
+          ATTEMPT: ${{ inputs.attempt }}
+          TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
+        run: |
+          pnpm exec border-collie worker "$TICKET" "$ATTEMPT" \
+            --in-place \
+            --timeout-minutes "$TIMEOUT_MINUTES"
+
+      - name: Upload run log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: worker-log-ticket-${{ inputs.ticket }}-attempt-${{ inputs.attempt }}-${{ github.run_id }}
+          path: .border-collie/logs/*.jsonl
+          if-no-files-found: warn

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,7 +21,7 @@ Adding the `claimed` label to a ticket *before* any work begins, plus a marker c
 _Avoid_: lock, lease, assignment
 
 **Worker**:
-A fresh-context Claude Code agent session dispatched against exactly one Ticket, isolated in its own git worktree and branch. Fed nothing beyond its ticket plus repo context it discovers itself.
+A fresh-context Claude Code agent session dispatched against exactly one Ticket, on its own agent branch — isolated in a git worktree on the local path, or in a Worker job's own dedicated checkout on the cloud path (issue #75), which needs no worktree since nothing else shares it. Fed nothing beyond its ticket plus repo context it discovers itself.
 _Avoid_: agent (unqualified), subagent
 
 **Done**:

--- a/src/adapters/worker.ts
+++ b/src/adapters/worker.ts
@@ -50,6 +50,16 @@ export interface WorkerConfig extends ClaudeRunConfig {
    * turn cap and wall clock are the stoppers, this is the meter.
    */
   maxCostUsd: number;
+  /**
+   * True for a Worker job that owns its sole checkout (issue #75): the agent
+   * branch is checked out directly in the current working directory instead
+   * of an isolated worktree, and the repo-level git lock is skipped — one
+   * job means one checkout with nothing to isolate from or serialize
+   * against. False (the local path's default) keeps today's worktree
+   * isolation, which protects the operator's own checkout from a Worker
+   * running alongside it.
+   */
+  inPlace: boolean;
 }
 
 /** The headless-claude argv every Worker shares: prompt, model, turn cap, stream-json, skip-permissions. */
@@ -265,19 +275,28 @@ export async function branchCommitSubjects(
 }
 
 /**
- * Dispatch one Worker against one claimed ticket: cut an agent branch in an
- * isolated worktree, run headless claude in it streaming to a transcript,
- * then judge the outcome and remove the worktree (branch retained). The
- * branch is cut from the remote default branch's current tip (fetched fresh
- * each dispatch), never the local checkout: a ticket is Dispatchable only
- * once its blockers' PRs have merged, and that gating holds only if the
+ * Dispatch one Worker against one claimed ticket: cut an agent branch, run
+ * headless claude on it streaming to a transcript, then judge the outcome.
+ * The branch is cut from the remote default branch's current tip (fetched
+ * fresh each dispatch), never the local checkout: a ticket is Dispatchable
+ * only once its blockers' PRs have merged, and that gating holds only if the
  * Worker's base contains those merges — the local checkout goes stale the
  * moment a sibling merges mid-run. Branch and transcript are namespaced per
  * attempt so a retry leaves the failed attempt's evidence intact for
- * Escalation. `-B` and the up-front removal reset leftovers of the SAME
- * attempt from a crashed run — a local branch that never became a PR is not
- * recorded progress (ADR 0001: GitHub is the only state store), so
- * re-running the Tick supersedes it.
+ * Escalation. `-B` and the up-front reset (a stale worktree removed, or a
+ * plain branch overwritten) discard leftovers of the SAME attempt from a
+ * crashed run — a local branch that never became a PR is not recorded
+ * progress (ADR 0001: GitHub is the only state store), so re-running the
+ * Tick supersedes it.
+ *
+ * `config.inPlace` picks which of two isolation strategies runs: the local
+ * path (default) cuts an isolated worktree so a Worker never touches the
+ * operator's own checkout, locking every git phase against sibling Workers'
+ * worktree/ref operations (the repo-level lock below); a Worker job (issue
+ * #75) owns its sole checkout instead, so it checks the branch out directly
+ * in the current working directory and skips both the worktree and the
+ * lock — nothing else is running in that checkout to isolate from or
+ * serialize against.
  */
 /** No-op default for the optional `log` parameter, so every existing caller need not pass one. */
 const noopLog: Log = ((_event: LogEvent) => {}) as Log;
@@ -294,6 +313,7 @@ export async function dispatchWorker(
 ): Promise<WorkerOutcome> {
   const branch = `${AGENT_BRANCH_PREFIX}${ticket}-attempt-${config.attempt}`;
   const worktree = join(RUN_DIR, "worktrees", `ticket-${ticket}`);
+  const cwd = config.inPlace ? "." : worktree;
   const transcript = join(
     RUN_DIR,
     "transcripts",
@@ -305,41 +325,52 @@ export async function dispatchWorker(
     `ticket-${ticket}-attempt-${config.attempt}.stderr.log`,
   );
 
-  const base = await withGitLock(async () => {
-    await removeWorktree(worktree, exec);
-    await exec("git", ["worktree", "prune"]);
-    await exec("git", ["fetch", "origin"]);
-    await exec("git", [
-      "worktree",
-      "add",
-      worktree,
-      "-B",
-      branch,
-      "origin/HEAD",
-    ]);
+  // A no-op stand-in for withGitLock when there is no sibling Worker to
+  // serialize against — the git lock itself must never run on this path.
+  const gitPhase = config.inPlace
+    ? <T>(operation: () => Promise<T>): Promise<T> => operation()
+    : withGitLock;
+
+  const base = await gitPhase(async () => {
+    if (config.inPlace) {
+      await exec("git", ["fetch", "origin"]);
+      await exec("git", ["checkout", "-B", branch, "origin/HEAD"]);
+    } else {
+      await removeWorktree(worktree, exec);
+      await exec("git", ["worktree", "prune"]);
+      await exec("git", ["fetch", "origin"]);
+      await exec("git", [
+        "worktree",
+        "add",
+        worktree,
+        "-B",
+        branch,
+        "origin/HEAD",
+      ]);
+    }
     return (await exec("git", ["rev-parse", branch])).trim();
   });
-  // Logged once the worktree actually exists, so an operator can find a
-  // Worker's evidence — the worktree while it runs, the transcript any time
+  // Logged once the checkout actually exists, so an operator can find a
+  // Worker's evidence — the checkout while it runs, the transcript any time
   // after — without deriving the paths by hand.
   log({
     kind: "worker-paths",
     level: "debug",
-    msg: `Worker for #${ticket} (attempt ${config.attempt}): worktree ${worktree}, transcript ${transcript}`,
+    msg: `Worker for #${ticket} (attempt ${config.attempt}): ${config.inPlace ? "checkout" : "worktree"} ${cwd}, transcript ${transcript}`,
     ticket,
     attempt: config.attempt,
-    worktree,
+    path: cwd,
     transcript,
   });
 
   try {
     // Headless Workers cannot answer permission prompts; skipping them is
-    // what confines the blast radius to the worktree plus the operator's
+    // what confines the blast radius to the checkout plus the operator's
     // own tracker.
     const { exitCode, endedBy, stdoutTail, stderrTail } = await spawnProcess({
       cmd: "claude",
       args: claudeArgs(workerPrompt(ticket), config.model, config.maxTurns),
-      cwd: worktree,
+      cwd,
       transcriptPath: transcript,
       stderrPath: stderrLog,
       timeoutMs: config.timeoutMs,
@@ -348,7 +379,7 @@ export async function dispatchWorker(
     });
     const newCommits = Number(
       (
-        await withGitLock(() =>
+        await gitPhase(() =>
           exec("git", ["rev-list", "--count", `${base}..${branch}`]),
         )
       ).trim(),
@@ -408,7 +439,11 @@ export async function dispatchWorker(
       ok: failure === undefined && infra === undefined,
     };
   } finally {
-    await withGitLock(() => removeWorktree(worktree, exec));
+    // Nothing to clean up in-place: the checkout is the job's own, torn down
+    // with the runner rather than removed here.
+    if (!config.inPlace) {
+      await withGitLock(() => removeWorktree(worktree, exec));
+    }
   }
 }
 

--- a/src/app/tick.ts
+++ b/src/app/tick.ts
@@ -91,6 +91,11 @@ export async function tickOnce(
             stallMs: config.stallMinutes * 60_000,
             maxTurns: config.maxTurns,
             maxCostUsd: config.maxCostUsd,
+            // A Tick may dispatch several Workers concurrently into this
+            // same checkout, so each still needs its own isolated worktree —
+            // never in-place (that path is a Worker job's own dedicated
+            // checkout; see src/app/worker.ts).
+            inPlace: false,
           },
           exec,
           realSpawnWorkerProcess,

--- a/src/app/worker.ts
+++ b/src/app/worker.ts
@@ -76,12 +76,15 @@ export async function runWorkerAttempt(
  * composed the same way the Tick's act phase composes them for a dispatched
  * Worker (src/app/tick.ts), minus the concurrency that only a whole batch
  * needs. A ticket's title is read directly (no world snapshot here) for the
- * PR title `openPrForOutcome` wants.
+ * PR title `openPrForOutcome` wants. `inPlace` forwards into the dispatched
+ * Worker's config (issue #75): true for a Worker job's own dedicated
+ * checkout, false (the default) for the local path's worktree isolation.
  */
 export async function workerAttemptOnce(
   config: WorkerAttemptConfig,
   ticket: number,
   attempt: number,
+  inPlace: boolean,
   deps: { log: Log },
 ): Promise<WorkerOutcome> {
   const exec = withDebugLogging(realExec, deps.log);
@@ -97,6 +100,7 @@ export async function workerAttemptOnce(
           stallMs: config.stallMinutes * 60_000,
           maxTurns: config.maxTurns,
           maxCostUsd: config.maxCostUsd,
+          inPlace,
         },
         exec,
         realSpawnWorkerProcess,

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -34,11 +34,16 @@ export interface Context extends CommandContext {
     dryRun: boolean,
     dispatchPaused?: boolean,
   ) => Promise<TickResult>;
-  /** A Worker settling its own Attempt (issue #71); see src/app/worker.ts. */
+  /**
+   * A Worker settling its own Attempt (issue #71); see src/app/worker.ts.
+   * `inPlace` (issue #75) skips worktree isolation and the git lock for a
+   * Worker job that owns its own checkout.
+   */
   readonly runWorker: (
     config: WorkerAttemptConfig,
     ticket: number,
     attempt: number,
+    inPlace: boolean,
   ) => Promise<WorkerOutcome>;
   readonly probe: (model: string) => Promise<boolean>;
   readonly now: () => number;
@@ -108,7 +113,11 @@ function tagFor(bindings: LogBindings): string {
  *   the artifact a Worker job uploads.
  *
  * The root logger binds a run identifier matching the file's name, so every
- * record — console or file — carries it.
+ * record — console or file — carries it. The identifier is injectable via
+ * `BORDER_COLLIE_RUN_ID` (falling back to a timestamp when unset) so a
+ * Worker job (issue #75) can set it from the job's own run identifier,
+ * making the uploaded log artifact's file name correlate directly with the
+ * job an operator can click into.
  *
  * The three report kinds bypass both sinks entirely: they print as the
  * familiar unadorned block straight to the process's stdout, byte-identical
@@ -125,11 +134,13 @@ function tagFor(bindings: LogBindings): string {
 function buildLog(
   cliProcess: StricliProcess,
   cwd: string,
+  env: NodeJS.ProcessEnv,
 ): {
   log: Log;
   setVerbose: (verbose: boolean) => void;
 } {
-  const runId = new Date().toISOString().replace(/[:.]/g, "-");
+  const runId =
+    env.BORDER_COLLIE_RUN_ID ?? new Date().toISOString().replace(/[:.]/g, "-");
   const rootLogger = new Logger({
     type: "hidden",
     stack: { capture: "off" },
@@ -182,9 +193,12 @@ function buildLog(
 }
 
 /** The real context: today's collaborators, wired exactly as the entry point wired them before. */
-export function buildRealContext(cwd: string = process.cwd()): Context {
+export function buildRealContext(
+  cwd: string = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+): Context {
   const cliProcess = nodeProcessAdapter();
-  const { log, setVerbose } = buildLog(cliProcess, cwd);
+  const { log, setVerbose } = buildLog(cliProcess, cwd, env);
   const now = () => Date.now();
   const scheduleInterval: IntervalScheduler = (ms, callback) => {
     const id = setInterval(callback, ms);
@@ -197,8 +211,8 @@ export function buildRealContext(cwd: string = process.cwd()): Context {
       resolveWorkerConfig(loadConfigFile(cwd), flags),
     tick: (config, dryRun, dispatchPaused) =>
       tickOnce(config, dryRun, dispatchPaused, { log, now, scheduleInterval }),
-    runWorker: (config, ticket, attempt) =>
-      workerAttemptOnce(config, ticket, attempt, { log }),
+    runWorker: (config, ticket, attempt, inPlace) =>
+      workerAttemptOnce(config, ticket, attempt, inPlace, { log }),
     probe: (model) => probeEnvironment(model),
     now,
     sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),

--- a/src/cli/worker-command.ts
+++ b/src/cli/worker-command.ts
@@ -9,16 +9,23 @@ import { WORKER_DEATH_PROSE } from "./docs.js";
 import { parseInteger, sharedFlags } from "./flags.js";
 
 /**
- * The worker command's own flag surface: model overrides plus verbosity, the
- * three `sharedFlags` entries that still mean something for one Worker
+ * The worker command's own flag surface: model overrides plus verbosity,
+ * the three `sharedFlags` entries that still mean something for one Worker
  * running one Attempt. Scope and concurrency (`--parent`, `--all`,
- * `--max-workers`, `--max-open-prs`, `--poll-seconds`) plan a Tick's dispatch
- * — irrelevant here, so they're left off rather than accepted and ignored.
+ * `--max-workers`, `--max-open-prs`, `--poll-seconds`) plan a Tick's
+ * dispatch — irrelevant here, so they're left off rather than accepted and
+ * ignored. `--timeout-minutes` and `--in-place` are this command's own,
+ * defined below rather than in `sharedFlags`: a Worker job's own wall-clock
+ * ceiling and dedicated checkout (issue #75) are concerns `tick`/`run`
+ * never have, and putting them in `sharedFlags` would silently let them
+ * override every Worker in a batch Tick too.
  */
 export interface WorkerFlags {
   model?: string;
   retryModel?: string;
+  timeoutMinutes?: number;
   verbose: boolean;
+  inPlace: boolean;
 }
 
 const { model, retryModel, verbose } = sharedFlags;
@@ -35,6 +42,8 @@ function resolveConfigFromWorkerFlags(
   const configFlags: Flags = {};
   if (flags.model !== undefined) configFlags.model = flags.model;
   if (flags.retryModel !== undefined) configFlags.retryModel = flags.retryModel;
+  if (flags.timeoutMinutes !== undefined)
+    configFlags.timeoutMinutes = flags.timeoutMinutes;
   try {
     return context.loadWorkerConfig(configFlags);
   } catch (error) {
@@ -53,7 +62,7 @@ async function workerHandler(
   const config = resolveConfigFromWorkerFlags(this, flags);
   if (config instanceof Error) return config;
 
-  const outcome = await this.runWorker(config, ticket, attempt);
+  const outcome = await this.runWorker(config, ticket, attempt, flags.inPlace);
   if (!outcome.ok) {
     this.process.exitCode = 1;
   }
@@ -81,18 +90,40 @@ export const workerCommand = buildCommand<
         },
       ],
     },
-    flags: { model, retryModel, verbose },
+    flags: {
+      model,
+      retryModel,
+      timeoutMinutes: {
+        kind: "parsed",
+        parse: parseInteger,
+        brief:
+          "wall-clock ceiling for this Worker, in minutes (default 45, overrides config file)",
+        placeholder: "n",
+        optional: true,
+      },
+      verbose,
+      inPlace: {
+        kind: "boolean",
+        brief:
+          "check the agent branch out in the current directory instead of an isolated worktree (for a Worker job with its own dedicated checkout)",
+        default: false,
+      },
+    },
   },
   docs: {
     brief:
       "run one Worker session for a Ticket and Attempt, settling it itself",
-    fullDescription: `worker runs a single Worker session against one Ticket and Attempt in the
-current working directory — an isolated worktree on an agent branch, running
-headless claude against exactly that ticket — then settles the outcome
-itself instead of leaving it for a Tick to read back: a successful Attempt's
-branch is pushed and opened as a draft PR that closes its ticket on merge,
-its body taken from the Worker's final message (mechanical fallback: ticket
-+ commit subjects).
+    fullDescription: `worker runs a single Worker session against one Ticket and Attempt on an
+agent branch, running headless claude against exactly that ticket, then
+settles the outcome itself instead of leaving it for a Tick to read back: a
+successful Attempt's branch is pushed and opened as a draft PR that closes
+its ticket on merge, its body taken from the Worker's final message
+(mechanical fallback: ticket + commit subjects). By default the branch is cut
+in an isolated worktree so the operator's own checkout is untouched;
+--in-place checks it out directly in the current working directory instead,
+for a Worker job whose checkout is already dedicated to this one Attempt —
+skipping the worktree and the repo-level git lock, which a single checkout
+has nothing to isolate from or serialize against.
 
 ${WORKER_DEATH_PROSE} settling here means the same tracker write a Tick's
 act phase would perform, through the same shared unit — nothing is

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -26,6 +26,7 @@ export interface Flags {
   all?: boolean;
   model?: string;
   retryModel?: string;
+  timeoutMinutes?: number;
 }
 
 export type Scope = { kind: "parent"; parent: number } | { kind: "all" };
@@ -171,7 +172,9 @@ function resolveSharedConfig(
     "retry_model",
   );
   const timeoutMinutes = asPositiveInt(
-    file.worker_timeout_minutes ?? DEFAULT_TIMEOUT_MINUTES,
+    flags.timeoutMinutes ??
+      file.worker_timeout_minutes ??
+      DEFAULT_TIMEOUT_MINUTES,
     "worker_timeout_minutes",
   );
   const stallMinutes = asPositiveInt(

--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -78,7 +78,8 @@ export type LogEvent = LogEventBase &
         kind: "worker-paths";
         ticket: number;
         attempt: number;
-        worktree: string;
+        /** The worktree (local path) or the checkout itself (`--in-place`, issue #75) the Worker ran in. */
+        path: string;
         transcript: string;
       }
     | {

--- a/tests/adapters/worker.test.ts
+++ b/tests/adapters/worker.test.ts
@@ -44,6 +44,7 @@ const CONFIG: WorkerConfig = {
   stallMs: 30_000,
   maxTurns: 200,
   maxCostUsd: 20,
+  inPlace: false,
 };
 
 /**
@@ -153,7 +154,7 @@ describe("dispatchWorker", () => {
         msg: `Worker for #4 (attempt 1): worktree ${WORKTREE}, transcript ${TRANSCRIPT}`,
         ticket: 4,
         attempt: 1,
-        worktree: WORKTREE,
+        path: WORKTREE,
         transcript: TRANSCRIPT,
       },
     ]);
@@ -524,6 +525,75 @@ describe("dispatchRemoteWorker", () => {
         "attempt=2",
       ],
     ]);
+  });
+});
+
+describe("dispatchWorker (in-place, issue #75)", () => {
+  const IN_PLACE_CONFIG: WorkerConfig = { ...CONFIG, inPlace: true };
+
+  it("checks the branch out directly in the current directory, running claude there — no worktree, no lock", async () => {
+    const { exec, calls } = fakeExec({ newCommits: "3" });
+    const { spawn, requests } = fakeSpawn(0);
+
+    await dispatchWorker(4, IN_PLACE_CONFIG, exec, spawn);
+
+    expect(calls).toEqual([
+      ["git", "fetch", "origin"],
+      ["git", "checkout", "-B", BRANCH, "origin/HEAD"],
+      ["git", "rev-parse", BRANCH],
+      ["git", "rev-list", "--count", `base-sha..${BRANCH}`],
+    ]);
+    expect(requests[0]).toMatchObject({ cwd: ".", transcriptPath: TRANSCRIPT });
+  });
+
+  it("logs the checkout (not worktree) and transcript paths at debug, before spawning", async () => {
+    const { exec } = fakeExec({ newCommits: "3" });
+    const { spawn } = fakeSpawn(0);
+    const { log, events } = recordingLog();
+
+    await dispatchWorker(4, IN_PLACE_CONFIG, exec, spawn, log);
+
+    expect(events).toEqual([
+      {
+        kind: "worker-paths",
+        level: "debug",
+        msg: `Worker for #4 (attempt 1): checkout ., transcript ${TRANSCRIPT}`,
+        ticket: 4,
+        attempt: 1,
+        path: ".",
+        transcript: TRANSCRIPT,
+      },
+    ]);
+  });
+
+  it("never removes a worktree, even when spawning throws, then rethrows", async () => {
+    const { exec, calls } = fakeExec();
+    const { spawn } = fakeSpawn(new Error("spawn claude ENOENT"));
+
+    await expect(
+      dispatchWorker(4, IN_PLACE_CONFIG, exec, spawn),
+    ).rejects.toThrow("ENOENT");
+
+    expect(calls).toEqual([
+      ["git", "fetch", "origin"],
+      ["git", "checkout", "-B", BRANCH, "origin/HEAD"],
+      ["git", "rev-parse", BRANCH],
+    ]);
+  });
+
+  it("succeeds when the process exits cleanly and new commits exist on the branch", async () => {
+    const { exec } = fakeExec({ newCommits: "3" });
+    const { spawn } = fakeSpawn(0);
+
+    const outcome = await dispatchWorker(4, IN_PLACE_CONFIG, exec, spawn);
+
+    expect(outcome).toMatchObject({
+      ticket: 4,
+      branch: BRANCH,
+      base: "base-sha",
+      newCommits: 3,
+      ok: true,
+    });
   });
 });
 

--- a/tests/cli/app.test.ts
+++ b/tests/cli/app.test.ts
@@ -99,6 +99,7 @@ interface FakeContext {
     config: WorkerAttemptConfig;
     ticket: number;
     attempt: number;
+    inPlace: boolean;
   }[];
   probeCalls: string[];
   events: LogEvent[];
@@ -124,6 +125,7 @@ function fakeContext(
     config: WorkerAttemptConfig;
     ticket: number;
     attempt: number;
+    inPlace: boolean;
   }[] = [];
   const probeCalls: string[] = [];
   const events: LogEvent[] = [];
@@ -164,8 +166,8 @@ function fakeContext(
         dispatchPaused: dispatchPaused ?? false,
       };
     },
-    runWorker: async (config, ticket, attempt) => {
-      runWorkerCalls.push({ config, ticket, attempt });
+    runWorker: async (config, ticket, attempt, inPlace) => {
+      runWorkerCalls.push({ config, ticket, attempt, inPlace });
       return runWorkerOutcome;
     },
     probe: async (model) => {
@@ -351,7 +353,7 @@ describe("command routing", () => {
     await runCli(["worker", "7", "2"], fake.context);
 
     expect(fake.runWorkerCalls).toEqual([
-      { config: FAKE_RESOLVED_CONFIG, ticket: 7, attempt: 2 },
+      { config: FAKE_RESOLVED_CONFIG, ticket: 7, attempt: 2, inPlace: false },
     ]);
   });
 });
@@ -370,6 +372,14 @@ describe("worker command", () => {
     ]);
   });
 
+  it("forwards a --timeout-minutes override to config resolution", async () => {
+    const fake = fakeContext();
+
+    await runCli(["worker", "7", "1", "--timeout-minutes", "50"], fake.context);
+
+    expect(fake.loadConfigCalls).toEqual([{ timeoutMinutes: 50 }]);
+  });
+
   it("omits unset flags from config resolution", async () => {
     const fake = fakeContext();
 
@@ -384,6 +394,22 @@ describe("worker command", () => {
     await runCli(["worker", "7", "1", "--verbose"], fake.context);
 
     expect(fake.verbosityCalls).toEqual([true]);
+  });
+
+  it("defaults --in-place to false, isolating the local path in a worktree", async () => {
+    const fake = fakeContext();
+
+    await runCli(["worker", "7", "1"], fake.context);
+
+    expect(fake.runWorkerCalls[0]?.inPlace).toBe(false);
+  });
+
+  it("forwards --in-place through to runWorker, for a Worker job's own checkout", async () => {
+    const fake = fakeContext();
+
+    await runCli(["worker", "7", "1", "--in-place"], fake.context);
+
+    expect(fake.runWorkerCalls[0]?.inPlace).toBe(true);
   });
 
   it("rejects a non-integer ticket without calling runWorker", async () => {
@@ -567,6 +593,34 @@ describe("help", () => {
 
     expect(fake.stdout()).not.toContain("--max-workers");
     expect(fake.stdout()).not.toContain("--parent");
+  });
+
+  it("offers --in-place only on worker's per-command help, not tick's or run's", async () => {
+    const worker = fakeContext();
+    await runCli(["worker", "--help"], worker.context);
+    expect(worker.stdout()).toContain("--in-place");
+
+    const tick = fakeContext();
+    await runCli(["tick", "--help"], tick.context);
+    expect(tick.stdout()).not.toContain("--in-place");
+
+    const run = fakeContext();
+    await runCli(["run", "--help"], run.context);
+    expect(run.stdout()).not.toContain("--in-place");
+  });
+
+  it("offers --timeout-minutes only on worker's per-command help, not tick's or run's", async () => {
+    const worker = fakeContext();
+    await runCli(["worker", "--help"], worker.context);
+    expect(worker.stdout()).toContain("--timeout-minutes");
+
+    const tick = fakeContext();
+    await runCli(["tick", "--help"], tick.context);
+    expect(tick.stdout()).not.toContain("--timeout-minutes");
+
+    const run = fakeContext();
+    await runCli(["run", "--help"], run.context);
+    expect(run.stdout()).not.toContain("--timeout-minutes");
   });
 });
 

--- a/tests/cli/context.test.ts
+++ b/tests/cli/context.test.ts
@@ -70,4 +70,42 @@ describe("buildRealContext's durable log file", () => {
     expect(contents).not.toContain("x-access-token");
     expect(contents).toContain("https://<redacted>@github.com/o/r.git");
   });
+
+  it("names the log file from BORDER_COLLIE_RUN_ID when set, so it correlates with the job that produced it (issue #75)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "border-collie-context-test-"));
+
+    const context = buildRealContext(dir, { BORDER_COLLIE_RUN_ID: "12345678" });
+    context.log({
+      kind: "claim",
+      level: "debug",
+      ticket: 1,
+      msg: "claimed #1",
+    });
+
+    const logsDir = join(dir, ".border-collie", "logs");
+    await vi.waitFor(() => {
+      expect(existsSync(logsDir)).toBe(true);
+    });
+    expect(readdirSync(logsDir)).toEqual(["12345678.jsonl"]);
+  });
+
+  it("falls back to a timestamp-derived name when BORDER_COLLIE_RUN_ID is unset", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "border-collie-context-test-"));
+
+    const context = buildRealContext(dir, {});
+    context.log({
+      kind: "claim",
+      level: "debug",
+      ticket: 1,
+      msg: "claimed #1",
+    });
+
+    const logsDir = join(dir, ".border-collie", "logs");
+    await vi.waitFor(() => {
+      expect(existsSync(logsDir)).toBe(true);
+    });
+    const [fileName] = readdirSync(logsDir);
+    expect(fileName).not.toBe("12345678.jsonl");
+    expect(fileName).toMatch(/^\d{4}-\d{2}-\d{2}T.*\.jsonl$/);
+  });
 });

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -129,6 +129,15 @@ describe("resolveConfig", () => {
     ).toThrow(ConfigError);
   });
 
+  it("lets a --timeout-minutes flag override the config file's Worker timeout", () => {
+    expect(
+      resolveConfig(
+        { parent: 1, worker_timeout_minutes: 90 },
+        { timeoutMinutes: 50 },
+      ).timeoutMinutes,
+    ).toBe(50);
+  });
+
   it("takes the Worker budget backstops from the config file, allowing a fractional cost cap", () => {
     const resolved = resolveConfig(
       { parent: 1, worker_max_turns: 80, worker_max_cost_usd: 7.5 },
@@ -333,6 +342,15 @@ describe("resolveWorkerConfig", () => {
 
     expect(resolved.model).toBe("opus");
     expect(resolved.retryModel).toBe("haiku");
+  });
+
+  it("lets --timeout-minutes override the config file's Worker timeout", () => {
+    const resolved = resolveWorkerConfig(
+      { worker_timeout_minutes: 90 },
+      { timeoutMinutes: 50 },
+    );
+
+    expect(resolved.timeoutMinutes).toBe(50);
   });
 
   it("takes the Worker timeout, stall window, and budget backstops from the config file", () => {


### PR DESCRIPTION
feat(ci): run a Worker as its own job

## Summary

A Worker now runs as its own GitHub Actions job — one per Ticket, taking the Ticket and Attempt as explicit `workflow_dispatch` inputs rather than inferring dispatch from a label or an assignee event. The job runs the existing `border-collie worker` entrypoint (issue #71), so it settles its own Attempt exactly as it does on the local path.

Since one job means one checkout with nothing shared, `dispatchWorker` gains an `--in-place` mode: it checks the agent branch out directly in the current working directory instead of cutting an isolated worktree, and skips the repo-level git lock and worktree pruning entirely on this path — none of that exists to serve a dedicated single-purpose checkout. The local path is unchanged (worktree isolation stays the default, since a Tick may still dispatch several Workers concurrently into one operator checkout).

The structured run log's identifier is now injectable via `BORDER_COLLIE_RUN_ID`, set from the job's own run id in the workflow, so the uploaded log artifact's file name correlates directly with the job an operator can click into. Worker skills (the `mattpocock-skills` plugin `/implement` depends on) install in the job before the session runs, so the Worker prompt resolves instead of degrading silently to unhandled text and an oddly-shaped PR.

Credentials: the built-in `GITHUB_TOKEN` stays read-only and unused for any write; a minted GitHub App installation token (scoped to whatever the App itself was granted — contents, issues, pull requests, never workflow modification) is the only credential that can push the branch or write to the tracker, kept to the one step and one env block that need it.

The job's own wall-clock ceiling and the Worker's internal watchdog are two separate, explicit inputs (`job_timeout_minutes`, `timeout_minutes`) rather than one derived from the other, since GitHub Actions expressions can't do arithmetic on dispatch inputs — a fail-fast validation step checks their relationship before anything is installed, so a misconfigured dispatch errors loudly instead of silently letting GitHub Actions race the internal watchdog that settles the Attempt.

## Changes

- `.github/workflows/worker.yml` — new: one job per Ticket, explicit `ticket`/`attempt`/`timeout_minutes`/`job_timeout_minutes` inputs, GitHub App token mint, skills install, `border-collie worker --in-place --timeout-minutes`, log artifact upload.
- `src/adapters/worker.ts` — `WorkerConfig.inPlace`; `dispatchWorker` branches its setup/teardown and skips the git lock when `inPlace` is set.
- `src/app/worker.ts`, `src/cli/context.ts`, `src/cli/worker-command.ts` — thread `inPlace` end to end via a new `--in-place` flag; `src/app/tick.ts`'s local batch-dispatch wiring pins `inPlace: false` explicitly.
- `src/cli/worker-command.ts` — new `--timeout-minutes` flag, scoped to `worker` only (not `sharedFlags`, so it can't silently leak onto `tick`/`run`).
- `src/core/config.ts` — `Flags.timeoutMinutes`, consulted by `resolveSharedConfig` ahead of the config file's `worker_timeout_minutes`.
- `src/cli/context.ts` — `buildRealContext`/`buildLog` take an injectable `env`, reading `BORDER_COLLIE_RUN_ID` with a timestamp fallback.
- `src/core/log.ts` — the `worker-paths` event's `worktree` field renamed to `path`, since it now sometimes holds a bare checkout (`.`) rather than a worktree.
- `CONTEXT.md` — the "Worker" glossary entry now names both isolation strategies.
- Tests updated/added across `tests/adapters/worker.test.ts`, `tests/cli/app.test.ts`, `tests/cli/context.test.ts`, `tests/core/config.test.ts`.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` (447 tests), `pnpm build`, `pnpm smoke` all pass
- [x] `actionlint .github/workflows/*.yml` clean
- [x] Verified `border-collie worker --help` shows `--timeout-minutes`/`--in-place`; `tick --help`/`run --help` do not
- [x] Two-axis `/code-review` run (Standards + Spec); both rounds of findings addressed (timeout-flag scope narrowed off `sharedFlags`, log field renamed, timeout-relationship validation added, CONTEXT.md updated)

Closes #75