### PR TITLE
fix(ci): set the Worker workflow's run-name so Worker liveness is readable

### DIFF
--- a/.github/workflows/border-collie-worker.yml
+++ b/.github/workflows/border-collie-worker.yml
@@ -10,6 +10,19 @@
 # checkout, which a dedicated job never has.
 name: Worker
 
+# The one place a running Worker says which Ticket it is running: the REST
+# API never echoes workflow_dispatch inputs back on the run itself, so the
+# Orchestrator's liveness check reads the ticket out of the run's display
+# title instead (`liveWorkerTickets`/`workerRunName`, src/adapters/tracker.ts,
+# issue #73) and must match this string exactly. Without it every claim looks
+# orphaned to the next Tick, which releases it out from under a Worker that
+# is still running (issue #111).
+#
+# Quoted deliberately: an unquoted `#` following a space starts a YAML
+# comment, which would silently truncate this to "border-collie worker" and
+# reintroduce the same failure.
+run-name: "border-collie worker #${{ inputs.ticket }} attempt ${{ inputs.attempt }}"
+
 on:
   workflow_dispatch:
     inputs:

--- a/src/core/scaffold.ts
+++ b/src/core/scaffold.ts
@@ -39,6 +39,24 @@ export function pinnedCliVersion(template: string): string | null {
   return CLI_PIN_PATTERN.exec(template)?.[1] ?? null;
 }
 
+/**
+ * A workflow's top-level `run-name:`, unquoted, or null if it declares none.
+ * The Worker template's is load-bearing rather than cosmetic (issue #111):
+ * Worker liveness is read back off a run's display title, so a template that
+ * declares none — or declares one YAML silently truncates at an unquoted `#`
+ * — leaves every in-flight claim looking orphaned to the next Tick. Returned
+ * raw enough that a truncated value stays visibly wrong to the caller
+ * comparing it against `workerRunName`, rather than being normalised into
+ * something that looks fine.
+ */
+const RUN_NAME_PATTERN = /^run-name:[ \t]*(.*?)[ \t]*$/m;
+
+export function declaredRunName(template: string): string | null {
+  const raw = RUN_NAME_PATTERN.exec(template)?.[1];
+  if (raw === undefined || raw === "") return null;
+  return raw.startsWith('"') && raw.endsWith('"') ? raw.slice(1, -1) : raw;
+}
+
 function versionParts(version: string): number[] {
   const release = version.split("-")[0] ?? version;
   return release.split(".").map(Number);

--- a/tests/adapters/scaffold.test.ts
+++ b/tests/adapters/scaffold.test.ts
@@ -7,7 +7,9 @@ import {
   loadTemplate,
   writeScaffoldFile,
 } from "../../src/adapters/scaffold.js";
+import { workerRunName } from "../../src/adapters/tracker.js";
 import {
+  declaredRunName,
   pinIsAhead,
   pinnedCliVersion,
   SCAFFOLD_FILES,
@@ -59,6 +61,34 @@ describe("loadTemplate", () => {
 
       expect(loadTemplate(relPath)).toBe(fromPackageRoot);
     }
+  });
+});
+
+/**
+ * The guard on the one string that ties a running Worker's job back to its
+ * Ticket (issue #111). `liveWorkerTickets` matches runs on their display
+ * title because workflow_dispatch inputs are not readable off a run, so the
+ * template's `run-name:` and `workerRunName` are two halves of one contract
+ * that nothing else checks: the tracker's own unit tests build their fake
+ * runs *with* `workerRunName`, so they stay green against a template that
+ * declares no run-name at all — which is exactly how the fleet shipped for
+ * a while, releasing live Workers' claims as orphaned every Tick.
+ */
+describe("the scaffolded Worker workflow's run-name", () => {
+  const runName = declaredRunName(
+    loadTemplate(".github/workflows/border-collie-worker.yml"),
+  );
+
+  it("declares one at all", () => {
+    expect(runName).not.toBeNull();
+  });
+
+  it("renders, from its dispatch inputs, exactly the title liveWorkerTickets matches on", () => {
+    const rendered = (runName as string)
+      .replace(/\$\{\{\s*inputs\.ticket\s*\}\}/, "5")
+      .replace(/\$\{\{\s*inputs\.attempt\s*\}\}/, "2");
+
+    expect(rendered).toBe(workerRunName(5, 2));
   });
 });
 


### PR DESCRIPTION
Closes #111.

`liveWorkerTickets` matches Worker runs by display title — the REST API never echoes `workflow_dispatch` inputs back on the run itself, so the title is the only place a running job says which Ticket it belongs to. But `border-collie-worker.yml` declared no `run-name:`, so every run's display title was literally `Worker`:

```console
$ gh run list --workflow border-collie-worker.yml --json displayTitle
[{"displayTitle":"Worker"}, ...]
```

`hasLiveWorker` was therefore **always false**, and any Tick landing between a Worker's dispatch and its pull request released the claim as an orphan — whatever triggered that Tick. On 2026-08-04 it happened twice to #106/#107/#108, once from a delayed `schedule` and once from a `workflow_run`, leaving three PRs open against unclaimed tickets.

Neither trigger was at fault: `types: [completed]` is correct (a *cancelled* run counts as completed too), and the Tick `concurrency` group correctly queued the scheduled Tick behind the manual one.

## The fix

```yaml
run-name: "border-collie worker #${{ inputs.ticket }} attempt ${{ inputs.attempt }}"
```

Quoting is load-bearing: unquoted, the ` #` starts a YAML comment and the name truncates to `border-collie worker`.

## Why a test was needed

`workerRunName` was exported and referenced by nothing outside its own unit tests — and those build their fake runs *with* `workerRunName`, so they stayed green against a template declaring no run-name at all. `declaredRunName` (core, alongside `pinnedCliVersion`) renders the shipped template's run-name so a test can hold the two halves of the contract against each other. It catches both the missing declaration and the unquoted-`#` truncation; verified failing against the pre-fix template.

## Not fixed here

A Tick running in the few seconds between `gh workflow run` returning and GitHub creating the run row still sees no live Worker. The window is small — the Tick that misfired was ~25s behind dispatch, well clear of it — but closing it properly wants a grace period on a just-posted claim marker. Worth its own ticket.

## Also worth noting

`dispatchableSet` does not veto a ticket with an *open* agent PR (only a merged one). Today `agentClaimCount < MAX_ATTEMPTS` happens to cover the fallout, but a released claim with a live PR is one attempt away from a duplicate dispatch. Not changed here.