### PR TITLE
fix(scaffold): create the labels the Orchestrator writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ To run the fleet in GitHub Actions instead of on your own machine, scaffold the 
 npx border-collie init
 ```
 
-This writes `.github/workflows/border-collie-tick.yml` (the Orchestrator, which also runs Conflict and Refinement Workers inline) and `.github/workflows/border-collie-worker.yml` (one job per dispatched Worker, skills setup included) — never overwriting a file already there unless `--force` is passed — then prints a checklist of the secrets and the minimum GitHub App permissions to supply before the first run (see "Continuous operation" below). Credentials come from a GitHub App you create and install yourself; border-collie hosts no shared service or webhook.
+This writes `.github/workflows/border-collie-tick.yml` (the Orchestrator, which also runs Conflict and Refinement Workers inline) and `.github/workflows/border-collie-worker.yml` (one job per dispatched Worker, skills setup included) — never overwriting a file already there unless `--force` is passed — creates the tracker labels the loop reads and writes (`ready-for-agent`, `ready-for-human`, `claimed`, `operator-steered`), leaving any that already exist exactly as they are, then prints a checklist of the secrets and the minimum GitHub App permissions to supply before the first run (see "Continuous operation" below). Credentials come from a GitHub App you create and install yourself; border-collie hosts no shared service or webhook.
+
+The labels are part of the scaffold because the Orchestrator writes them: a repo with every credential in place but no `claimed` label fails at the first Claim of its first Tick. If `init` cannot reach the tracker — no `gh` on the PATH, no remote yet, an unauthenticated shell — the workflow files are still written, and the labels are reported with the `gh label create` commands to run by hand.
 
 ## Release process
 
@@ -77,7 +79,7 @@ The pinned version is deliberate rather than `@latest`: the cron backstop runs u
 
 Nothing in the Worker job installs the *target* repo's own dependencies — preparing a toolchain to build and test in is the Worker session's own job, guided by the target repo's `CLAUDE.md`.
 
-`border-collie init` scaffolds both workflow files above into a fresh repository and prints this same checklist.
+`border-collie init` scaffolds both workflow files above into a fresh repository, creates the tracker labels the loop depends on, and prints this same checklist.
 
 ## Status
 

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -57,8 +57,16 @@ actual_version=$("$bin" --version) || die "border-collie --version exited non-ze
 # workspace symlinks and no source tree to fall back on.
 log "Running border-collie init against a fresh target repo"
 target_dir=$(mktemp -d)
-(cd "$target_dir" && "$bin" init >/dev/null) ||
+init_output=$(cd "$target_dir" && "$bin" init) ||
   die "border-collie init exited non-zero"
+
+# The temp dir is no git repo, so the label step (issue #100) cannot reach a
+# tracker — the case that must degrade to the checklist rather than take the
+# scaffold down with it. Nothing but a cold run outside a repo proves it.
+case "$init_output" in
+*"gh label create claimed"*) ;;
+*) die "init did not fall back to the hand-run label commands off-tracker" ;;
+esac
 for f in border-collie-tick.yml border-collie-worker.yml; do
   path="$target_dir/.github/workflows/$f"
   [ -s "$path" ] || die "init did not scaffold a non-empty $f"

--- a/src/adapters/tracker.ts
+++ b/src/adapters/tracker.ts
@@ -19,6 +19,7 @@ import {
   type MergedAgentPr,
   OPERATOR_STEERED_LABEL,
   type OpenAgentPr,
+  type OrchestratorLabel,
   parseAttemptMarker,
   parseQueuedBehindMarker,
   queuedBehindMarker,
@@ -588,6 +589,46 @@ export async function liveWorkerTickets(
     if (ticket !== undefined) live.add(ticket);
   }
   return live;
+}
+
+/**
+ * Every label name the repository has today (issue #100) — what `init` diffs
+ * the Orchestrator's label set against so it creates only what is missing,
+ * the same read-then-write shape the workflow files get. `gh label list`
+ * rather than the labels API: one page of 500 covers any repo an operator
+ * would point a fleet at, and no pagination to get wrong.
+ */
+export async function listLabelNames(exec: Exec = realExec): Promise<string[]> {
+  const stdout = await exec("gh", [
+    "label",
+    "list",
+    "--limit",
+    "500",
+    "--json",
+    "name",
+  ]);
+  const labels = JSON.parse(stdout) as { name?: string }[];
+  return labels.map((label) => label.name ?? "").filter((name) => name !== "");
+}
+
+/**
+ * Create one of the Orchestrator's labels. Never `--force`: an existing label
+ * belongs to the repository, and re-running `init` must not repaint a colour
+ * or reword a description an operator chose.
+ */
+export async function createLabel(
+  label: OrchestratorLabel,
+  exec: Exec = realExec,
+): Promise<void> {
+  await exec("gh", [
+    "label",
+    "create",
+    label.name,
+    "--color",
+    label.color,
+    "--description",
+    label.description,
+  ]);
 }
 
 /**

--- a/src/app/init.ts
+++ b/src/app/init.ts
@@ -4,13 +4,16 @@ import {
   loadTemplate,
   writeScaffoldFile,
 } from "../adapters/scaffold.js";
+import { createLabel, listLabelNames } from "../adapters/tracker.js";
 import {
+  type LabelAction,
   pinCliVersion,
   planScaffold,
   SCAFFOLD_FILES,
   type ScaffoldAction,
   scaffoldWrites,
 } from "../core/scaffold.js";
+import { ORCHESTRATOR_LABELS, type OrchestratorLabel } from "../core/types.js";
 
 export interface InitScaffoldDeps {
   exists: (cwd: string, relPath: string) => boolean;
@@ -56,5 +59,73 @@ export function initScaffoldOnce(
     write: writeScaffoldFile,
     loadTemplate,
     cliVersion,
+  });
+}
+
+export interface InitLabelDeps {
+  listLabels: () => Promise<string[]>;
+  createLabel: (label: OrchestratorLabel) => Promise<void>;
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Create the tracker labels the loop depends on (issue #100), skipping the
+ * ones already there — the same write-what's-missing, leave-what-exists shape
+ * the workflow files get, and for the same reason: those labels belong to the
+ * target repository, not to `init`.
+ *
+ * A tracker `init` cannot reach is reported, never thrown. This is the one
+ * step that needs a network and an authenticated `gh`, and the workflow files
+ * are on disk by the time it runs — failing the command outright would take a
+ * scaffold the operator already has and call it an error. Every label is
+ * returned as `failed` instead, which the report turns into the hand-run
+ * commands, degrading to exactly the checklist treatment the App permissions
+ * get.
+ */
+export async function runInitLabels(
+  deps: InitLabelDeps,
+): Promise<LabelAction[]> {
+  let existing: Set<string>;
+  try {
+    existing = new Set(await deps.listLabels());
+  } catch (error) {
+    const unreachable = messageOf(error);
+    return ORCHESTRATOR_LABELS.map((label) => ({
+      name: label.name,
+      outcome: "failed" as const,
+      error: unreachable,
+    }));
+  }
+
+  const actions: LabelAction[] = [];
+  for (const label of ORCHESTRATOR_LABELS) {
+    if (existing.has(label.name)) {
+      actions.push({ name: label.name, outcome: "exists" });
+      continue;
+    }
+    try {
+      await deps.createLabel(label);
+      actions.push({ name: label.name, outcome: "created" });
+    } catch (error) {
+      // One refused label must not cost the others their attempt: an
+      // operator handed a partial set should still be told which.
+      actions.push({
+        name: label.name,
+        outcome: "failed",
+        error: messageOf(error),
+      });
+    }
+  }
+  return actions;
+}
+
+/** The real composition for the label step. */
+export function initLabelsOnce(): Promise<LabelAction[]> {
+  return runInitLabels({
+    listLabels: () => listLabelNames(),
+    createLabel: (label) => createLabel(label),
   });
 }

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -5,7 +5,7 @@ import { fileTransport } from "tslog/transports/file";
 import { loadConfigFile } from "../adapters/config-file.js";
 import { probeEnvironment, RUN_DIR } from "../adapters/worker.js";
 import type { IntervalScheduler } from "../app/act.js";
-import { initScaffoldOnce } from "../app/init.js";
+import { initLabelsOnce, initScaffoldOnce } from "../app/init.js";
 import { type TickResult, tickOnce } from "../app/tick.js";
 import { workerAttemptOnce } from "../app/worker.js";
 import {
@@ -21,7 +21,7 @@ import {
   type LogEvent,
   scrubCredentials,
 } from "../core/log.js";
-import type { ScaffoldAction } from "../core/scaffold.js";
+import type { LabelAction, ScaffoldAction } from "../core/scaffold.js";
 import type { WorkerOutcome } from "../core/types.js";
 import { reportBlockText } from "./console-report.js";
 
@@ -50,6 +50,13 @@ export interface Context extends CommandContext {
   readonly probe: (model: string) => Promise<boolean>;
   /** `init` (issue #76): scaffold the workflows into the target repo at cwd. */
   readonly initScaffold: (force: boolean) => ScaffoldAction[];
+  /**
+   * `init` (issue #100): create the tracker labels the loop writes. A second
+   * seam rather than a return field on `initScaffold`, so the file scaffold
+   * stays the synchronous, offline step it has always been and the one step
+   * that needs a network stays separately fakeable.
+   */
+  readonly initLabels: () => Promise<LabelAction[]>;
   readonly now: () => number;
   readonly sleep: (ms: number) => Promise<void>;
   /** The fleet heartbeat's scheduler; see src/app/act.ts. */
@@ -225,6 +232,7 @@ export function buildRealContext(
       workerAttemptOnce(config, ticket, attempt, inPlace, { log }),
     probe: (model) => probeEnvironment(model),
     initScaffold: (force) => initScaffoldOnce(cwd, force),
+    initLabels: () => initLabelsOnce(),
     now,
     sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
     scheduleInterval,

--- a/src/cli/init-command.ts
+++ b/src/cli/init-command.ts
@@ -1,15 +1,20 @@
 import { buildCommand } from "@stricli/core";
-import { renderChecklist, renderScaffoldReport } from "../core/scaffold.js";
+import {
+  renderChecklist,
+  renderLabelReport,
+  renderScaffoldReport,
+} from "../core/scaffold.js";
 import type { Context } from "./context.js";
 
 export interface InitFlags {
   force: boolean;
 }
 
-function initHandler(this: Context, flags: InitFlags): void {
+async function initHandler(this: Context, flags: InitFlags): Promise<void> {
   const actions = this.initScaffold(flags.force);
+  const labels = await this.initLabels();
   this.process.stdout.write(
-    `${renderScaffoldReport(actions)}\n\n${renderChecklist()}\n`,
+    `${renderScaffoldReport(actions)}\n\n${renderLabelReport(labels)}\n\n${renderChecklist()}\n`,
   );
 }
 
@@ -31,13 +36,18 @@ export const initCommand = buildCommand<InitFlags, [], Context>({
     fullDescription: `init scaffolds the workflows a target repository needs to run border-collie
 in GitHub Actions — the Orchestrator's Tick (which also runs Conflict and
 Refinement Workers inline) and the Worker job, skills setup included — into
-.github/workflows in the current working directory, then prints a checklist
-of the secrets and the minimum GitHub App permissions to supply before the
-first run.
+.github/workflows in the current working directory, creates the tracker
+labels the loop reads and writes, then prints a checklist of the secrets and
+the minimum GitHub App permissions to supply before the first run.
 
 A file already present at a scaffolded path is left alone and reported as
 skipped, never overwritten silently; --force overwrites it instead, reported
-as such. The listed GitHub App permissions deliberately exclude workflow
+as such. A label already on the tracker is likewise left exactly as it is,
+--force or not: its colour and description belong to the repository. If the
+tracker cannot be reached at all, the workflows are still scaffolded and the
+labels are reported with the commands to create them by hand.
+
+The listed GitHub App permissions deliberately exclude workflow
 modification, so a Worker can never rewrite the workflow that runs it.`,
   },
 });

--- a/src/core/scaffold.ts
+++ b/src/core/scaffold.ts
@@ -7,6 +7,13 @@
  * adapters/scaffold.ts's concern.
  */
 
+import {
+  OPERATOR_STEERED_LABEL,
+  ORCHESTRATOR_LABELS,
+  type OrchestratorLabel,
+  READY_FOR_AGENT,
+} from "./types.js";
+
 /**
  * The files `init` scaffolds, relative to the target repo root — the exact
  * workflows this repo runs on itself (see .github/workflows/), so a target
@@ -105,6 +112,87 @@ export function renderScaffoldReport(actions: ScaffoldAction[]): string {
   return ["Scaffolded workflows:", ...actions.map(actionLine)].join("\n");
 }
 
+export type LabelOutcome = "created" | "exists" | "failed";
+
+export interface LabelAction {
+  name: string;
+  outcome: LabelOutcome;
+  /** Why the tracker refused, on `failed` only. */
+  error?: string;
+}
+
+/**
+ * The command an operator runs to add a label `init` could not (issue #100),
+ * so a tracker it cannot reach — no `gh` on the PATH, no remote yet, an
+ * unauthenticated shell — degrades to the checklist treatment the App
+ * permissions already get rather than to a silent gap.
+ */
+export function labelCreateCommand(label: OrchestratorLabel): string {
+  return `gh label create ${label.name} --color ${label.color} --description ${JSON.stringify(label.description)}`;
+}
+
+function labelLine(action: LabelAction): string {
+  switch (action.outcome) {
+    case "created":
+      return `  created    ${action.name}`;
+    case "exists":
+      return `  exists     ${action.name} (left as-is)`;
+    case "failed":
+      return `  failed     ${action.name}`;
+  }
+}
+
+/**
+ * The distinct refusals behind the failed actions, one indented line each and
+ * in first-seen order. A subprocess failure arrives as a message with the
+ * command's own stderr and its blank lines glued on, which would otherwise
+ * open a hole in the middle of the report.
+ */
+function failureLines(actions: LabelAction[]): string[] {
+  const reasons = actions
+    .filter((action) => action.outcome === "failed")
+    .map((action) => action.error?.trim() || "the tracker write failed");
+  return [...new Set(reasons)].flatMap((reason) =>
+    reason
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line !== "")
+      .map((line) => `  ${line}`),
+  );
+}
+
+/**
+ * The label report (issue #100). Every label the loop depends on is listed,
+ * created or not, because "exists" is the answer an operator re-running `init`
+ * needs as much as "created". A label that could not be written is followed by
+ * the reason and the hand-run command, since the first Claim of the first Tick
+ * is otherwise where the gap surfaces.
+ */
+export function renderLabelReport(actions: LabelAction[]): string {
+  const lines = ["Tracker labels:", ...actions.map(labelLine)];
+  const failed = actions.filter((action) => action.outcome === "failed");
+  if (failed.length > 0) {
+    const byName = new Map(ORCHESTRATOR_LABELS.map((l) => [l.name, l]));
+    lines.push(
+      "",
+      ...failureLines(actions),
+      "",
+      "  The Orchestrator writes these labels — the first Claim fails without",
+      "  them. Create the failed ones by hand before the first Tick:",
+      ...failed
+        .map((action) => byName.get(action.name))
+        .filter((label) => label !== undefined)
+        .map((label) => `    ${labelCreateCommand(label)}`),
+    );
+  }
+  return lines.join("\n");
+}
+
+/** The label set as prose, read off the one table so it cannot drift. */
+function labelNames(): string {
+  return ORCHESTRATOR_LABELS.map((label) => label.name).join(", ");
+}
+
 /**
  * The secrets and GitHub App permissions checklist (issue #76): a missing
  * credential is meant to be discovered here, before the first Tick, not from
@@ -112,6 +200,11 @@ export function renderScaffoldReport(actions: ScaffoldAction[]): string {
  * border-collie-worker.yml actually read (README.md "Continuous operation").
  * `BORDER_COLLIE_APP_ID` is a repository *variable*, not a secret — it isn't
  * sensitive — matching both scaffolded workflows.
+ *
+ * The labels earn their place here for the same reason (issue #100): a
+ * scaffolded repo that has every credential still fails its first Claim
+ * without them, and a checklist that stayed silent about it sent the operator
+ * to a failed run to find out.
  */
 export function renderChecklist(): string {
   return `Next steps:
@@ -134,6 +227,18 @@ export function renderChecklist(): string {
 
 3. Add a border-collie.json at the repo root with at least a "parent" issue
    number (run \`border-collie --help\` for the full config shape).
+
+4. Label a Ticket ${READY_FOR_AGENT} so the fleet has something to take.
+   Applying it vouches for that Ticket's text as trusted input to an agent
+   holding your credentials.
+
+The tracker labels the loop depends on —
+  ${labelNames()}
+— are created by \`init\` itself, and the label report above says which ones
+it had to add. Any it could not reach the tracker to create are named there
+too, with the command to add them by hand; the first Claim of the first Tick
+fails without them. Only ${OPERATOR_STEERED_LABEL} is ever applied by a human:
+it is the flag that takes a pull request out of the automatic Refinement loop.
 
 Worker skills install automatically inside each Worker job — no separate
 setup step is needed for those.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3,15 +3,59 @@
  * Vocabulary follows CONTEXT.md.
  */
 
-export const READY_FOR_AGENT = "ready-for-agent";
-export const READY_FOR_HUMAN = "ready-for-human";
+/** One tracker label the loop depends on, as `init` would create it. */
+export interface OrchestratorLabel {
+  readonly name: string;
+  /** Shown beside the label on the tracker — what its presence means. */
+  readonly description: string;
+  /** Six hex digits, no leading `#`, as `gh label create --color` takes it. */
+  readonly color: string;
+}
+
+/**
+ * Every label the loop reads or writes, defined once (issue #100). The
+ * constants below are *derived* from this table rather than listed beside it,
+ * so a label the Orchestrator starts writing cannot be one `init` forgets to
+ * create — the drift that scripts/sync-workflow-version.mjs's duplicated
+ * TEMPLATES list settles for. A repo missing one of these fails at its first
+ * write of it, which for `claimed` is the first Claim of the first Tick.
+ */
+const LABELS = {
+  readyForAgent: {
+    name: "ready-for-agent",
+    description: "Specified and trusted: a border-collie Worker may take it",
+    color: "0e8a16",
+  },
+  readyForHuman: {
+    name: "ready-for-human",
+    description: "Escalated to a human: the agent attempts are spent",
+    color: "d93f0b",
+  },
+  claimed: {
+    name: "claimed",
+    description: "Claimed by border-collie: a Worker is in flight",
+    color: "5319e7",
+  },
+  operatorSteered: {
+    name: "operator-steered",
+    description: "Operator is steering this PR: automatic Refinement skips it",
+    color: "1d76db",
+  },
+} as const satisfies Record<string, OrchestratorLabel>;
+
+/** The whole label set, in the order `init` reports it. */
+export const ORCHESTRATOR_LABELS: readonly OrchestratorLabel[] =
+  Object.values(LABELS);
+
+export const READY_FOR_AGENT = LABELS.readyForAgent.name;
+export const READY_FOR_HUMAN = LABELS.readyForHuman.name;
 
 /**
  * The label a Claim writes (CONTEXT.md "Claim"): border-collie's own
  * namespace, never applied by a human, so its presence alone is agent-claim
  * evidence independent of assignees.
  */
-export const CLAIM_LABEL = "claimed";
+export const CLAIM_LABEL = LABELS.claimed.name;
 
 /** A Ticket gets at most this many Attempts before Escalation (CONTEXT.md). */
 export const MAX_ATTEMPTS = 2;
@@ -176,7 +220,7 @@ export function parseAttemptMarker(body: string): AttemptFailure | undefined {
  * (CONTEXT.md "Operator-steered"). Distinct from `CLAIM_LABEL`: that one is
  * Ticket-scoped and agent-held, this one is PR-scoped and human-held.
  */
-export const OPERATOR_STEERED_LABEL = "operator-steered";
+export const OPERATOR_STEERED_LABEL = LABELS.operatorSteered.name;
 
 /**
  * A pull request gets at most this many Refinement rounds before Refinement

--- a/tests/adapters/tracker.test.ts
+++ b/tests/adapters/tracker.test.ts
@@ -5,9 +5,11 @@ import {
   commentConflictUnresolved,
   commentQueuedBehind,
   createDraftPr,
+  createLabel,
   type Exec,
   escalateTicket,
   giveUpOnPr,
+  listLabelNames,
   liveWorkerTickets,
   markPrDraft,
   markPrReady,
@@ -1390,6 +1392,56 @@ function recordingExec(): { exec: Exec; calls: string[][] } {
   };
   return { exec, calls };
 }
+
+/** Issue #100: the read-then-create pair `init` scaffolds the labels with. */
+describe("listLabelNames", () => {
+  it("reads the repository's label names", async () => {
+    const calls: string[][] = [];
+    const exec: Exec = async (cmd, args) => {
+      calls.push([cmd, ...args]);
+      return JSON.stringify([{ name: "bug" }, { name: READY_FOR_AGENT }]);
+    };
+
+    expect(await listLabelNames(exec)).toEqual(["bug", READY_FOR_AGENT]);
+    expect(calls).toEqual([
+      ["gh", "label", "list", "--limit", "500", "--json", "name"],
+    ]);
+  });
+
+  it("reads a repository with no labels at all as none", async () => {
+    const exec: Exec = async () => "[]";
+
+    expect(await listLabelNames(exec)).toEqual([]);
+  });
+});
+
+describe("createLabel", () => {
+  it("creates the label with its colour and description, never --force", async () => {
+    const { exec, calls } = recordingExec();
+
+    await createLabel(
+      {
+        name: CLAIM_LABEL,
+        description: "A Worker is in flight",
+        color: "5319e7",
+      },
+      exec,
+    );
+
+    expect(calls).toEqual([
+      [
+        "gh",
+        "label",
+        "create",
+        CLAIM_LABEL,
+        "--color",
+        "5319e7",
+        "--description",
+        "A Worker is in flight",
+      ],
+    ]);
+  });
+});
 
 describe("claimTicket", () => {
   it("adds the claim label first, then posts the claim marker comment", async () => {

--- a/tests/app/init.test.ts
+++ b/tests/app/init.test.ts
@@ -2,8 +2,18 @@ import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { initScaffoldOnce, runInitScaffold } from "../../src/app/init.js";
+import {
+  initScaffoldOnce,
+  runInitLabels,
+  runInitScaffold,
+} from "../../src/app/init.js";
 import { SCAFFOLD_FILES } from "../../src/core/scaffold.js";
+import {
+  CLAIM_LABEL,
+  ORCHESTRATOR_LABELS,
+  type OrchestratorLabel,
+  READY_FOR_AGENT,
+} from "../../src/core/types.js";
 import { pinnedCliVersion } from "../helpers/workflow-template.js";
 
 function fakeDeps(existing: string[] = [], version = "9.9.9") {
@@ -128,5 +138,112 @@ describe("initScaffoldOnce", () => {
         ),
       );
     }
+  });
+});
+
+function fakeLabelDeps(
+  existing: string[] = [],
+  refuse: (label: OrchestratorLabel) => Error | undefined = () => undefined,
+) {
+  const created: OrchestratorLabel[] = [];
+  return {
+    deps: {
+      listLabels: async () => existing,
+      createLabel: async (label: OrchestratorLabel) => {
+        const refusal = refuse(label);
+        if (refusal !== undefined) throw refusal;
+        created.push(label);
+      },
+    },
+    created,
+  };
+}
+
+/**
+ * Issue #100: a scaffolded repo had none of the labels the Orchestrator
+ * writes, so a repo that had followed every printed step still failed at the
+ * first Claim of the first Tick.
+ */
+describe("runInitLabels", () => {
+  it("creates every label the loop depends on, on a repo that has none", async () => {
+    const { deps, created } = fakeLabelDeps();
+
+    const actions = await runInitLabels(deps);
+
+    expect(created).toEqual([...ORCHESTRATOR_LABELS]);
+    expect(actions).toEqual(
+      ORCHESTRATOR_LABELS.map((label) => ({
+        name: label.name,
+        outcome: "created",
+      })),
+    );
+  });
+
+  it("leaves an existing label untouched and says it was already there", async () => {
+    const { deps, created } = fakeLabelDeps([READY_FOR_AGENT]);
+
+    const actions = await runInitLabels(deps);
+
+    expect(created.some((label) => label.name === READY_FOR_AGENT)).toBe(false);
+    expect(actions).toContainEqual({
+      name: READY_FOR_AGENT,
+      outcome: "exists",
+    });
+  });
+
+  /**
+   * The exact state issue #100 found this repository in: the two triage
+   * labels present, `claimed` never created, and nothing that would have
+   * noticed until a Claim tried to write it.
+   */
+  it("adds only what is missing from a partly-labelled repo", async () => {
+    const { deps, created } = fakeLabelDeps([
+      "ready-for-agent",
+      "ready-for-human",
+      "bug",
+    ]);
+
+    await runInitLabels(deps);
+
+    expect(created.map((label) => label.name)).toEqual([
+      CLAIM_LABEL,
+      "operator-steered",
+    ]);
+  });
+
+  it("reports an unreachable tracker instead of failing the whole init", async () => {
+    const deps = {
+      listLabels: async () => {
+        throw new Error("gh: not authenticated");
+      },
+      createLabel: async () => {
+        throw new Error("never reached");
+      },
+    };
+
+    const actions = await runInitLabels(deps);
+
+    expect(actions).toEqual(
+      ORCHESTRATOR_LABELS.map((label) => ({
+        name: label.name,
+        outcome: "failed",
+        error: "gh: not authenticated",
+      })),
+    );
+  });
+
+  it("keeps going past a refused label, so one refusal costs only itself", async () => {
+    const { deps, created } = fakeLabelDeps([], (label) =>
+      label.name === CLAIM_LABEL ? new Error("HTTP 403") : undefined,
+    );
+
+    const actions = await runInitLabels(deps);
+
+    expect(actions).toContainEqual({
+      name: CLAIM_LABEL,
+      outcome: "failed",
+      error: "HTTP 403",
+    });
+    expect(created).toHaveLength(ORCHESTRATOR_LABELS.length - 1);
   });
 });

--- a/tests/cli/app.test.ts
+++ b/tests/cli/app.test.ts
@@ -9,7 +9,7 @@ import {
   type WorkerAttemptConfig,
 } from "../../src/core/config.js";
 import type { Log, LogEvent } from "../../src/core/log.js";
-import type { ScaffoldAction } from "../../src/core/scaffold.js";
+import type { LabelAction, ScaffoldAction } from "../../src/core/scaffold.js";
 import type {
   Ticket,
   WorkerOutcome,
@@ -106,6 +106,7 @@ interface FakeContext {
   events: LogEvent[];
   verbosityCalls: boolean[];
   initScaffoldCalls: boolean[];
+  initLabelsCalls: boolean[];
 }
 
 function fakeContext(
@@ -114,6 +115,7 @@ function fakeContext(
     tickResults?: { world: WorldSnapshot; infraFailures?: number }[];
     runWorkerOutcome?: WorkerOutcome;
     initScaffoldResult?: ScaffoldAction[];
+    initLabelsResult?: LabelAction[];
   } = {},
 ): FakeContext {
   const stdoutLines: string[] = [];
@@ -134,9 +136,11 @@ function fakeContext(
   const events: LogEvent[] = [];
   const verbosityCalls: boolean[] = [];
   const initScaffoldCalls: boolean[] = [];
+  const initLabelsCalls: boolean[] = [];
   const tickResults = overrides.tickResults ?? [{ world: CLOSED_WORLD }];
   const runWorkerOutcome = overrides.runWorkerOutcome ?? workerOutcome();
   const initScaffoldResult = overrides.initScaffoldResult ?? [];
+  const initLabelsResult = overrides.initLabelsResult ?? [];
 
   const context: Context = {
     process: {
@@ -190,6 +194,10 @@ function fakeContext(
       initScaffoldCalls.push(force);
       return initScaffoldResult;
     },
+    initLabels: async () => {
+      initLabelsCalls.push(true);
+      return initLabelsResult;
+    },
   };
 
   return {
@@ -203,6 +211,7 @@ function fakeContext(
     events,
     verbosityCalls,
     initScaffoldCalls,
+    initLabelsCalls,
   };
 }
 
@@ -528,6 +537,46 @@ describe("init command", () => {
     expect(fake.stdout()).toContain(".github/workflows/border-collie-tick.yml");
     expect(fake.stdout()).toContain("BORDER_COLLIE_APP_PRIVATE_KEY");
     expect(fake.stdout()).toContain("CLAUDE_CODE_OAUTH_TOKEN");
+  });
+
+  /**
+   * Issue #100: the labels the loop writes are part of what a repo needs
+   * scaffolded, so `init` creates them on the same run as the workflows.
+   */
+  it("creates the tracker labels and reports what it did", async () => {
+    const fake = fakeContext({
+      initLabelsResult: [
+        { name: "claimed", outcome: "created" },
+        { name: "ready-for-agent", outcome: "exists" },
+      ],
+    });
+
+    await runCli(["init"], fake.context);
+
+    expect(fake.initLabelsCalls).toEqual([true]);
+    expect(fake.stdout()).toContain("created    claimed");
+    expect(fake.stdout()).toContain("exists     ready-for-agent");
+  });
+
+  it("still exits 0 with the workflows scaffolded when the tracker is unreachable", async () => {
+    const fake = fakeContext({
+      initScaffoldResult: [
+        {
+          relPath: ".github/workflows/border-collie-tick.yml",
+          outcome: "written",
+        },
+      ],
+      initLabelsResult: [
+        { name: "claimed", outcome: "failed", error: "gh: not authenticated" },
+      ],
+    });
+
+    await runCli(["init"], fake.context);
+
+    expect(fake.context.process.exitCode).toBeFalsy();
+    expect(fake.stdout()).toContain("wrote      .github/workflows");
+    expect(fake.stdout()).toContain("gh: not authenticated");
+    expect(fake.stdout()).toContain("gh label create claimed");
   });
 });
 

--- a/tests/core/scaffold.test.ts
+++ b/tests/core/scaffold.test.ts
@@ -1,12 +1,21 @@
 import { describe, expect, it } from "vitest";
 import {
+  labelCreateCommand,
   pinCliVersion,
   planScaffold,
   renderChecklist,
+  renderLabelReport,
   renderScaffoldReport,
   SCAFFOLD_FILES,
   scaffoldWrites,
 } from "../../src/core/scaffold.js";
+import {
+  CLAIM_LABEL,
+  OPERATOR_STEERED_LABEL,
+  ORCHESTRATOR_LABELS,
+  READY_FOR_AGENT,
+  READY_FOR_HUMAN,
+} from "../../src/core/types.js";
 import { pinnedCliVersion } from "../helpers/workflow-template.js";
 
 describe("pinCliVersion", () => {
@@ -165,5 +174,143 @@ describe("renderChecklist", () => {
     expect(checklist).toContain("Issues: Read and write");
     expect(checklist).toContain("Pull requests: Read and write");
     expect(checklist).toContain("Actions: Read and write");
+  });
+
+  /**
+   * Issue #100: a scaffolded repo with every credential still failed its
+   * first Claim, and the checklist — the place a gap is meant to surface
+   * before a run rather than during one — said nothing about labels.
+   */
+  it("names every label the loop depends on", () => {
+    for (const label of ORCHESTRATOR_LABELS) {
+      expect(checklist).toContain(label.name);
+    }
+  });
+
+  it("singles out the one label a human applies", () => {
+    expect(checklist).toContain(
+      `Only ${OPERATOR_STEERED_LABEL} is ever applied`,
+    );
+  });
+
+  it("keeps every line inside the block width the rest of it holds to", () => {
+    for (const line of checklist.split("\n")) {
+      expect(line.length).toBeLessThanOrEqual(78);
+    }
+  });
+});
+
+/**
+ * Issue #100: every label the Orchestrator reads or writes, defined once so
+ * the set `init` creates cannot drift from the set the loop uses. This asserts
+ * the constants the rest of the codebase imports are all *in* that set —
+ * the drift the issue named, in the direction it named it.
+ */
+describe("ORCHESTRATOR_LABELS", () => {
+  const names = ORCHESTRATOR_LABELS.map((label) => label.name);
+
+  it("covers every label constant the loop is written against", () => {
+    expect(names).toContain(READY_FOR_AGENT);
+    expect(names).toContain(READY_FOR_HUMAN);
+    expect(names).toContain(CLAIM_LABEL);
+    expect(names).toContain(OPERATOR_STEERED_LABEL);
+  });
+
+  it("gives each label a description and a six-digit hex colour", () => {
+    for (const label of ORCHESTRATOR_LABELS) {
+      expect(label.description).not.toBe("");
+      expect(label.color).toMatch(/^[0-9a-f]{6}$/);
+    }
+  });
+});
+
+describe("labelCreateCommand", () => {
+  it("quotes the description, so a multi-word one survives a copy-paste", () => {
+    const command = labelCreateCommand({
+      name: "claimed",
+      description: "Claimed by border-collie: a Worker is in flight",
+      color: "5319e7",
+    });
+
+    expect(command).toBe(
+      'gh label create claimed --color 5319e7 --description "Claimed by border-collie: a Worker is in flight"',
+    );
+  });
+});
+
+describe("renderLabelReport", () => {
+  it("reports a created label", () => {
+    const report = renderLabelReport([
+      { name: CLAIM_LABEL, outcome: "created" },
+    ]);
+
+    expect(report).toContain(`created    ${CLAIM_LABEL}`);
+  });
+
+  it("says an existing label was left as it was", () => {
+    const report = renderLabelReport([
+      { name: READY_FOR_AGENT, outcome: "exists" },
+    ]);
+
+    expect(report).toContain(`exists     ${READY_FOR_AGENT}`);
+    expect(report).toContain("left as-is");
+  });
+
+  it("gives a failed label the reason and the command to run by hand", () => {
+    const report = renderLabelReport([
+      { name: CLAIM_LABEL, outcome: "failed", error: "gh: no such remote" },
+    ]);
+
+    expect(report).toContain(`failed     ${CLAIM_LABEL}`);
+    expect(report).toContain("gh: no such remote");
+    expect(report).toContain(`gh label create ${CLAIM_LABEL} --color`);
+  });
+
+  /**
+   * An unreachable tracker fails every label with one and the same refusal;
+   * four copies of it would bury the four commands that actually matter.
+   */
+  it("states a shared refusal once, however many labels it took down", () => {
+    const report = renderLabelReport(
+      ORCHESTRATOR_LABELS.map((label) => ({
+        name: label.name,
+        outcome: "failed" as const,
+        error: "gh: not authenticated",
+      })),
+    );
+
+    expect(report.match(/gh: not authenticated/g)).toHaveLength(1);
+    expect(report.match(/gh label create /g)).toHaveLength(
+      ORCHESTRATOR_LABELS.length,
+    );
+  });
+
+  /**
+   * A refused `gh` arrives as a message with the command's own stderr and its
+   * trailing blank lines glued on, which would open a hole mid-report.
+   */
+  it("flattens a multi-line subprocess message into indented lines", () => {
+    const report = renderLabelReport([
+      {
+        name: CLAIM_LABEL,
+        outcome: "failed",
+        error: "Command failed: gh label list\nfatal: not a git repository\n\n",
+      },
+    ]);
+
+    expect(report).toContain("  Command failed: gh label list\n");
+    expect(report).toContain("  fatal: not a git repository\n");
+    expect(report).not.toContain("\n\n\n");
+  });
+
+  it("adds no hand-run block when every label landed", () => {
+    const report = renderLabelReport(
+      ORCHESTRATOR_LABELS.map((label) => ({
+        name: label.name,
+        outcome: "created" as const,
+      })),
+    );
+
+    expect(report).not.toContain("gh label create");
   });
 });


### PR DESCRIPTION
Closes #100.

## Problem

A repo scaffolded by `init` had none of the labels the loop writes. A target with the App installed, the secrets set, `border-collie.json` written and a Ticket labelled `ready-for-agent` still failed at the first Claim of its first Tick — having followed every step the checklist printed.

## What changed

`init` creates them, the same write-what's-missing, leave-what-exists shape the workflow files already get. An existing label is left exactly as it is, `--force` or not: its colour and description belong to the repository, not to `init`.

The set is defined **once** — a table in `src/core/types.ts` that `READY_FOR_AGENT`, `READY_FOR_HUMAN`, `CLAIM_LABEL` and `OPERATOR_STEERED_LABEL` are now derived *from* rather than listed beside. A label the Orchestrator starts writing cannot be one `init` forgets to create, which is the drift `scripts/sync-workflow-version.mjs`'s duplicated `TEMPLATES` list settles for.

A tracker `init` cannot reach — no `gh` on the PATH, no remote yet, an unauthenticated shell — is reported, never thrown. The workflows are on disk by the time the label step runs, and failing the command outright would take a scaffold the operator already has and call it an error. Every label comes back with the command to create it by hand, degrading to exactly the checklist treatment the App permissions already get. One refused label costs only itself, not the others' attempt.

```
Tracker labels:
  failed     ready-for-agent
  failed     ready-for-human
  failed     claimed
  failed     operator-steered

  Command failed: gh label list --limit 500 --json name
  failed to run git: fatal: not a git repository (or any of the parent directories): .git

  The Orchestrator writes these labels — the first Claim fails without
  them. Create the failed ones by hand before the first Tick:
    gh label create ready-for-agent --color 0e8a16 --description "Specified and trusted: a border-collie Worker may take it"
    ...
```

The checklist now names the label set and singles out `operator-steered` as the one a human ever applies.

## Layers touched

| Layer | Change |
| --- | --- |
| `core/types.ts` | the one label table; constants derived from it |
| `core/scaffold.ts` | `renderLabelReport`, `labelCreateCommand`, checklist prose |
| `adapters/tracker.ts` | `listLabelNames`, `createLabel` |
| `app/init.ts` | `runInitLabels` — list, create what's missing, report what it couldn't |
| `cli/` | new async `initLabels` seam; `init` prints scaffold → labels → checklist |

## Verification

`typecheck`, `biome`, 582 tests, `smoke` all pass. `scripts/smoke.sh` now asserts the off-tracker fallback from a cold tarball install in a non-repo temp dir — the path unit tests can't reach.

## Notes

- The issue's evidence that *this* repo lacks `claimed` is stale: `claimed` and `operator-steered` were created 2026-08-02. All four exist here, so there is nothing to backfill.
- The `tick` preflight the issue floats as "worth also considering" is **not** in this PR. It would add a `gh label list` per Tick and a new failure mode, and only helps repos scaffolded by an older version. Easy to add separately if wanted.