### PR TITLE
fix(ci): install the Orchestrator from npm instead of building the checkout

### DIFF
--- a/.github/workflows/border-collie-tick.yml
+++ b/.github/workflows/border-collie-tick.yml
@@ -83,13 +83,13 @@ jobs:
         with:
           node-version: 24
 
-      # The Orchestrator is installed, never built from the checkout above
-      # (issue #93). This file is also what `init` scaffolds into a target
-      # repo (src/core/scaffold.ts), and that repo is the one being herded —
-      # it has no dist/ of ours to run and need not be a Node project at all.
-      # The version is pinned rather than floating because the cron above runs
-      # unattended; `pnpm run sync:version` keeps it in step with
-      # package.json, and a test fails the build if it ever drifts.
+      # The Orchestrator is installed, never built from the checkout above:
+      # this repository is the one being herded, not the herder, so it holds
+      # no build of border-collie to run and need not be a Node project at
+      # all. Pinned rather than floating because the cron above fires
+      # unattended, and a floating install would hand a sleeping fleet
+      # whatever released overnight — re-scaffold with `border-collie init
+      # --force` to move to a newer version deliberately.
       - name: Install border-collie
         run: npm install -g border-collie@0.3.0
 

--- a/.github/workflows/border-collie-tick.yml
+++ b/.github/workflows/border-collie-tick.yml
@@ -79,16 +79,19 @@ jobs:
           # clone doesn't have.
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v6
-
       - uses: actions/setup-node@v7
         with:
           node-version: 24
-          cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
-
-      - run: pnpm run build
+      # The Orchestrator is installed, never built from the checkout above
+      # (issue #93). This file is also what `init` scaffolds into a target
+      # repo (src/core/scaffold.ts), and that repo is the one being herded —
+      # it has no dist/ of ours to run and need not be a Node project at all.
+      # The version is pinned rather than floating because the cron above runs
+      # unattended; `pnpm run sync:version` keeps it in step with
+      # package.json, and a test fails the build if it ever drifts.
+      - name: Install border-collie
+        run: npm install -g border-collie@0.3.0
 
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code@latest
@@ -104,4 +107,4 @@ jobs:
           # this Tick makes (claims, comments, labels, closures) rides the
           # same credential rather than juggling two.
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: node dist/main.js tick
+        run: border-collie tick

--- a/.github/workflows/border-collie-worker.yml
+++ b/.github/workflows/border-collie-worker.yml
@@ -84,10 +84,10 @@ jobs:
           node-version: 24
 
       # Installed, never built from the checkout above — see the same step in
-      # border-collie-tick.yml for why (issue #93). Nothing here installs the
-      # *target* repo's own dependencies: a scaffolded repo need not be a Node
-      # project, so preparing a toolchain to build and test in is the Worker
-      # session's own job, guided by the target repo's CLAUDE.md.
+      # border-collie-tick.yml for why. Note what this does *not* do: it never
+      # installs this repository's own dependencies, because a herded repo
+      # need not be a Node project. Preparing a toolchain to build and test in
+      # is the Worker session's own job, guided by this repository's CLAUDE.md.
       - name: Install border-collie
         run: npm install -g border-collie@0.3.0
 

--- a/.github/workflows/border-collie-worker.yml
+++ b/.github/workflows/border-collie-worker.yml
@@ -32,7 +32,7 @@ on:
           Wall-clock ceiling in minutes for the job itself. GitHub Actions
           expressions cannot add a margin onto timeout_minutes at dispatch
           time, so this is its own input — keep it a few minutes above
-          timeout_minutes, covering setup (checkout, install, build, skills)
+          timeout_minutes, covering setup (checkout, installs, skills)
           before the watchdog starts and settlement (the tracker write)
           after it fires, so GitHub Actions never races the watchdog that
           kills the claude subprocess and settles the Attempt
@@ -79,16 +79,17 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: pnpm/action-setup@v6
-
       - uses: actions/setup-node@v7
         with:
           node-version: 24
-          cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
-
-      - run: pnpm run build
+      # Installed, never built from the checkout above — see the same step in
+      # border-collie-tick.yml for why (issue #93). Nothing here installs the
+      # *target* repo's own dependencies: a scaffolded repo need not be a Node
+      # project, so preparing a toolchain to build and test in is the Worker
+      # session's own job, guided by the target repo's CLAUDE.md.
+      - name: Install border-collie
+        run: npm install -g border-collie@0.3.0
 
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code@latest
@@ -116,7 +117,7 @@ jobs:
           ATTEMPT: ${{ inputs.attempt }}
           TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
         run: |
-          pnpm exec border-collie worker "$TICKET" "$ATTEMPT" \
+          border-collie worker "$TICKET" "$ATTEMPT" \
             --in-place \
             --timeout-minutes "$TIMEOUT_MINUTES"
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This writes `.github/workflows/border-collie-tick.yml` (the Orchestrator, which 
 
 Releases are tag-driven (see `.github/workflows/release.yml`):
 
-1. Bump the version and tag it: `npm version <patch|minor|major>`.
+1. Bump the version and tag it: `npm version <patch|minor|major>`. This also rewrites the `border-collie@<version>` pin in both scaffolded workflows (the `version` lifecycle script, `scripts/sync-workflow-version.mjs`) and stages the result into the version commit; a test fails the build if the pin and `package.json` ever drift apart.
 2. Push the tag: `git push --follow-tags`.
 3. Pushing a `v*` tag runs the release workflow: the same lint/typecheck/test/build/smoke gates as CI, a guard that the tag matches `package.json`'s version, a publish to npm over OIDC trusted publishing (no npm token stored in the repo), and a GitHub Release with generated notes.
 
@@ -65,6 +65,12 @@ Writes that must retrigger a workflow — dispatching a Worker's job, and a bran
 
 - `BORDER_COLLIE_APP_ID` (repository variable — not sensitive) and `BORDER_COLLIE_APP_PRIVATE_KEY` (repository secret): a GitHub App installed on this repository with contents, issues, and pull request write access, and Actions read/write access to dispatch and read back Worker job runs (deliberately excluding the separate Workflows permission, so a Worker can never rewrite the workflow *file* that runs it).
 - `CLAUDE_CODE_OAUTH_TOKEN`: a subscription OAuth token (`claude setup-token`) for the headless sessions the Tick still runs inline — Conflict Workers and Refinement rounds.
+
+Both workflows install the published CLI (`npm install -g border-collie@<version>`) rather than building the repository they check out. The checkout is the repo being *herded*, not the herder: a scaffolded target repo has no build of this package to run, and need not be a Node project at all. One consequence for this repository specifically — it is a consumer of its own package like any other, so a change to fleet behaviour reaches the fleet only once it is released, not when it merges.
+
+The pinned version is deliberate rather than `@latest`: the cron backstop runs unattended, and a floating install would hand a sleeping fleet a breaking release. A repo keeps whatever version scaffolded it until its workflows are re-scaffolded with `border-collie init --force`.
+
+Nothing in the Worker job installs the *target* repo's own dependencies — preparing a toolchain to build and test in is the Worker session's own job, guided by the target repo's `CLAUDE.md`.
 
 `border-collie init` scaffolds both workflow files above into a fresh repository and prints this same checklist.
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,12 @@ This writes `.github/workflows/border-collie-tick.yml` (the Orchestrator, which 
 
 Releases are tag-driven (see `.github/workflows/release.yml`):
 
-1. Bump the version and tag it: `npm version <patch|minor|major>`. This also rewrites the `border-collie@<version>` pin in both scaffolded workflows (the `version` lifecycle script, `scripts/sync-workflow-version.mjs`) and stages the result into the version commit; a test fails the build if the pin and `package.json` ever drift apart.
+1. Bump the version and tag it: `npm version <patch|minor|major>`.
 2. Push the tag: `git push --follow-tags`.
 3. Pushing a `v*` tag runs the release workflow: the same lint/typecheck/test/build/smoke gates as CI, a guard that the tag matches `package.json`'s version, a publish to npm over OIDC trusted publishing (no npm token stored in the repo), and a GitHub Release with generated notes.
+4. **Once the publish has landed**, point this repository's own fleet at it: `pnpm run sync:version`, then commit the two workflow files it rewrites.
+
+Step 4 is deliberately after the publish rather than folded into step 1. The workflows `npm install -g border-collie@<version>`, so a pin bumped ahead of the publish would 404 every Tick that fired in the window between — including the half-hourly cron. A pin *behind* `package.json` is harmless, and is the normal state between steps 1 and 4: the fleet simply keeps running the last version that exists. A test enforces that one-sidedness, failing the build only if a pin names a version this package hasn't reached.
 
 To rehearse a release without publishing, run the release workflow manually from the Actions tab (`workflow_dispatch`) — it runs the same gates and a `pnpm publish --dry-run` instead of a real publish.
 

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "dev": "tsx src/main.ts",
     "logs:pretty": "node scripts/logs-pretty.mjs",
     "smoke": "scripts/smoke.sh",
-    "sync:version": "node scripts/sync-workflow-version.mjs",
-    "version": "pnpm run sync:version && git add .github/workflows"
+    "sync:version": "node scripts/sync-workflow-version.mjs"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "test:watch": "vitest",
     "dev": "tsx src/main.ts",
     "logs:pretty": "node scripts/logs-pretty.mjs",
-    "smoke": "scripts/smoke.sh"
+    "smoke": "scripts/smoke.sh",
+    "sync:version": "node scripts/sync-workflow-version.mjs",
+    "version": "pnpm run sync:version && git add .github/workflows"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.5",

--- a/scripts/sync-workflow-version.mjs
+++ b/scripts/sync-workflow-version.mjs
@@ -1,15 +1,14 @@
 #!/usr/bin/env node
 /**
- * Rewrite the border-collie version the scaffolded workflows pin so it always
- * names this package's own version (issue #93).
+ * Point this repository's own fleet at the version it most recently published
+ * (issue #93), by rewriting the `border-collie@<version>` pin in the two
+ * scaffolded workflows to match package.json.
  *
- * The workflows install the published CLI rather than building the checkout,
- * which makes the pin part of what `init` hands a target repo — and nothing
- * about bumping package.json updates a yml on its own. This runs from npm's
- * `version` lifecycle, after the bump and before the version commit, so the
- * rewrite rides along in that commit rather than trailing it. A test
- * (tests/adapters/scaffold.test.ts) fails the build if the two ever drift, so
- * forgetting to run this is caught rather than shipped.
+ * Run this *after* a release publishes, never before — see README "Release
+ * process". The pin names what the workflows `npm install -g`, so a pin ahead
+ * of npm 404s every Tick until the publish lands; a pin behind it merely
+ * keeps the fleet on the previous version, which is why the guard in
+ * tests/adapters/scaffold.test.ts rejects only the former.
  */
 import { readFileSync, writeFileSync } from "node:fs";
 
@@ -18,17 +17,20 @@ const PIN_PATTERN = /(npm install -g border-collie@)(\S+)/g;
 const { version } = JSON.parse(readFileSync("package.json", "utf8"));
 
 // Deliberately duplicated from SCAFFOLD_FILES (src/core/scaffold.ts) rather
-// than imported: this runs from the `version` lifecycle, where dist/ reflects
-// whatever was last built, and a stale build silently syncing the wrong set
-// of files is worse than two short lists that a drifting pin fails a test.
+// than imported, so this stays a plain node script with no build step —
+// matching scripts/logs-pretty.mjs's own copy of RUN_DIR. A file added there
+// and forgotten here keeps a stale pin, which the guard catches at the next
+// release rather than silently shipping.
 const TEMPLATES = [
   ".github/workflows/border-collie-tick.yml",
   ".github/workflows/border-collie-worker.yml",
 ];
 
-let changed = false;
-
-for (const relPath of TEMPLATES) {
+// Every template is read and checked before any is written: this rewrites
+// files that are also the `init` templates, and a run that updates one and
+// exits on the next would leave the two disagreeing about which version the
+// fleet runs.
+const planned = TEMPLATES.map((relPath) => {
   const before = readFileSync(relPath, "utf8");
   let pins = 0;
   const after = before.replace(PIN_PATTERN, (_match, install) => {
@@ -36,18 +38,27 @@ for (const relPath of TEMPLATES) {
     return `${install}${version}`;
   });
 
-  if (pins === 0) {
+  return { relPath, before, after, pins };
+});
+
+const unpinned = planned.filter((template) => template.pins === 0);
+
+if (unpinned.length > 0) {
+  for (const { relPath } of unpinned) {
     console.error(
-      `${relPath}: no \`npm install -g border-collie@<version>\` step to sync — the workflow no longer pins the Orchestrator`,
+      `${relPath}: no \`npm install -g border-collie@<version>\` step to sync — the workflow no longer pins the CLI`,
     );
-    process.exit(1);
   }
+  process.exit(1);
+}
 
-  if (after === before) continue;
+const changed = planned.filter(
+  (template) => template.after !== template.before,
+);
 
+for (const { relPath, after } of changed) {
   writeFileSync(relPath, after);
-  changed = true;
   console.log(`synced ${relPath} to border-collie@${version}`);
 }
 
-if (!changed) console.log(`already at border-collie@${version}`);
+if (changed.length === 0) console.log(`already at border-collie@${version}`);

--- a/scripts/sync-workflow-version.mjs
+++ b/scripts/sync-workflow-version.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * Rewrite the border-collie version the scaffolded workflows pin so it always
+ * names this package's own version (issue #93).
+ *
+ * The workflows install the published CLI rather than building the checkout,
+ * which makes the pin part of what `init` hands a target repo — and nothing
+ * about bumping package.json updates a yml on its own. This runs from npm's
+ * `version` lifecycle, after the bump and before the version commit, so the
+ * rewrite rides along in that commit rather than trailing it. A test
+ * (tests/adapters/scaffold.test.ts) fails the build if the two ever drift, so
+ * forgetting to run this is caught rather than shipped.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+
+const PIN_PATTERN = /(npm install -g border-collie@)(\S+)/g;
+
+const { version } = JSON.parse(readFileSync("package.json", "utf8"));
+
+// Deliberately duplicated from SCAFFOLD_FILES (src/core/scaffold.ts) rather
+// than imported: this runs from the `version` lifecycle, where dist/ reflects
+// whatever was last built, and a stale build silently syncing the wrong set
+// of files is worse than two short lists that a drifting pin fails a test.
+const TEMPLATES = [
+  ".github/workflows/border-collie-tick.yml",
+  ".github/workflows/border-collie-worker.yml",
+];
+
+let changed = false;
+
+for (const relPath of TEMPLATES) {
+  const before = readFileSync(relPath, "utf8");
+  let pins = 0;
+  const after = before.replace(PIN_PATTERN, (_match, install) => {
+    pins += 1;
+    return `${install}${version}`;
+  });
+
+  if (pins === 0) {
+    console.error(
+      `${relPath}: no \`npm install -g border-collie@<version>\` step to sync — the workflow no longer pins the Orchestrator`,
+    );
+    process.exit(1);
+  }
+
+  if (after === before) continue;
+
+  writeFileSync(relPath, after);
+  changed = true;
+  console.log(`synced ${relPath} to border-collie@${version}`);
+}
+
+if (!changed) console.log(`already at border-collie@${version}`);

--- a/src/core/scaffold.ts
+++ b/src/core/scaffold.ts
@@ -19,9 +19,10 @@ export const SCAFFOLD_FILES: readonly string[] = [
 ];
 
 /**
- * How the scaffolded workflows install the Orchestrator (issue #93). A target
- * repo is not this repo: it has no `dist/` to run and no lockfile of ours to
- * install from, so the workflows install the published CLI rather than
+ * How the scaffolded workflows install the border-collie CLI (issue #93) — the
+ * Tick's Orchestrator and the Worker entrypoint alike ship in the one package.
+ * A target repo is not this repo: it has no `dist/` to run and no lockfile of
+ * ours to install from, so the workflows install the published CLI rather than
  * building the checkout — the checkout is the repo being herded, never the
  * herder. The pin is deliberate: the Tick's half-hourly cron runs unattended,
  * and a floating `@latest` would hand an unattended fleet a breaking release.
@@ -29,13 +30,48 @@ export const SCAFFOLD_FILES: readonly string[] = [
 const CLI_PIN_PATTERN = /npm install -g border-collie@(\S+)/;
 
 /**
- * The version a scaffolded workflow pins the Orchestrator to, or null if it
- * names none — a template that floats is as much a failure of the invariant
- * as one naming the wrong version, so an unpinned install reads as null
- * rather than as some default.
+ * The version a scaffolded workflow pins the CLI to, or null if it names
+ * none — a template that floats is as much a failure of the invariant as one
+ * naming the wrong version, so an unpinned install reads as null rather than
+ * as some default.
  */
 export function pinnedCliVersion(template: string): string | null {
   return CLI_PIN_PATTERN.exec(template)?.[1] ?? null;
+}
+
+function versionParts(version: string): number[] {
+  const release = version.split("-")[0] ?? version;
+  return release.split(".").map(Number);
+}
+
+/**
+ * Whether a pin names a version newer than this package's own — the one
+ * state that is always broken, because a version this package has not
+ * reached cannot be on npm yet and `npm install -g border-collie@<it>` can
+ * only 404.
+ *
+ * A pin *behind* package.json is fine, and is the normal state for a release
+ * (issue #93): `npm version` bumps package.json before the tag push
+ * publishes anything, so between those two moments this repo's own fleet has
+ * to keep running the last version that actually exists. `pnpm run
+ * sync:version` moves the pin up afterwards, once there is something to move
+ * it to — so the pin lags a release rather than leading it.
+ *
+ * Prerelease identifiers are compared on the release triple alone, which is
+ * all this guard needs: it exists to catch a pin naming an unpublished
+ * *version*, not to order two prereleases of one.
+ */
+export function pinIsAhead(pin: string, packageVersion: string): boolean {
+  const pinned = versionParts(pin);
+  const own = versionParts(packageVersion);
+
+  for (let i = 0; i < Math.max(pinned.length, own.length); i++) {
+    const a = pinned[i] ?? 0;
+    const b = own[i] ?? 0;
+    if (a !== b) return a > b;
+  }
+
+  return false;
 }
 
 export type ScaffoldOutcome = "written" | "overwritten" | "skipped-exists";

--- a/src/core/scaffold.ts
+++ b/src/core/scaffold.ts
@@ -18,6 +18,26 @@ export const SCAFFOLD_FILES: readonly string[] = [
   ".github/workflows/border-collie-worker.yml",
 ];
 
+/**
+ * How the scaffolded workflows install the Orchestrator (issue #93). A target
+ * repo is not this repo: it has no `dist/` to run and no lockfile of ours to
+ * install from, so the workflows install the published CLI rather than
+ * building the checkout — the checkout is the repo being herded, never the
+ * herder. The pin is deliberate: the Tick's half-hourly cron runs unattended,
+ * and a floating `@latest` would hand an unattended fleet a breaking release.
+ */
+const CLI_PIN_PATTERN = /npm install -g border-collie@(\S+)/;
+
+/**
+ * The version a scaffolded workflow pins the Orchestrator to, or null if it
+ * names none — a template that floats is as much a failure of the invariant
+ * as one naming the wrong version, so an unpinned install reads as null
+ * rather than as some default.
+ */
+export function pinnedCliVersion(template: string): string | null {
+  return CLI_PIN_PATTERN.exec(template)?.[1] ?? null;
+}
+
 export type ScaffoldOutcome = "written" | "overwritten" | "skipped-exists";
 
 export interface ScaffoldAction {
@@ -91,5 +111,9 @@ export function renderChecklist(): string {
    number (run \`border-collie --help\` for the full config shape).
 
 Worker skills install automatically inside each Worker job — no separate
-setup step is needed for those.`;
+setup step is needed for those.
+
+The scaffolded workflows install border-collie from npm at a pinned version,
+so this repository needs no build of its own to run one and keeps that
+version until you re-scaffold with \`border-collie init --force\`.`;
 }

--- a/tests/adapters/scaffold.test.ts
+++ b/tests/adapters/scaffold.test.ts
@@ -7,7 +7,11 @@ import {
   loadTemplate,
   writeScaffoldFile,
 } from "../../src/adapters/scaffold.js";
-import { pinnedCliVersion, SCAFFOLD_FILES } from "../../src/core/scaffold.js";
+import {
+  pinIsAhead,
+  pinnedCliVersion,
+  SCAFFOLD_FILES,
+} from "../../src/core/scaffold.js";
 
 describe("fileExists", () => {
   it("is false for a path that isn't there", () => {
@@ -59,21 +63,31 @@ describe("loadTemplate", () => {
 });
 
 /**
- * The drift guard for the version the templates pin (issue #93). `init` hands
- * a target repo these files verbatim, so the pin is what that repo will run
- * forever after — and a pin naming a version this package isn't would either
- * install code the operator never scaffolded or fail outright. Nothing about
- * a bumped package.json updates a yml on its own, so the invariant is checked
- * here and kept true mechanically by `pnpm run sync:version` (the `version`
- * lifecycle script, README "Release process").
+ * The guard on the version the templates pin (issue #93). `init` hands a
+ * target repo these files verbatim, so the pin is what that repo runs until
+ * it is re-scaffolded, and a pin naming a version that isn't on npm fails
+ * every Tick with a 404.
+ *
+ * The invariant is one-sided on purpose: a pin *behind* package.json is the
+ * normal state between `npm version` and the publish it precedes, so only a
+ * pin that leads is an error. `pnpm run sync:version` closes the gap after a
+ * release (README "Release process").
  */
 describe("the scaffolded templates' pinned version", () => {
   const packageVersion = JSON.parse(readFileSync("package.json", "utf8"))
     .version as string;
 
   for (const relPath of SCAFFOLD_FILES) {
-    it(`matches this package's own version in ${relPath}`, () => {
-      expect(pinnedCliVersion(loadTemplate(relPath))).toBe(packageVersion);
+    describe(relPath, () => {
+      const pin = pinnedCliVersion(loadTemplate(relPath));
+
+      it("pins a version rather than floating", () => {
+        expect(pin).not.toBeNull();
+      });
+
+      it("never names a version this package hasn't reached, which could not be on npm yet", () => {
+        expect(pinIsAhead(pin as string, packageVersion)).toBe(false);
+      });
     });
   }
 });

--- a/tests/adapters/scaffold.test.ts
+++ b/tests/adapters/scaffold.test.ts
@@ -7,7 +7,7 @@ import {
   loadTemplate,
   writeScaffoldFile,
 } from "../../src/adapters/scaffold.js";
-import { SCAFFOLD_FILES } from "../../src/core/scaffold.js";
+import { pinnedCliVersion, SCAFFOLD_FILES } from "../../src/core/scaffold.js";
 
 describe("fileExists", () => {
   it("is false for a path that isn't there", () => {
@@ -56,4 +56,24 @@ describe("loadTemplate", () => {
       expect(loadTemplate(relPath)).toBe(fromPackageRoot);
     }
   });
+});
+
+/**
+ * The drift guard for the version the templates pin (issue #93). `init` hands
+ * a target repo these files verbatim, so the pin is what that repo will run
+ * forever after — and a pin naming a version this package isn't would either
+ * install code the operator never scaffolded or fail outright. Nothing about
+ * a bumped package.json updates a yml on its own, so the invariant is checked
+ * here and kept true mechanically by `pnpm run sync:version` (the `version`
+ * lifecycle script, README "Release process").
+ */
+describe("the scaffolded templates' pinned version", () => {
+  const packageVersion = JSON.parse(readFileSync("package.json", "utf8"))
+    .version as string;
+
+  for (const relPath of SCAFFOLD_FILES) {
+    it(`matches this package's own version in ${relPath}`, () => {
+      expect(pinnedCliVersion(loadTemplate(relPath))).toBe(packageVersion);
+    });
+  }
 });

--- a/tests/core/scaffold.test.ts
+++ b/tests/core/scaffold.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  pinnedCliVersion,
   planScaffold,
   renderChecklist,
   renderScaffoldReport,
@@ -38,6 +39,34 @@ describe("planScaffold", () => {
       relPath: second,
       outcome: "written",
     });
+  });
+});
+
+describe("pinnedCliVersion", () => {
+  it("reads the version a template pins the orchestrator to", () => {
+    const template = [
+      "      - name: Install border-collie",
+      "        run: npm install -g border-collie@1.2.3",
+    ].join("\n");
+
+    expect(pinnedCliVersion(template)).toBe("1.2.3");
+  });
+
+  it("is null for a template that installs nothing", () => {
+    expect(pinnedCliVersion("name: Worker\n")).toBeNull();
+  });
+
+  it("ignores another package's pin on a neighbouring line", () => {
+    const template = [
+      "        run: npm install -g @anthropic-ai/claude-code@latest",
+      "        run: npm install -g border-collie@0.9.0",
+    ].join("\n");
+
+    expect(pinnedCliVersion(template)).toBe("0.9.0");
+  });
+
+  it("is null when the install floats instead of pinning", () => {
+    expect(pinnedCliVersion("run: npm install -g border-collie\n")).toBeNull();
   });
 });
 
@@ -108,6 +137,11 @@ describe("renderChecklist", () => {
   it("excludes the Workflows permission, so a Worker can never rewrite its own workflow", () => {
     expect(checklist).toContain("Leave Workflows ungranted");
     expect(checklist).not.toMatch(/Workflows:\s*Read/);
+  });
+
+  it("says how the orchestrator itself arrives, so no build is expected of the target repo", () => {
+    expect(checklist).toContain("install border-collie from npm");
+    expect(checklist).toContain("border-collie init --force");
   });
 
   it("lists the minimum repository permissions", () => {

--- a/tests/core/scaffold.test.ts
+++ b/tests/core/scaffold.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  pinIsAhead,
   pinnedCliVersion,
   planScaffold,
   renderChecklist,
@@ -67,6 +68,32 @@ describe("pinnedCliVersion", () => {
 
   it("is null when the install floats instead of pinning", () => {
     expect(pinnedCliVersion("run: npm install -g border-collie\n")).toBeNull();
+  });
+});
+
+describe("pinIsAhead", () => {
+  it("is false for a pin this package has exactly reached", () => {
+    expect(pinIsAhead("0.3.0", "0.3.0")).toBe(false);
+  });
+
+  it("is false for a pin lagging behind, the normal state mid-release", () => {
+    expect(pinIsAhead("0.3.0", "0.3.1")).toBe(false);
+    expect(pinIsAhead("0.9.9", "1.0.0")).toBe(false);
+  });
+
+  it("is true for a pin naming a version that cannot be on npm yet", () => {
+    expect(pinIsAhead("0.3.1", "0.3.0")).toBe(true);
+    expect(pinIsAhead("1.0.0", "0.9.9")).toBe(true);
+  });
+
+  it("compares numerically, not as strings", () => {
+    expect(pinIsAhead("0.10.0", "0.9.0")).toBe(true);
+    expect(pinIsAhead("0.9.0", "0.10.0")).toBe(false);
+  });
+
+  it("compares a prerelease on its release triple", () => {
+    expect(pinIsAhead("0.4.0-beta.1", "0.4.0")).toBe(false);
+    expect(pinIsAhead("0.5.0-beta.1", "0.4.0")).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #93.

## The problem

Both scaffolded workflows built border-collie out of the repository they checked out — `pnpm install --frozen-lockfile`, `pnpm run build`, then `node dist/main.js tick` (Tick) or `pnpm exec border-collie worker` (Worker). Different spellings of the same assumption: that the checkout *is* this repository.

It isn't. `src/core/scaffold.ts` ships both files verbatim as the `init` templates, and `package.json`'s `files` publishes them to npm, so they are copied as-is into every target repo. There, the checkout is the repo being *herded*: it has no `dist/` of ours to run, no lockfile of ours to install from, and need not be a Node project at all. The Tick named in the issue title had the bug; so did the Worker.

## The fix

Both workflows now `npm install -g border-collie@<version>` and invoke it off PATH. `actions/checkout` stays — including `fetch-depth: 0` on the Tick, which a Conflict or Refinement Worker's rebase needs for the commit graph. `gates.yml` is deliberately untouched: it is this repo's own CI, not a scaffolded template, so building its checkout is correct there.

The pin is deliberate rather than `@latest` — the Tick's cron fires unattended, and a floating install would hand a sleeping fleet whatever released overnight. A repo keeps the version that scaffolded it until re-scaffolded with `border-collie init --force`.

## The pin must lag a release, never lead it

The first commit tied the pin to npm's `version` lifecycle. That was wrong, and review caught it: `npm version patch` wrote `0.3.1` into the workflows *before* the tag push published `0.3.1`, so any Tick firing in that window — the half-hourly cron, a closed pull request, a finished Worker — ran `npm install -g border-collie@0.3.1` and 404ed. A failed publish would have left the fleet down until someone noticed.

The invariant is now one-sided. A pin *behind* `package.json` is fine and is the normal state mid-release: the fleet keeps running the last version that actually exists. Only a pin that leads is an error, because that one cannot resolve. `pinIsAhead` decides, the guard in `tests/adapters/scaffold.test.ts` rejects only the leading case, and syncing moved out of the `version` lifecycle to a step after the publish (README "Release process", step 4).

## Two consequences worth a reviewer's attention

**This repository stops dogfooding `HEAD`.** It now runs its own published version, so a change to fleet behaviour reaches the fleet on release rather than on merge. That makes it a consumer of its own package like any other — but it is a real behaviour change, and the alternative (letting this repo's copies diverge from the templates they also serve as) is a legitimate call to make differently.

**Nothing installs the target repo's own dependencies any more.** `pnpm install --frozen-lockfile` was quietly doing double duty; a generic template cannot know whether a target is pnpm, npm, or not JavaScript. Preparing a toolchain to build and test in is now the Worker session's job, guided by the target repo's `CLAUDE.md`. Worth watching on the next Worker run here.

## Verification

- All five CI gates pass locally (lint, typecheck, test, build, smoke). `smoke` covers `border-collie init` against a fresh target repo.
- Both workflow files parse as valid YAML.
- The guard was exercised in all three directions: a leading pin fails, an unpinned float fails, a lagging pin passes.
- `sync-workflow-version.mjs` validates every template before writing any — confirmed that a worker file with no pin leaves the tick file untouched rather than half-applying.
