### PR TITLE
feat(act): dispatch without waiting, with liveness from the tracker

### DIFF
--- a/src/adapters/tracker.ts
+++ b/src/adapters/tracker.ts
@@ -10,6 +10,7 @@ import {
   CLAIM_MARKER,
   CONFLICT_UNRESOLVED_MARKER,
   FAILURE_DESCRIPTIONS,
+  type FailureReason,
   INFRA_DESCRIPTIONS,
   type InfraReason,
   MAX_ATTEMPTS,
@@ -126,6 +127,9 @@ function toTicket(issue: GithubIssue): Ticket {
     agentClaimCount: 0,
     attemptFailures: [],
     voidedAtMs: undefined,
+    lastFailureAtMs: undefined,
+    lastFailureReason: undefined,
+    hasLiveWorker: false,
   };
 }
 
@@ -147,6 +151,8 @@ interface ClaimHistory {
   agentClaimCount: number;
   attemptFailures: AttemptFailure[];
   voidedAtMs: number | undefined;
+  lastFailureAtMs: number | undefined;
+  lastFailureReason: FailureReason | undefined;
 }
 
 /**
@@ -160,7 +166,12 @@ interface ClaimHistory {
  * auditable and attempt state needs no local store. `voidedAtMs` tracks
  * whether a void marker is still the latest one — a later claim or release
  * resolves it — so the circuit breaker can be derived from it fresh each Tick
- * (CONTEXT.md "Infrastructure failure").
+ * (CONTEXT.md "Infrastructure failure"). `lastFailureAtMs`/`lastFailureReason`
+ * track the same thing for a Ticket-failure release instead of a void — reset
+ * by a later claim exactly like `voidedAtMs`, and left undefined by a release
+ * carrying no attempt record (an orphan release) — feeding the correlation
+ * heuristic recomputed at Tick time (issue #73; `classify.ts`'s
+ * `correlatedFailureTimestampsMs`).
  */
 async function readClaimHistory(
   ticket: number,
@@ -175,12 +186,16 @@ async function readClaimHistory(
     agentClaimCount: 0,
     attemptFailures: [],
     voidedAtMs: undefined,
+    lastFailureAtMs: undefined,
+    lastFailureReason: undefined,
   };
   for (const comment of comments) {
     if (comment.body?.includes(CLAIM_MARKER)) {
       history.hasAgentClaim = true;
       history.agentClaimCount += 1;
       history.voidedAtMs = undefined;
+      history.lastFailureAtMs = undefined;
+      history.lastFailureReason = undefined;
     } else if (comment.body?.includes(VOID_MARKER)) {
       history.agentClaimCount = Math.max(0, history.agentClaimCount - 1);
       history.voidedAtMs = commentTimestamp(comment.created_at);
@@ -188,7 +203,14 @@ async function readClaimHistory(
       history.hasAgentClaim = false;
       history.voidedAtMs = undefined;
       const failure = parseAttemptMarker(comment.body);
-      if (failure) history.attemptFailures.push(failure);
+      if (failure) {
+        history.attemptFailures.push(failure);
+        history.lastFailureAtMs = commentTimestamp(comment.created_at);
+        history.lastFailureReason = failure.reason;
+      } else {
+        history.lastFailureAtMs = undefined;
+        history.lastFailureReason = undefined;
+      }
     }
   }
   return history;
@@ -492,6 +514,69 @@ async function listMergedAgentPrs(exec: Exec): Promise<MergedAgentPr[]> {
 }
 
 /**
+ * The GitHub Actions workflow file a Worker job runs from (issue #75),
+ * dispatched with the Ticket and Attempt as explicit workflow_dispatch
+ * inputs — never inferred from a label or an assignee event, since the
+ * Orchestrator already knows which Ticket it decided to dispatch.
+ */
+export const WORKER_WORKFLOW_FILE = "border-collie-worker.yml";
+
+const WORKER_RUN_NAME_PREFIX = "border-collie worker #";
+
+/**
+ * The `run-name:` the Worker workflow (issue #75) must set from its ticket
+ * and attempt inputs, so a running job's ticket is readable from the run
+ * list below without decoding workflow_dispatch inputs — the REST API never
+ * echoes those back on the run itself.
+ */
+export function workerRunName(ticket: number, attempt: number): string {
+  return `${WORKER_RUN_NAME_PREFIX}${ticket} attempt ${attempt}`;
+}
+
+function ticketFromWorkerRunName(displayTitle: string): number | undefined {
+  if (!displayTitle.startsWith(WORKER_RUN_NAME_PREFIX)) return undefined;
+  const match = /^\d+/.exec(displayTitle.slice(WORKER_RUN_NAME_PREFIX.length));
+  return match ? Number(match[0]) : undefined;
+}
+
+interface GhWorkflowRun {
+  status?: string;
+  displayTitle?: string;
+}
+
+/**
+ * Ticket numbers with a Worker job GitHub has not yet marked `completed` —
+ * queued, in progress, or otherwise still running. Worker liveness read from
+ * GitHub itself (issue #64, #73) rather than a promise held in the
+ * Orchestrator's memory: a restarted Orchestrator reaches the same verdict,
+ * and a job GitHub itself already finished (whether it settled cleanly or
+ * was killed by its own wall-clock ceiling) is never mistaken for one still
+ * live, so the orphan check can release its Claim.
+ */
+export async function liveWorkerTickets(
+  exec: Exec = realExec,
+): Promise<Set<number>> {
+  const stdout = await exec("gh", [
+    "run",
+    "list",
+    "--workflow",
+    WORKER_WORKFLOW_FILE,
+    "--json",
+    "status,displayTitle",
+    "--limit",
+    "100",
+  ]);
+  const runs = JSON.parse(stdout) as GhWorkflowRun[];
+  const live = new Set<number>();
+  for (const run of runs) {
+    if (run.status === "completed") continue;
+    const ticket = ticketFromWorkerRunName(run.displayTitle ?? "");
+    if (ticket !== undefined) live.add(ticket);
+  }
+  return live;
+}
+
+/**
  * Observe phase: read the Scope from GitHub. Parent scope lists the parent's
  * sub-issues (open and closed — the planner needs closed ones to reason about
  * later); repo-wide scope lists open agent-ready issues, excluding PRs
@@ -526,9 +611,26 @@ export async function readScope(
       ticket.agentClaimCount = history.agentClaimCount;
       ticket.attemptFailures = history.attemptFailures;
       ticket.voidedAtMs = history.voidedAtMs;
+      ticket.lastFailureAtMs = history.lastFailureAtMs;
+      ticket.lastFailureReason = history.lastFailureReason;
     }
     if (ticket.openBlockers > 0) {
       ticket.blockedBy = await readOpenBlockers(ticket.number, exec);
+    }
+  }
+
+  // Worker liveness matters only for a ticket the orphan check could
+  // otherwise mistake for abandoned: open, claim-labelled, no PR yet because
+  // its Worker (local or remote) has not finished. Read once, repo-wide, and
+  // fanned back onto every such ticket — cheaper than one call per ticket,
+  // and the same shape as the PR listings below.
+  const claimedOpenTickets = tickets.filter(
+    (t) => t.state === "open" && t.labels.includes(CLAIM_LABEL),
+  );
+  if (claimedOpenTickets.length > 0) {
+    const live = await liveWorkerTickets(exec);
+    for (const ticket of claimedOpenTickets) {
+      ticket.hasLiveWorker = live.has(ticket.number);
     }
   }
 

--- a/src/adapters/worker.ts
+++ b/src/adapters/worker.ts
@@ -12,7 +12,7 @@ import {
   type FailureReason,
   type WorkerOutcome,
 } from "../core/types.js";
-import { type Exec, realExec } from "./tracker.js";
+import { type Exec, realExec, WORKER_WORKFLOW_FILE } from "./tracker.js";
 
 /**
  * The WorkerHost seam: everything a dispatched Worker needs around it —
@@ -410,6 +410,38 @@ export async function dispatchWorker(
   } finally {
     await withGitLock(() => removeWorktree(worktree, exec));
   }
+}
+
+/**
+ * Dispatch one Worker against one claimed ticket by triggering its GitHub
+ * Actions job (issue #75) and returning immediately, without an outcome —
+ * the fire-and-forget half of the dispatch seam (issue #73), alongside the
+ * synchronous `dispatchWorker` above, which the local path keeps unchanged.
+ * The job runs the Worker entrypoint command, which settles its own Attempt
+ * (src/app/worker.ts, issue #71): opening the draft PR itself on success,
+ * releasing with the forensic record on a Ticket failure, or voiding the
+ * Attempt on an Infrastructure failure. The next Tick reads the result back
+ * from the tracker, and reads the job's own running state as this ticket's
+ * Worker liveness (`liveWorkerTickets`, adapters/tracker.ts) rather than
+ * waiting on it here. Ticket and attempt are explicit workflow_dispatch
+ * inputs — dispatch is never inferred from a label or an assignee event,
+ * since the Orchestrator already knows which Ticket it decided to dispatch.
+ */
+export async function dispatchRemoteWorker(
+  ticket: number,
+  attempt: number,
+  exec: Exec = realExec,
+): Promise<undefined> {
+  await exec("gh", [
+    "workflow",
+    "run",
+    WORKER_WORKFLOW_FILE,
+    "-f",
+    `ticket=${ticket}`,
+    "-f",
+    `attempt=${attempt}`,
+  ]);
+  return undefined;
 }
 
 /** The probe's own generous window: a healthy environment answers in seconds. */

--- a/src/app/act.ts
+++ b/src/app/act.ts
@@ -38,16 +38,41 @@ export type IntervalScheduler = (
 ) => () => void;
 
 /**
+ * A dispatch that waits for the Worker to finish and resolves with its
+ * outcome — what the local, synchronous path (`dispatchWorker`,
+ * adapters/worker.ts) always is, and the only kind the Worker entrypoint's
+ * own dispatch call can sensibly be (src/app/worker.ts, issue #71): it runs
+ * the session itself, so firing-and-forgetting from its own perspective
+ * would make no sense. A stricter return type than `DispatchWorker` below,
+ * and so always assignable to it.
+ */
+export type SyncDispatchWorker = (
+  ticket: number,
+  attempt: number,
+  onActivity: () => void,
+) => Promise<WorkerOutcome>;
+
+/**
  * Dispatch one Worker against one claimed ticket; the caller binds the
  * attempt number to a model (the retry ladder). `onActivity` is called
  * whenever the Worker process produces output — the fleet heartbeat's
  * activity signal, riding the process adapter's existing observation.
+ *
+ * Two implementations share this seam (issue #73). The local one
+ * (`dispatchWorker`) runs the Worker to completion and always resolves with
+ * its outcome — a `SyncDispatchWorker`. The remote one (`dispatchRemoteWorker`,
+ * adapters/worker.ts) triggers the Worker's GitHub Actions job and resolves
+ * immediately with `undefined`: no outcome to settle here, because the job
+ * runs the Worker entrypoint that settles its own Attempt (src/app/worker.ts)
+ * and the next Tick reads the result back from the tracker. `act` below
+ * therefore completes without waiting for a Worker dispatched this way —
+ * there is nothing left for it to await.
  */
 export type DispatchWorker = (
   ticket: number,
   attempt: number,
   onActivity: () => void,
-) => Promise<WorkerOutcome>;
+) => Promise<WorkerOutcome | undefined>;
 
 /** Open the draft PR for a successful Attempt; resolves with the PR URL. */
 export type OpenPr = (outcome: WorkerOutcome) => Promise<string>;
@@ -67,9 +92,14 @@ export type DispatchRefinementWorker = (
   round: number,
 ) => Promise<RefinementOutcome>;
 
-/** What one spawn action came to: the Attempt, and its PR when one was opened. */
+/**
+ * What one spawn action came to: the Attempt, and its PR when one was
+ * opened. `outcome` is undefined when the dispatch was fire-and-forget (the
+ * remote implementation) — the Worker settles its own Attempt elsewhere, so
+ * there is nothing here to reclassify or settle.
+ */
 interface SpawnResult {
-  outcome: WorkerOutcome;
+  outcome: WorkerOutcome | undefined;
   prUrl?: string;
   /** PR opening failed after a successful Attempt; reported, then rethrown. */
   prFailure?: unknown;
@@ -191,13 +221,23 @@ function describeRefinement(outcome: RefinementOutcome): string {
  * Act phase: perform the planned writes in plan order (releases first), one
  * at a time, narrating each as it lands. Spawns are the exception: each
  * Worker starts as its action is reached but runs concurrently, its branch
- * becoming a draft PR the moment it succeeds, and the Tick waits for all of
- * them before reporting outcomes. The same-way-same-Tick heuristic
+ * becoming a draft PR the moment it succeeds, and the Tick waits for
+ * whichever of them the injected `dispatch` actually hands back an outcome
+ * for before reporting. The local, synchronous dispatch hands back every
+ * outcome, so this is unchanged for it: the same-way-same-Tick heuristic
  * reclassifies correlated deaths once every Worker has settled, then each
  * outcome's write — the forensic release for a Ticket failure, the void for
  * an Infrastructure failure — is delegated to `settleAttempt`, the unit a
- * Worker settling its own Attempt will one day share. The report's infra
- * count is what trips the caller's circuit breaker. A tracker failure
+ * Worker settling its own Attempt also shares (src/app/worker.ts, issue
+ * #71). The remote dispatch (issue #73) hands back `undefined` instead, once
+ * its Worker's GitHub Actions job is merely triggered — nothing to
+ * reclassify or settle here, so this phase (and the Tick as a whole) never
+ * waits for that Worker to actually finish; the job settles its own Attempt,
+ * and a later Tick reads the result back from the tracker. The report's
+ * infra count is what trips the caller's circuit breaker, and only ever
+ * counts outcomes this Tick actually saw — a fire-and-forget dispatch's
+ * eventual infra failure instead surfaces through `deriveBreaker`'s own
+ * tracker read (breaker.ts) once its Worker reports. A tracker failure
  * mid-way throws — the stateless recovery story is re-running the Tick,
  * which recomputes the world and re-plans whatever is still due. PR upkeep
  * runs alongside dispatch: the mechanical branch update and draft→ready flip
@@ -344,6 +384,17 @@ export async function act(
           dispatch(action.ticket, action.attempt, handle.touch)
             .finally(handle.stop)
             .then(async (outcome): Promise<SpawnResult> => {
+              if (outcome === undefined) {
+                // Fire-and-forget: the Worker's job settles its own Attempt
+                // elsewhere (src/app/worker.ts, issue #71), and the next
+                // Tick reads the result back from the tracker.
+                workerLog({
+                  kind: "worker-dispatched-async",
+                  level: "info",
+                  msg: "Worker dispatched to a remote job; it will settle its own Attempt",
+                });
+                return { outcome: undefined, log: workerLog };
+              }
               if (!outcome.ok) return { outcome, log: workerLog };
               try {
                 return {
@@ -373,14 +424,22 @@ export async function act(
         result.status === "fulfilled",
     )
     .map((result) => result.value);
+  // A fire-and-forget dispatch (the remote implementation) settles nothing
+  // here — its outcome is undefined, and its Attempt is settled by the
+  // Worker job itself (src/app/worker.ts). Only the reportable (defined)
+  // outcomes are reclassified and settled below.
+  const reportable = fulfilled.filter(
+    (spawn): spawn is SpawnResult & { outcome: WorkerOutcome } =>
+      spawn.outcome !== undefined,
+  );
   // Reclassify once every Worker has settled: only the full Tick's outcomes
   // can show several Workers dying the same way (an environment problem,
   // not a coincidence of tickets). Zipped straight back onto the spawn
   // results so each outcome keeps its own PR and sub-logger.
   const reclassifiedOutcomes = reclassifyCorrelatedFailures(
-    fulfilled.map((spawn) => spawn.outcome),
+    reportable.map((spawn) => spawn.outcome),
   );
-  const outcomes = fulfilled.map((spawn, i) => ({
+  const outcomes = reportable.map((spawn, i) => ({
     outcome: reclassifiedOutcomes[i] ?? spawn.outcome,
     prUrl: spawn.prUrl,
     log: spawn.log,

--- a/src/app/worker.ts
+++ b/src/app/worker.ts
@@ -9,17 +9,21 @@ import { dispatchWorker, realSpawnWorkerProcess } from "../adapters/worker.js";
 import { modelForAttempt, type WorkerAttemptConfig } from "../core/config.js";
 import type { Log } from "../core/log.js";
 import type { WorkerOutcome } from "../core/types.js";
-import type { DispatchWorker, OpenPr } from "./act.js";
+import type { OpenPr, SyncDispatchWorker } from "./act.js";
 import { settleAttempt } from "./settle.js";
 
 /**
- * A Worker settling its own Attempt (issue #71): the same `DispatchWorker`
- * and `OpenPr` seams the act phase spawns a batch of Workers through
- * (src/app/act.ts), injectable so a fake dispatch/openPr exercises this unit
- * without a real session.
+ * A Worker settling its own Attempt (issue #71): the same `OpenPr` seam the
+ * act phase spawns a batch of Workers through (src/app/act.ts), injectable
+ * so a fake dispatch/openPr exercises this unit without a real session.
+ * `dispatch` is a `SyncDispatchWorker`, not the wider `DispatchWorker`: this
+ * command IS the Worker running its own session, so its own dispatch call
+ * always waits for that session and always gets a real outcome back — the
+ * fire-and-forget remote implementation (issue #73) belongs at the Tick's
+ * act phase, not here.
  */
 export interface WorkerAttemptDeps {
-  dispatch: DispatchWorker;
+  dispatch: SyncDispatchWorker;
   openPr: OpenPr;
   exec: Exec;
   log: Log;

--- a/src/core/breaker.ts
+++ b/src/core/breaker.ts
@@ -1,3 +1,8 @@
+import {
+  CORRELATED_WINDOW_MS,
+  clusterWithinWindow,
+  correlatedFailureTimestampsMs,
+} from "./classify.js";
 import type { WorldSnapshot } from "./types.js";
 
 /**
@@ -45,44 +50,46 @@ export function probeDue(breaker: OpenBreaker, nowMs: number): boolean {
 }
 
 /**
- * Void markers this close together are read as one Tick's worth: the live
- * loop trips once per Tick no matter how many Workers died the same way
+ * Timestamps this close together are read as one Tick's worth: the live loop
+ * trips once per Tick no matter how many Workers died the same way
  * (CONTEXT.md "Infrastructure failure" — correlated), and every void comment
  * for one Tick posts back-to-back right after its Workers settle. Ticks
  * themselves are always spaced by at least the base cooldown once the
  * breaker is open, so this window can't merge two genuinely separate trips.
+ * Every cluster becomes one trip regardless of size — unlike
+ * `correlatedFailureTimestampsMs` below, a single held void always trips: it
+ * is not a coincidence heuristic, the Worker already evidenced the
+ * environment cause itself.
  */
-const CORRELATED_VOID_WINDOW_MS = 60_000;
+function collapseWithinWindow(msSorted: number[]): number[] {
+  return clusterWithinWindow(msSorted, CORRELATED_WINDOW_MS).map(
+    (cluster) => cluster.at(-1) as number,
+  );
+}
 
 /**
  * Derive the breaker fresh from the world snapshot: every in-Scope ticket's
  * still-held void marker (`Ticket.voidedAtMs`, undefined once a later claim
- * or release resolves it) contributes its timestamp; timestamps within
- * `CORRELATED_VOID_WINDOW_MS` of each other collapse to the one Tick that
- * produced them. Each surviving timestamp is one trip, folded through
+ * or release resolves it) contributes its timestamp, alongside every
+ * correlated Ticket-failure timestamp `correlatedFailureTimestampsMs`
+ * recomputes from the tracker (issue #73 — a self-reporting Worker never
+ * sees a sibling's outcome to batch against, so this replaces the batch the
+ * act phase used to reclassify inline). The merged timestamps collapse
+ * within `CORRELATED_WINDOW_MS` of each other to the one Tick that produced
+ * them, and each surviving timestamp is one trip, folded through
  * `tripBreaker` in chronological order — the same sequence a live process
- * would have applied as each Tick's voids landed. A fresh process therefore
- * reaches the same verdict as one that watched the failures happen, with no
- * store beyond the tracker's own comments.
+ * would have applied as each Tick's infrastructure failures landed. A fresh
+ * process therefore reaches the same verdict as one that watched them
+ * happen, with no store beyond the tracker's own comments.
  */
 export function deriveBreaker(world: WorldSnapshot): Breaker {
   const voidTimestampsMs = world.tickets
     .map((ticket) => ticket.voidedAtMs)
-    .filter((ms): ms is number => ms !== undefined)
-    .sort((a, b) => a - b);
-
-  const tripTimestampsMs: number[] = [];
-  for (const ms of voidTimestampsMs) {
-    const lastIndex = tripTimestampsMs.length - 1;
-    if (
-      lastIndex >= 0 &&
-      ms - (tripTimestampsMs[lastIndex] as number) <= CORRELATED_VOID_WINDOW_MS
-    ) {
-      tripTimestampsMs[lastIndex] = ms;
-    } else {
-      tripTimestampsMs.push(ms);
-    }
-  }
+    .filter((ms): ms is number => ms !== undefined);
+  const correlatedTimestampsMs = correlatedFailureTimestampsMs(world.tickets);
+  const tripTimestampsMs = collapseWithinWindow(
+    [...voidTimestampsMs, ...correlatedTimestampsMs].sort((a, b) => a - b),
+  );
 
   return tripTimestampsMs.reduce<Breaker>(
     (breaker, ms) => tripBreaker(breaker, ms),

--- a/src/core/classify.ts
+++ b/src/core/classify.ts
@@ -1,4 +1,9 @@
-import type { InfraReason, WorkerOutcome } from "./types.js";
+import type {
+  FailureReason,
+  InfraReason,
+  Ticket,
+  WorkerOutcome,
+} from "./types.js";
 
 /**
  * Failure classification (CONTEXT.md "Infrastructure failure"): pure
@@ -103,7 +108,7 @@ export function parseResultEvent(tail: string): ResultEvent | undefined {
  * same evidence: both are measured from a Worker that ran to completion,
  * which proves the environment was up.
  */
-const CORRELATABLE: ReadonlySet<string> = new Set([
+const CORRELATABLE: ReadonlySet<FailureReason> = new Set([
   "nonzero-exit",
   "timeout",
   "stall",
@@ -131,4 +136,90 @@ export function reclassifyCorrelatedFailures(
       ? { ...outcome, failure: undefined, infra: "correlated" as const }
       : outcome,
   );
+}
+
+/**
+ * Same-Tick window for the correlation heuristic: timestamps this close
+ * together read as one Tick's worth of coincident deaths — void markers
+ * (breaker.ts's own trip collapsing) or, now that a self-reporting Worker
+ * settles alone and never sees a sibling's outcome (issue #73),
+ * Ticket-failure releases recomputed from the tracker below.
+ */
+export const CORRELATED_WINDOW_MS = 60_000;
+
+/**
+ * Group sorted timestamps into clusters: a new cluster starts whenever a
+ * timestamp is more than `windowMs` past its cluster's own latest member.
+ * The one clustering primitive both same-Tick heuristics share, since they
+ * differ only in what counts as a trip once clustered: breaker.ts's void
+ * collapsing trips on every cluster regardless of size (a single void always
+ * trips), while `correlatedFailureTimestampsMs` below only trips a cluster of
+ * two or more (a lone Ticket-failure release is not evidence of anything).
+ */
+export function clusterWithinWindow(
+  sortedMs: number[],
+  windowMs: number,
+): number[][] {
+  const clusters: number[][] = [];
+  for (const ms of sortedMs) {
+    const current = clusters.at(-1);
+    const latest = current?.at(-1);
+    if (
+      current !== undefined &&
+      latest !== undefined &&
+      ms - latest <= windowMs
+    ) {
+      current.push(ms);
+    } else {
+      clusters.push([ms]);
+    }
+  }
+  return clusters;
+}
+
+/**
+ * `reclassifyCorrelatedFailures` above needs a batch of outcomes seen
+ * together in one process, which a self-reporting Worker never has (issue
+ * #73): each settles its own Attempt alone, whether locally or as its own
+ * GitHub Actions job. This is the same heuristic recomputed instead from
+ * `Ticket.lastFailureAtMs`/`lastFailureReason` — the tracker's own record of
+ * each ticket's latest release, one pair per ticket, mirroring
+ * `voidedAtMs` — across every ticket in Scope: two or more tickets whose
+ * latest release still carries the same correlatable reason
+ * (`CORRELATABLE`), posted within `CORRELATED_WINDOW_MS` of each other, are
+ * read as one environment problem rather than a coincidence of tickets.
+ * Each surviving cluster contributes its last timestamp, exactly like a void
+ * marker's, for `deriveBreaker` (breaker.ts) to fold through the same trip
+ * sequence a live batch would have.
+ *
+ * Unlike a void, a correlated release cannot be un-counted after the fact:
+ * the Attempt already released and counted against the ticket's cap before
+ * this Tick ever ran. Recomputing at Tick time recovers the breaker trip —
+ * dispatch still pauses so the outage cannot burn further Attempts — but not
+ * the Attempt itself, a known, accepted narrowing of "counts as nothing"
+ * (CONTEXT.md "Infrastructure failure") that a synchronous batch no longer
+ * makes possible.
+ */
+export function correlatedFailureTimestampsMs(tickets: Ticket[]): number[] {
+  const byReason = new Map<FailureReason, number[]>();
+  for (const { lastFailureAtMs, lastFailureReason } of tickets) {
+    if (lastFailureAtMs === undefined || lastFailureReason === undefined) {
+      continue;
+    }
+    if (!CORRELATABLE.has(lastFailureReason)) continue;
+    const timestamps = byReason.get(lastFailureReason) ?? [];
+    timestamps.push(lastFailureAtMs);
+    byReason.set(lastFailureReason, timestamps);
+  }
+  const trips: number[] = [];
+  for (const timestamps of byReason.values()) {
+    timestamps.sort((a, b) => a - b);
+    for (const cluster of clusterWithinWindow(
+      timestamps,
+      CORRELATED_WINDOW_MS,
+    )) {
+      if (cluster.length >= 2) trips.push(cluster.at(-1) as number);
+    }
+  }
+  return trips.sort((a, b) => a - b);
 }

--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -26,7 +26,9 @@ interface LogEventBase {
  * Worker-lifecycle kinds (`spawn` through `attempt-released`, and the
  * `conflict-*` kinds) omit the ticket/attempt/pr they'd otherwise repeat on
  * every call — a dispatched Worker's sub-logger binds those once; see
- * {@link Log.child}.
+ * {@link Log.child}. `worker-dispatched-async` is a fire-and-forget
+ * dispatch's only narration this Tick (issue #73): its Worker settles its
+ * own Attempt elsewhere, so there is no `worker-outcome` to follow it.
  */
 export type LogEvent = LogEventBase &
   (
@@ -45,6 +47,7 @@ export type LogEvent = LogEventBase &
         rounds: number;
       }
     | { kind: "spawn" }
+    | { kind: "worker-dispatched-async" }
     | { kind: "worker-outcome"; outcome: WorkerOutcome }
     | { kind: "heartbeat"; workers: WorkerHeartbeat[] }
     | { kind: "pr-opened"; prUrl: string }

--- a/src/core/plan.ts
+++ b/src/core/plan.ts
@@ -37,14 +37,21 @@ export function dispatchableSet(world: WorldSnapshot): Ticket[] {
 
 /**
  * Orphaned agent claim: an open ticket carrying both the claim label and the
- * claim marker but with no agent PR, open or merged — leftover from a
- * crashed run. (No live-Worker check yet: the stateless Orchestrator has no
- * Workers at Tick start until spawning lands with a later ticket. A
- * merged-PR claim is not orphaned: that ticket is done and merely awaiting
- * closure verification. Requiring the marker too — not just the label —
- * fails safe on a crash between the two claim writes: a labelled ticket with
- * no marker looks like an interrupted claim rather than a crashed run's
- * leftover, so it is left for a human to notice instead of auto-released.)
+ * claim marker, no agent PR (open or merged), and no Worker job still live —
+ * leftover from a crashed or finished-without-reporting run. A merged-PR
+ * claim is not orphaned: that ticket is done and merely awaiting closure
+ * verification. Requiring the marker too — not just the label — fails safe
+ * on a crash between the two claim writes: a labelled ticket with no marker
+ * looks like an interrupted claim rather than a crashed run's leftover, so it
+ * is left for a human to notice instead of auto-released. The live-Worker
+ * check (`Ticket.hasLiveWorker`, issue #73) is what keeps this from firing
+ * against a claim whose Worker is still actually running: dispatch is now
+ * fire-and-forget, so by the time this Tick observes the ticket, its Worker
+ * may not have finished (and thus opened no PR) yet — a promise once held
+ * only in the Orchestrator's memory would have blocked here in-process, but
+ * a self-reporting Worker gives that memory nothing to hold. Once GitHub
+ * itself marks the job no longer live with still no PR and no report, this
+ * releases it, whether the Worker crashed or simply never wrote back.
  * Released back to unclaimed; it rejoins the dispatchable set on the next
  * Tick's recomputed snapshot.
  */
@@ -63,6 +70,7 @@ function isOrphanedClaim(ticket: Ticket, world: WorldSnapshot): boolean {
     ticket.state === "open" &&
     ticket.labels.includes(CLAIM_LABEL) &&
     ticket.hasAgentClaim &&
+    !ticket.hasLiveWorker &&
     !hasOpenAgentPr(world, ticket.number) &&
     !hasMergedAgentPr(world, ticket.number)
   );

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -300,6 +300,28 @@ export interface Ticket {
    * these across in-Scope tickets (CONTEXT.md "Infrastructure failure").
    */
   voidedAtMs: number | undefined;
+  /**
+   * Timestamp (ms) of the ticket's most recent Ticket-failure release, when
+   * it is still the latest border-collie marker on the ticket — the
+   * Ticket-failure analogue of `voidedAtMs`. Undefined once superseded by a
+   * later claim, or when the latest release carried no attempt record (an
+   * orphan release). A self-reporting Worker settles alone and never sees a
+   * sibling's outcome, so the same-way-same-Tick correlation heuristic
+   * (CONTEXT.md "Infrastructure failure" — correlated) is recomputed from
+   * this pair across in-Scope tickets instead of from a batch in the act
+   * phase (issue #73; see `classify.ts`'s `correlatedFailureTimestampsMs`).
+   */
+  lastFailureAtMs: number | undefined;
+  /** The reason recorded on that same latest release, paired with `lastFailureAtMs`. */
+  lastFailureReason: FailureReason | undefined;
+  /**
+   * True when a Worker job for this ticket is still running on GitHub —
+   * anything short of `completed` (issue #73). Worker liveness read from
+   * GitHub itself, replacing a promise held in the Orchestrator's memory, so
+   * a restarted Orchestrator reaches the same verdict and an orphaned-claim
+   * check never releases a Claim whose Worker is still actually working.
+   */
+  hasLiveWorker: boolean;
 }
 
 /**

--- a/tests/adapters/tracker.test.ts
+++ b/tests/adapters/tracker.test.ts
@@ -7,6 +7,7 @@ import {
   type Exec,
   escalateTicket,
   giveUpOnPr,
+  liveWorkerTickets,
   markPrReady,
   readScope,
   readTicketTitle,
@@ -15,7 +16,9 @@ import {
   startRefinementRound,
   updatePrBranch,
   voidAttempt,
+  WORKER_WORKFLOW_FILE,
   withDebugLogging,
+  workerRunName,
 } from "../../src/adapters/tracker.js";
 import type { Log, LogEvent } from "../../src/core/log.js";
 import {
@@ -62,13 +65,14 @@ const prItem = (overrides: Record<string, unknown> = {}) => ({
 
 /**
  * Fake the subprocess seam. `gh api <endpoint> --paginate --slurp` calls are
- * answered from `api` keyed by endpoint; `gh pr list` from `prList`. An
- * un-mapped gh api endpoint throws, so a test also asserts which reads do NOT
- * happen.
+ * answered from `api` keyed by endpoint; `gh pr list` from `prList`; `gh run
+ * list` (Worker liveness) from `runList`. An un-mapped gh api endpoint
+ * throws, so a test also asserts which reads do NOT happen.
  */
 function fakeExec(opts: {
   api?: Record<string, unknown>;
   prList?: unknown[];
+  runList?: unknown[];
 }): {
   exec: Exec;
   calls: string[][];
@@ -82,6 +86,12 @@ function fakeExec(opts: {
         throw new Error(`unexpected gh pr list: ${[cmd, ...args].join(" ")}`);
       }
       return JSON.stringify(opts.prList);
+    }
+    if (args[0] === "run" && args[1] === "list") {
+      if (opts.runList === undefined) {
+        throw new Error(`unexpected gh run list: ${[cmd, ...args].join(" ")}`);
+      }
+      return JSON.stringify(opts.runList);
     }
     if (args[0] === "api") {
       const endpoint = args[1] ?? "";
@@ -113,8 +123,11 @@ const compare = (base: string, head: string) =>
   `repos/{owner}/{repo}/compare/${base}...${head}`;
 
 /** The gh operation a recorded call performed, for asserting read order. */
-const op = (call: string[]) =>
-  call[1] === "pr" && call[2] === "list" ? "pr-list" : call[2];
+const op = (call: string[]) => {
+  if (call[1] === "pr" && call[2] === "list") return "pr-list";
+  if (call[1] === "run" && call[2] === "list") return "run-list";
+  return call[2];
+};
 
 describe("readScope", () => {
   it("reads a parent's sub-issues, then comments, then the open and closed PR listings", async () => {
@@ -222,6 +235,7 @@ describe("readScope", () => {
         hasAgentClaim: false,
         agentClaimCount: 0,
         attemptFailures: [],
+        hasLiveWorker: false,
       },
       {
         number: 4,
@@ -234,6 +248,7 @@ describe("readScope", () => {
         hasAgentClaim: false,
         agentClaimCount: 0,
         attemptFailures: [],
+        hasLiveWorker: false,
       },
     ]);
   });
@@ -294,6 +309,7 @@ describe("readScope", () => {
         [CLOSED_PULLS]: [[]],
       },
       prList: [],
+      runList: [],
     });
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
@@ -323,6 +339,7 @@ describe("readScope", () => {
         [CLOSED_PULLS]: [[]],
       },
       prList: [],
+      runList: [],
     });
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
@@ -472,6 +489,7 @@ describe("readScope", () => {
         [CLOSED_PULLS]: [[]],
       },
       prList: [],
+      runList: [],
     });
 
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
@@ -564,6 +582,163 @@ describe("readScope", () => {
     const world = await readScope({ kind: "parent", parent: 1 }, exec);
 
     expect(world.tickets[0]).toMatchObject({ voidedAtMs: undefined });
+  });
+
+  it("records the latest Ticket-failure release's timestamp and reason for the correlation heuristic", async () => {
+    const { exec } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [
+          [
+            { body: `${CLAIM_MARKER}\n🐕 claimed` },
+            {
+              body: `${RELEASE_MARKER}\n${attemptMarker(FAILURE)}\n🐕 Attempt 1 failed`,
+              created_at: "2026-01-01T00:05:00.000Z",
+            },
+          ],
+        ],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.tickets[0]).toMatchObject({
+      lastFailureAtMs: Date.parse("2026-01-01T00:05:00.000Z"),
+      lastFailureReason: FAILURE.reason,
+    });
+  });
+
+  it("resolves the last Ticket-failure release once a later claim lands", async () => {
+    const { exec } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [
+          [
+            { body: `${CLAIM_MARKER}\n🐕 claimed` },
+            {
+              body: `${RELEASE_MARKER}\n${attemptMarker(FAILURE)}\n🐕 Attempt 1 failed`,
+              created_at: "2026-01-01T00:05:00.000Z",
+            },
+            { body: `${CLAIM_MARKER}\n🐕 claimed again` },
+          ],
+        ],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.tickets[0]).toMatchObject({
+      lastFailureAtMs: undefined,
+      lastFailureReason: undefined,
+    });
+  });
+
+  it("leaves lastFailureAtMs/lastFailureReason undefined after an orphan release (no attempt record)", async () => {
+    const { exec } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [
+          [
+            issue({
+              number: 5,
+              labels: [{ name: "ready-for-agent" }, { name: CLAIM_LABEL }],
+            }),
+          ],
+        ],
+        [comments(5)]: [
+          [
+            { body: `${CLAIM_MARKER}\n🐕 claimed` },
+            { body: `${RELEASE_MARKER}\n🐕 released an orphaned claim` },
+          ],
+        ],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [],
+      runList: [],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.tickets[0]).toMatchObject({
+      lastFailureAtMs: undefined,
+      lastFailureReason: undefined,
+    });
+  });
+
+  it("reads Worker liveness only when an open ticket carries the claim label", async () => {
+    const { exec, calls } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [[issue({ number: 5 })]],
+        [comments(5)]: [[]],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [],
+      // runList deliberately unmapped: fetching it would throw.
+    });
+
+    await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(calls.map(op)).not.toContain("run-list");
+  });
+
+  it("marks a claimed ticket's Worker live when its job is still running", async () => {
+    const { exec, calls } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [
+          [
+            issue({
+              number: 5,
+              labels: [{ name: "ready-for-agent" }, { name: CLAIM_LABEL }],
+            }),
+          ],
+        ],
+        [comments(5)]: [[{ body: `${CLAIM_MARKER}\n🐕 claimed` }]],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [],
+      runList: [{ status: "in_progress", displayTitle: workerRunName(5, 1) }],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.tickets[0]?.hasLiveWorker).toBe(true);
+    expect(calls.find((c) => c[1] === "run")).toEqual([
+      "gh",
+      "run",
+      "list",
+      "--workflow",
+      WORKER_WORKFLOW_FILE,
+      "--json",
+      "status,displayTitle",
+      "--limit",
+      "100",
+    ]);
+  });
+
+  it("does not mark a claimed ticket's Worker live once GitHub marks its job completed", async () => {
+    const { exec } = fakeExec({
+      api: {
+        [SUB_ISSUES]: [
+          [
+            issue({
+              number: 5,
+              labels: [{ name: "ready-for-agent" }, { name: CLAIM_LABEL }],
+            }),
+          ],
+        ],
+        [comments(5)]: [[{ body: `${CLAIM_MARKER}\n🐕 claimed` }]],
+        [CLOSED_PULLS]: [[]],
+      },
+      prList: [],
+      runList: [{ status: "completed", displayTitle: workerRunName(5, 1) }],
+    });
+
+    const world = await readScope({ kind: "parent", parent: 1 }, exec);
+
+    expect(world.tickets[0]?.hasLiveWorker).toBe(false);
   });
 
   it("maps open agent-branch PRs with their upkeep signals, ignoring other branches", async () => {
@@ -1425,6 +1600,54 @@ describe("readTicketTitle", () => {
     const title = await readTicketTitle(7, exec);
 
     expect(title).toBe("Ticket #7");
+  });
+});
+
+describe("workerRunName", () => {
+  it("names a run by ticket and attempt", () => {
+    expect(workerRunName(5, 1)).toBe("border-collie worker #5 attempt 1");
+  });
+});
+
+describe("liveWorkerTickets", () => {
+  it("reads the Worker workflow's own run list", async () => {
+    const { exec, calls } = fakeExec({ runList: [] });
+
+    await liveWorkerTickets(exec);
+
+    expect(calls).toEqual([
+      [
+        "gh",
+        "run",
+        "list",
+        "--workflow",
+        WORKER_WORKFLOW_FILE,
+        "--json",
+        "status,displayTitle",
+        "--limit",
+        "100",
+      ],
+    ]);
+  });
+
+  it("collects tickets whose job GitHub has not marked completed", async () => {
+    const { exec } = fakeExec({
+      runList: [
+        { status: "in_progress", displayTitle: workerRunName(5, 1) },
+        { status: "queued", displayTitle: workerRunName(9, 2) },
+        { status: "completed", displayTitle: workerRunName(4, 1) },
+      ],
+    });
+
+    expect(await liveWorkerTickets(exec)).toEqual(new Set([5, 9]));
+  });
+
+  it("ignores a run whose display title does not match the Worker naming convention", async () => {
+    const { exec } = fakeExec({
+      runList: [{ status: "in_progress", displayTitle: "some other workflow" }],
+    });
+
+    expect(await liveWorkerTickets(exec)).toEqual(new Set());
   });
 });
 

--- a/tests/adapters/worker.test.ts
+++ b/tests/adapters/worker.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import type { Exec } from "../../src/adapters/tracker.js";
+import { type Exec, WORKER_WORKFLOW_FILE } from "../../src/adapters/tracker.js";
 import {
   branchCommitSubjects,
   type ClaudeRunConfig,
@@ -10,6 +10,7 @@ import {
   conflictWorkerPrompt,
   dispatchConflictWorker,
   dispatchRefinementWorker,
+  dispatchRemoteWorker,
   dispatchWorker,
   probeEnvironment,
   pushAgentBranch,
@@ -501,6 +502,28 @@ describe("dispatchWorker", () => {
     expect(outcome.transcript).toBe(
       ".border-collie/transcripts/ticket-7-attempt-2.jsonl",
     );
+  });
+});
+
+describe("dispatchRemoteWorker", () => {
+  it("triggers the Worker workflow with ticket and attempt as explicit inputs, resolving with no outcome", async () => {
+    const { exec, calls } = fakeExec();
+
+    const result = await dispatchRemoteWorker(7, 2, exec);
+
+    expect(result).toBeUndefined();
+    expect(calls).toEqual([
+      [
+        "gh",
+        "workflow",
+        "run",
+        WORKER_WORKFLOW_FILE,
+        "-f",
+        "ticket=7",
+        "-f",
+        "attempt=2",
+      ],
+    ]);
   });
 });
 

--- a/tests/app/act.test.ts
+++ b/tests/app/act.test.ts
@@ -589,6 +589,71 @@ describe("act", () => {
     expect(report).toEqual({ infraFailures: 0 });
   });
 
+  it("completes without waiting for a Worker dispatched fire-and-forget (the remote implementation, issue #73)", async () => {
+    const { exec, calls } = recordingExec();
+    const { openPr, opened } = recordingOpenPr();
+    const { log, events } = recordingLog();
+    // The remote dispatch resolves once the job is merely triggered — never
+    // once it finishes. Nothing here ever settles it, proving the Tick
+    // itself never waited for that to happen.
+    const dispatch: DispatchWorker = async () => undefined;
+
+    const report = await act([{ type: "spawn", ticket: 7, attempt: 1 }], {
+      dispatch,
+      openPr,
+      dispatchConflict: noConflict,
+      dispatchRefinement: noRefinement,
+      exec,
+      now,
+      scheduleInterval,
+      log,
+    });
+
+    expect(opened).toEqual([]); // nothing to open a PR for yet
+    expect(calls).toEqual([]); // nothing to write to the tracker yet
+    expect(report).toEqual({ infraFailures: 0 });
+    expect(events.map((e) => e.kind)).toEqual([
+      "spawn",
+      "worker-dispatched-async",
+    ]);
+  });
+
+  it("settles only the Workers dispatch actually hands back an outcome for", async () => {
+    const { exec, calls } = recordingExec();
+    const { openPr, opened } = recordingOpenPr();
+    const { log, events } = recordingLog();
+    const dispatch: DispatchWorker = async (ticket) =>
+      ticket === 2 ? undefined : outcome(4, { newCommits: 3 });
+
+    const report = await act(
+      [
+        { type: "spawn", ticket: 2, attempt: 1 },
+        { type: "spawn", ticket: 4, attempt: 1 },
+      ],
+      {
+        dispatch,
+        openPr,
+        dispatchConflict: noConflict,
+        dispatchRefinement: noRefinement,
+        exec,
+        now,
+        scheduleInterval,
+        log,
+      },
+    );
+
+    expect(opened).toEqual([4]);
+    expect(calls).toEqual([]); // a clean success writes nothing beyond its claim
+    expect(report).toEqual({ infraFailures: 0 });
+    const ticket2Events = events.filter(
+      (e) => (e as { ticket?: number }).ticket === 2,
+    );
+    expect(ticket2Events.map((e) => e.kind)).toEqual([
+      "spawn",
+      "worker-dispatched-async",
+    ]);
+  });
+
   it("still reports finished Workers when a sibling dispatch throws, then rethrows", async () => {
     const { exec } = recordingExec();
     const { openPr } = recordingOpenPr();

--- a/tests/app/run.test.ts
+++ b/tests/app/run.test.ts
@@ -23,6 +23,9 @@ function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
     agentClaimCount: 0,
     attemptFailures: [],
     voidedAtMs: undefined,
+    lastFailureAtMs: undefined,
+    lastFailureReason: undefined,
+    hasLiveWorker: false,
     ...overrides,
   };
 }

--- a/tests/app/worker.test.ts
+++ b/tests/app/worker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Exec } from "../../src/adapters/tracker.js";
-import type { DispatchWorker, OpenPr } from "../../src/app/act.js";
+import type { OpenPr, SyncDispatchWorker } from "../../src/app/act.js";
 import { runWorkerAttempt } from "../../src/app/worker.js";
 import type { Log, LogBindings, LogEvent } from "../../src/core/log.js";
 import {
@@ -62,7 +62,7 @@ describe("runWorkerAttempt", () => {
     const { exec, calls } = recordingExec();
     const { log, events } = recordingLog();
     const dispatched: [number, number][] = [];
-    const dispatch: DispatchWorker = async (ticket, attempt) => {
+    const dispatch: SyncDispatchWorker = async (ticket, attempt) => {
       dispatched.push([ticket, attempt]);
       return outcome({ newCommits: 3 });
     };
@@ -94,7 +94,7 @@ describe("runWorkerAttempt", () => {
     const { exec, calls } = recordingExec();
     const { log, events } = recordingLog();
     let openPrCalled = false;
-    const dispatch: DispatchWorker = async () =>
+    const dispatch: SyncDispatchWorker = async () =>
       outcome({
         exitCode: 1,
         newCommits: 0,
@@ -129,7 +129,7 @@ describe("runWorkerAttempt", () => {
     const { exec, calls } = recordingExec();
     const { log, events } = recordingLog();
     let openPrCalled = false;
-    const dispatch: DispatchWorker = async () =>
+    const dispatch: SyncDispatchWorker = async () =>
       outcome({ exitCode: 1, newCommits: 0, infra: "usage-limit", ok: false });
     const openPr: OpenPr = async () => {
       openPrCalled = true;
@@ -166,7 +166,7 @@ describe("runWorkerAttempt", () => {
     const { exec } = recordingExec();
     const { log } = recordingLog();
     const attempts: [number, number][] = [];
-    const dispatch: DispatchWorker = async (ticket, attempt) => {
+    const dispatch: SyncDispatchWorker = async (ticket, attempt) => {
       attempts.push([ticket, attempt]);
       return outcome({ ticket, attempt });
     };
@@ -180,7 +180,7 @@ describe("runWorkerAttempt", () => {
   it("still settles the Attempt when PR opening fails, then rethrows, logging the failure at error", async () => {
     const { exec } = recordingExec();
     const { log, events } = recordingLog();
-    const dispatch: DispatchWorker = async () => outcome();
+    const dispatch: SyncDispatchWorker = async () => outcome();
     const openPr: OpenPr = async () => {
       throw new Error("gh pr create exploded");
     };

--- a/tests/cli/app.test.ts
+++ b/tests/cli/app.test.ts
@@ -36,6 +36,9 @@ function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
     agentClaimCount: 0,
     attemptFailures: [],
     voidedAtMs: undefined,
+    lastFailureAtMs: undefined,
+    lastFailureReason: undefined,
+    hasLiveWorker: false,
     ...overrides,
   };
 }

--- a/tests/core/breaker.test.ts
+++ b/tests/core/breaker.test.ts
@@ -21,6 +21,9 @@ function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
     agentClaimCount: 0,
     attemptFailures: [],
     voidedAtMs: undefined,
+    lastFailureAtMs: undefined,
+    lastFailureReason: undefined,
+    hasLiveWorker: false,
     ...overrides,
   };
 }
@@ -148,5 +151,56 @@ describe("deriveBreaker", () => {
     expect(
       probeDue({ openedAtMs: 0, trips: 1 }, BREAKER_BASE_COOLDOWN_MS),
     ).toBe(true);
+  });
+
+  it("trips on two tickets whose latest release correlates the same way within one Tick (issue #73)", () => {
+    // A self-reporting Worker never sees a sibling's outcome, so this can no
+    // longer be reclassified in the act phase — it is recomputed here from
+    // each ticket's own latest release instead (CONTEXT.md "Infrastructure
+    // failure" — correlated).
+    const w = world([
+      ticket({
+        number: 4,
+        lastFailureAtMs: 1_000,
+        lastFailureReason: "nonzero-exit",
+      }),
+      ticket({
+        number: 7,
+        lastFailureAtMs: 1_500,
+        lastFailureReason: "nonzero-exit",
+      }),
+    ]);
+
+    expect(deriveBreaker(w)).toEqual(tripBreaker(undefined, 1_500));
+  });
+
+  it("does not trip on a single Ticket-failure release — one death is a ticket failure until proven otherwise", () => {
+    const w = world([
+      ticket({
+        number: 4,
+        lastFailureAtMs: 1_000,
+        lastFailureReason: "timeout",
+      }),
+    ]);
+
+    expect(deriveBreaker(w)).toBeUndefined();
+  });
+
+  it("collapses a held void and a correlated release close together into a single trip", () => {
+    const w = world([
+      ticket({ number: 2, voidedAtMs: 1_000 }),
+      ticket({
+        number: 4,
+        lastFailureAtMs: 1_200,
+        lastFailureReason: "stall",
+      }),
+      ticket({
+        number: 7,
+        lastFailureAtMs: 1_400,
+        lastFailureReason: "stall",
+      }),
+    ]);
+
+    expect(deriveBreaker(w)).toEqual(tripBreaker(undefined, 1_400));
   });
 });

--- a/tests/core/classify.test.ts
+++ b/tests/core/classify.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from "vitest";
 import {
+  CORRELATED_WINDOW_MS,
   classifyInfrastructure,
+  clusterWithinWindow,
+  correlatedFailureTimestampsMs,
   lastResultLine,
   parseResultEvent,
   reclassifyCorrelatedFailures,
 } from "../../src/core/classify.js";
-import type { WorkerOutcome } from "../../src/core/types.js";
+import type {
+  FailureReason,
+  Ticket,
+  WorkerOutcome,
+} from "../../src/core/types.js";
 
 describe("classifyInfrastructure", () => {
   it("classifies a usage-limit death", () => {
@@ -211,6 +218,121 @@ describe("reclassifyCorrelatedFailures", () => {
     expect(reclassifyCorrelatedFailures([infra, failed(4, "stall")])).toEqual([
       infra,
       failed(4, "stall"),
+    ]);
+  });
+});
+
+function ticketWithFailure(
+  lastFailureAtMs: number | undefined,
+  lastFailureReason: FailureReason | undefined,
+): Ticket {
+  return {
+    number: 1,
+    title: "Ticket",
+    state: "open",
+    assignees: [],
+    labels: ["ready-for-agent"],
+    openBlockers: 0,
+    blockedBy: [],
+    hasAgentClaim: false,
+    agentClaimCount: 1,
+    attemptFailures: [],
+    voidedAtMs: undefined,
+    lastFailureAtMs,
+    lastFailureReason,
+    hasLiveWorker: false,
+  };
+}
+
+describe("clusterWithinWindow", () => {
+  it("groups timestamps within the window into one cluster", () => {
+    expect(clusterWithinWindow([0, 500, 900], 1_000)).toEqual([[0, 500, 900]]);
+  });
+
+  it("starts a fresh cluster once a gap exceeds the window", () => {
+    expect(clusterWithinWindow([0, 500, 2_000], 1_000)).toEqual([
+      [0, 500],
+      [2_000],
+    ]);
+  });
+
+  it("measures each gap against the cluster's own latest member, not its first", () => {
+    // 0 -> 900 -> 1_800: each successive gap is 900 (within the window), so
+    // the whole run stays one cluster even though 1_800 is 1_800 past 0.
+    expect(clusterWithinWindow([0, 900, 1_800], 1_000)).toEqual([
+      [0, 900, 1_800],
+    ]);
+  });
+
+  it("returns one singleton cluster per timestamp when nothing is close enough", () => {
+    expect(clusterWithinWindow([0, 5_000, 10_000], 1_000)).toEqual([
+      [0],
+      [5_000],
+      [10_000],
+    ]);
+  });
+
+  it("returns no clusters for no timestamps", () => {
+    expect(clusterWithinWindow([], CORRELATED_WINDOW_MS)).toEqual([]);
+  });
+});
+
+describe("correlatedFailureTimestampsMs", () => {
+  it("trips on two tickets whose latest release shares a correlatable reason within the window", () => {
+    const tickets = [
+      ticketWithFailure(1_000, "nonzero-exit"),
+      ticketWithFailure(1_500, "nonzero-exit"),
+    ];
+
+    expect(correlatedFailureTimestampsMs(tickets)).toEqual([1_500]);
+  });
+
+  it("ignores a single failure — one death is a ticket failure until proven otherwise", () => {
+    const tickets = [ticketWithFailure(1_000, "timeout")];
+
+    expect(correlatedFailureTimestampsMs(tickets)).toEqual([]);
+  });
+
+  it("ignores tickets that failed in different ways", () => {
+    const tickets = [
+      ticketWithFailure(1_000, "stall"),
+      ticketWithFailure(1_050, "timeout"),
+    ];
+
+    expect(correlatedFailureTimestampsMs(tickets)).toEqual([]);
+  });
+
+  it("never reclassifies budget breaches or clean no-commit exits, same as the batch heuristic", () => {
+    const tickets = [
+      ticketWithFailure(1_000, "budget"),
+      ticketWithFailure(1_050, "budget"),
+      ticketWithFailure(1_100, "no-commits"),
+      ticketWithFailure(1_150, "no-commits"),
+    ];
+
+    expect(correlatedFailureTimestampsMs(tickets)).toEqual([]);
+  });
+
+  it("ignores tickets whose latest marker is no longer a Ticket-failure release", () => {
+    const tickets = [
+      ticketWithFailure(undefined, undefined),
+      ticketWithFailure(undefined, undefined),
+    ];
+
+    expect(correlatedFailureTimestampsMs(tickets)).toEqual([]);
+  });
+
+  it("does not collapse two correlated pairs spaced beyond the window into one trip", () => {
+    const tickets = [
+      ticketWithFailure(0, "stall"),
+      ticketWithFailure(500, "stall"),
+      ticketWithFailure(CORRELATED_WINDOW_MS * 10, "stall"),
+      ticketWithFailure(CORRELATED_WINDOW_MS * 10 + 500, "stall"),
+    ];
+
+    expect(correlatedFailureTimestampsMs(tickets)).toEqual([
+      500,
+      CORRELATED_WINDOW_MS * 10 + 500,
     ]);
   });
 });

--- a/tests/core/plan.test.ts
+++ b/tests/core/plan.test.ts
@@ -22,6 +22,9 @@ function ticket(overrides: Partial<Ticket> & { number: number }): Ticket {
     agentClaimCount: 0,
     attemptFailures: [],
     voidedAtMs: undefined,
+    lastFailureAtMs: undefined,
+    lastFailureReason: undefined,
+    hasLiveWorker: false,
     ...overrides,
   };
 }
@@ -158,6 +161,25 @@ describe("plan", () => {
     );
 
     expect(actions).toEqual([{ type: "release", ticket: 5 }]);
+  });
+
+  it("keeps a claim whose Worker job is still live, even with no PR yet (issue #73)", () => {
+    // Dispatch is fire-and-forget: by the time this Tick observes the world,
+    // the Worker (local or remote) may not have opened its PR yet. Worker
+    // liveness read from GitHub is what keeps this from reading as orphaned.
+    const actions = plan(
+      world([
+        ticket({
+          number: 5,
+          labels: ["ready-for-agent", CLAIM_LABEL],
+          hasAgentClaim: true,
+          hasLiveWorker: true,
+        }),
+      ]),
+      { maxWorkers: 3, maxOpenPrs: 5 },
+    );
+
+    expect(actions).toEqual([]);
   });
 
   it("keeps an agent claim whose ticket has an open agent PR", () => {

--- a/tests/core/render.test.ts
+++ b/tests/core/render.test.ts
@@ -39,6 +39,9 @@ function ticket(
     agentClaimCount: 0,
     attemptFailures: [],
     voidedAtMs: undefined,
+    lastFailureAtMs: undefined,
+    lastFailureReason: undefined,
+    hasLiveWorker: false,
     ...overrides,
   };
 }


### PR DESCRIPTION
feat(act): dispatch without waiting, with liveness from the tracker

## Summary

The act phase's dispatch seam gains a second, fire-and-forget implementation: `DispatchWorker` may now resolve with `undefined` once a Worker's job is merely triggered, and `act()` treats that as nothing to settle — the Worker settles its own Attempt itself (issue #71) and a later Tick reads the result back from the tracker. The local, synchronous `dispatchWorker` is untouched.

- `dispatchRemoteWorker` (`src/adapters/worker.ts`) triggers the Worker's GitHub Actions job via `gh workflow run`, passing ticket and attempt as explicit inputs, and resolves immediately with no outcome.
- Worker liveness moves from a promise held in the Orchestrator's memory to a running GitHub Actions job: `liveWorkerTickets` (`src/adapters/tracker.ts`) reads the Worker workflow's run list, feeding `Ticket.hasLiveWorker`. `isOrphanedClaim` (`src/core/plan.ts`) now checks it, so a Ticket whose Worker is still running is never mistaken for an abandoned claim — and once GitHub marks that job `completed` with nothing reported, the claim becomes recoverable again.
- The same-way-same-Tick correlated-infrastructure heuristic depended on seeing a batch of outcomes together, which a self-reporting Worker no longer produces. It's recomputed at Tick time instead: each ticket's latest Ticket-failure release (`lastFailureAtMs`/`lastFailureReason`) feeds `correlatedFailureTimestampsMs`, whose trips fold into the circuit breaker's tracker-derived state (`deriveBreaker`) alongside void markers.
- A shared `clusterWithinWindow` primitive in `classify.ts` now backs both the breaker's void-collapsing and the new correlation clustering.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx vitest run` (462 tests)
- New/updated coverage: fire-and-forget dispatch in `act()` (no waiting, no settling), `dispatchRemoteWorker`, `liveWorkerTickets`/`workerRunName`, `isOrphanedClaim` with a live Worker, `correlatedFailureTimestampsMs`/`clusterWithinWindow`, and `deriveBreaker` tripping on correlated releases — all driven through the existing `Exec` fake, no live GitHub calls.

Closes #73