### PR TITLE
fix(classify): classify infrastructure from the environment's own fields

### DIFF
--- a/src/adapters/worker.ts
+++ b/src/adapters/worker.ts
@@ -3,8 +3,8 @@ import { createWriteStream, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
   classifyInfrastructure,
-  lastResultLine,
   parseResultEvent,
+  resultEventEvidence,
 } from "../core/classify.js";
 import type { Log, LogEvent } from "../core/log.js";
 import {
@@ -414,13 +414,16 @@ export async function dispatchWorker(
     // is kept (discarding it refunds nothing and the retry would cost more)
     // and the overrun is flagged instead. Infra is only consulted for
     // Workers that already died — a successful Attempt is never voided —
-    // and only against stderr plus the result line, never the transcript
-    // body, where a ticket legitimately about rate limits would match by
-    // content instead of cause.
+    // and only against stderr plus the result event's environment-authored
+    // fields, never the transcript body nor the Worker's closing message,
+    // where a ticket legitimately about rate limits would match by content
+    // instead of cause.
     const turnCapHit = result?.subtype === "error_max_turns";
     const infra =
       trigger !== undefined && !turnCapHit
-        ? classifyInfrastructure(`${stderrTail}\n${lastResultLine(stdoutTail)}`)
+        ? classifyInfrastructure(
+            `${stderrTail}\n${resultEventEvidence(result)}`,
+          )
         : undefined;
     const failure: FailureReason | undefined = turnCapHit
       ? "budget"
@@ -519,6 +522,10 @@ export async function probeEnvironment(
   return (
     endedBy === "exit" &&
     exitCode === 0 &&
+    // The whole of stdout is fair evidence here, unlike a Worker's: the probe
+    // runs a fixed one-word prompt with no ticket behind it, so nothing it
+    // prints can match by content instead of cause, and its plain-text stdout
+    // carries no result event to project.
     classifyInfrastructure(`${stderrTail}\n${stdoutTail}`) === undefined
   );
 }

--- a/src/core/classify.ts
+++ b/src/core/classify.ts
@@ -42,31 +42,58 @@ const INFRA_SIGNATURES: [InfraReason, RegExp][] = [
  * when nothing points at the environment. Only ever consulted for Workers
  * that already failed: a successful Attempt is never voided, whatever
  * transient noise its logs carry. Callers must pass only text the
- * environment itself produced (stderr, the result event line) — never the
- * transcript body, where a ticket legitimately about rate limits or network
- * errors would match by content, not cause, and void its attempts forever.
+ * environment itself produced (stderr, `resultEventEvidence` below) — never
+ * the transcript body nor the result event's `result` field, both of which
+ * carry the Worker's own words, where a ticket legitimately about rate limits
+ * or network errors would match by content, not cause, and void its attempts
+ * forever.
  */
 export function classifyInfrastructure(text: string): InfraReason | undefined {
   return INFRA_SIGNATURES.find(([, signature]) => signature.test(text))?.[0];
 }
 
 /**
- * The raw last result-event line of a transcript tail, or "" when none. The
- * one stdout line safe to classify against: on a failed run it carries the
- * CLI's own error text, not the Worker's prose or tool output.
+ * The environment-authored fields of the transcript's final stream-json
+ * result event. Deliberately excludes `result`, the CLI's verbatim copy of
+ * the Worker's closing message: that field is model-authored prose, and
+ * classifying against it made a Worker that merely wrote about rate limits
+ * void its own Attempt (issue #79). Every field here is the CLI's own
+ * account of the run, which no agent can write.
  */
-export function lastResultLine(tail: string): string {
-  return (
-    tail.split("\n").findLast((line) => line.includes('"type":"result"')) ?? ""
-  );
-}
-
-/** The budget-relevant fields of the transcript's final stream-json result event. */
 export interface ResultEvent {
   subtype: string | undefined;
   totalCostUsd: number | undefined;
   numTurns: number | undefined;
   durationMs: number | undefined;
+  /** The CLI's own verdict on the run; absent on CLI versions predating it. */
+  isError: boolean | undefined;
+  /** HTTP status of the API error that ended the run, when one did. */
+  apiErrorStatus: string | number | undefined;
+}
+
+/**
+ * The result event rendered as classification evidence, or "" when there is
+ * nothing to say. The one projection of stdout safe to pass to
+ * `classifyInfrastructure`: it is built from `ResultEvent`, which carries no
+ * model-authored field, so the type system — not a caller's discipline —
+ * keeps the Worker's prose away from the signatures.
+ *
+ * A run the CLI itself calls clean (`is_error: false`) yields no evidence at
+ * all: whatever ended such a Worker, the environment carried it to its end.
+ * The status renders under a bare `status` key so `INFRA_SIGNATURES`, written
+ * against the CLI's error dialect, reads it as the API error it is.
+ */
+export function resultEventEvidence(event: ResultEvent | undefined): string {
+  if (event === undefined || event.isError === false) return "";
+  const fields: string[] = [];
+  if (event.subtype !== undefined) fields.push(`"subtype":"${event.subtype}"`);
+  if (event.apiErrorStatus !== undefined) {
+    // Rendered raw rather than re-encoded: the evidence is a blob for the
+    // signatures to read, never parsed back, and a quoted "429" would not
+    // match the status signature a bare 429 does.
+    fields.push(`"status":${event.apiErrorStatus}`);
+  }
+  return fields.length === 0 ? "" : `{${fields.join(",")}}`;
 }
 
 /**
@@ -98,6 +125,12 @@ export function parseResultEvent(tail: string): ResultEvent | undefined {
     numTurns: typeof last.num_turns === "number" ? last.num_turns : undefined,
     durationMs:
       typeof last.duration_ms === "number" ? last.duration_ms : undefined,
+    isError: typeof last.is_error === "boolean" ? last.is_error : undefined,
+    apiErrorStatus:
+      typeof last.api_error_status === "string" ||
+      typeof last.api_error_status === "number"
+        ? last.api_error_status
+        : undefined,
   };
 }
 

--- a/tests/adapters/worker.test.ts
+++ b/tests/adapters/worker.test.ts
@@ -434,6 +434,48 @@ describe("dispatchWorker", () => {
     });
   });
 
+  it("never voids on infra-looking text in the Worker's closing message either (issue #79)", async () => {
+    const { exec } = fakeExec({ newCommits: "0" });
+    // A clean session that did nothing: exit 0, no commits, empty stderr. Its
+    // final message quotes every signature — the shape that voided Attempts
+    // forever, because the result event copies that message verbatim.
+    const { spawn } = fakeSpawn(0, "exit", {
+      stdoutTail: JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        api_error_status: null,
+        result:
+          "Read classify.ts: usage limit, rate limit, 401 unauthorized and ECONNRESET are the signatures.",
+      }),
+      stderrTail: "",
+    });
+
+    const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      failure: "no-commits",
+      infra: undefined,
+    });
+  });
+
+  it("classifies from the result event's API status, which the environment wrote", async () => {
+    const { exec } = fakeExec({ newCommits: "0" });
+    const { spawn } = fakeSpawn(1, "exit", {
+      stdoutTail:
+        '{"type":"result","subtype":"error_during_execution","is_error":true,"api_error_status":429}',
+    });
+
+    const outcome = await dispatchWorker(4, CONFIG, exec, spawn);
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      failure: undefined,
+      infra: "rate-limit",
+    });
+  });
+
   it("never voids on infra-looking text in the transcript body: classification is by cause, not content", async () => {
     const { exec } = fakeExec({ newCommits: "0" });
     // A ticket legitimately about rate limiting: the Worker's prose and tool

--- a/tests/core/classify.test.ts
+++ b/tests/core/classify.test.ts
@@ -4,9 +4,9 @@ import {
   classifyInfrastructure,
   clusterWithinWindow,
   correlatedFailureTimestampsMs,
-  lastResultLine,
   parseResultEvent,
   reclassifyCorrelatedFailures,
+  resultEventEvidence,
 } from "../../src/core/classify.js";
 import type {
   FailureReason,
@@ -81,6 +81,8 @@ describe("parseResultEvent", () => {
       totalCostUsd: 1.25,
       numTurns: 40,
       durationMs: 54000,
+      isError: undefined,
+      apiErrorStatus: undefined,
     });
   });
 
@@ -107,24 +109,80 @@ describe("parseResultEvent", () => {
       totalCostUsd: undefined,
       numTurns: undefined,
       durationMs: undefined,
+      isError: undefined,
+      apiErrorStatus: undefined,
     });
+  });
+
+  it("reads the environment's own verdict fields, never the Worker's message", () => {
+    const tail =
+      '{"type":"result","subtype":"error_during_execution","is_error":true,"api_error_status":429,"result":"quota talk"}';
+
+    expect(parseResultEvent(tail)).toMatchObject({
+      isError: true,
+      apiErrorStatus: 429,
+    });
+    expect(parseResultEvent(tail)).not.toHaveProperty("result");
   });
 });
 
-describe("lastResultLine", () => {
-  it("returns the raw last result-event line", () => {
-    const tail = [
-      '{"type":"assistant","message":{}}',
-      '{"type":"result","subtype":"success"}',
-    ].join("\n");
+describe("resultEventEvidence", () => {
+  /** The regression from issue #79, taken from workflow run 30637310067. */
+  it("never carries the Worker's own words, however infra-looking they are", () => {
+    const tail = JSON.stringify({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      api_error_status: null,
+      num_turns: 43,
+      result:
+        'Confirmed INFRA_SIGNATURES order (usage-limit, auth, rate-limit, network), CORRELATABLE excludes "budget" and "no-commits". Retries on ECONNRESET and http 429 after authentication_error.',
+    });
 
-    expect(lastResultLine(tail)).toBe('{"type":"result","subtype":"success"}');
+    const evidence = resultEventEvidence(parseResultEvent(tail));
+
+    expect(evidence).toBe("");
+    expect(classifyInfrastructure(evidence)).toBeUndefined();
   });
 
-  it("returns the empty string when no result line exists", () => {
+  it("still classifies a run the API ended, from the status the environment wrote", () => {
+    const tail =
+      '{"type":"result","subtype":"error_during_execution","is_error":true,"api_error_status":429}';
+
     expect(
-      lastResultLine('{"type":"assistant"}\nprose about rate limits'),
+      classifyInfrastructure(resultEventEvidence(parseResultEvent(tail))),
+    ).toBe("rate-limit");
+  });
+
+  it("classifies a status the CLI reported as text just as well", () => {
+    const tail =
+      '{"type":"result","subtype":"error_during_execution","is_error":true,"api_error_status":"rate_limit_error"}';
+
+    expect(
+      classifyInfrastructure(resultEventEvidence(parseResultEvent(tail))),
+    ).toBe("rate-limit");
+  });
+
+  it("keeps the subtype of an errored run, which no agent authors", () => {
+    const tail = '{"type":"result","subtype":"error_during_execution"}';
+
+    expect(resultEventEvidence(parseResultEvent(tail))).toBe(
+      '{"subtype":"error_during_execution"}',
+    );
+  });
+
+  it("has nothing to say about a run the CLI itself calls clean", () => {
+    expect(
+      resultEventEvidence(
+        parseResultEvent(
+          '{"type":"result","subtype":"success","is_error":false}',
+        ),
+      ),
     ).toBe("");
+  });
+
+  it("has nothing to say when no result event survived", () => {
+    expect(resultEventEvidence(undefined)).toBe("");
   });
 });
 


### PR DESCRIPTION
Fixes #79.

## The bug

`classifyInfrastructure` was fed `stderr` plus the raw last result-event line. That line's `result` field is the CLI's verbatim copy of the Worker's closing message — model-authored prose — so a Worker that merely *wrote about* rate limits classified its own Attempt as an infrastructure failure: voided instead of burned, retrying forever instead of escalating, and tripping the circuit breaker on a healthy environment.

Reproduced against `main` before fixing: a result event with `is_error: false`, `subtype: "success"`, and a `result` quoting the signature names classified as `rate-limit`.

## The fix

- `ResultEvent` gains `isError` and `apiErrorStatus`, both environment-authored. It still has no `result` field, so the projection is enforced by the type rather than by caller discipline.
- New `resultEventEvidence(event)` replaces `lastResultLine` (deleted, no other callers). It renders only `subtype` and the API status, and renders nothing at all when the CLI itself reports `is_error: false` — the issue's directions 1 and 2 together.
- `dispatchWorker` classifies `stderrTail + resultEventEvidence(result)`, reusing the event it already parsed for the budget fields, so the transcript is parsed once.

`probeEnvironment` deliberately keeps classifying its whole stdout. Its output is plain text rather than stream-json, so there is no result event to project, and its prompt is a fixed one-word reply with no ticket behind it — nothing it prints can match by content instead of cause. A comment there records why the rule differs.

## Tests

The three cases the issue specified:

- A clean `success` event whose `result` quotes every signature → no evidence, classifies `undefined`. This is the regression, taken from workflow run 30637310067.
- `is_error: true` with a genuine `api_error_status: 429` → still classifies `rate-limit`.
- `dispatchWorker` with a clean exit, zero commits, and a closing message about rate limits → `failure: "no-commits"`, `infra: undefined`.

Full suite passes (589 tests), plus typecheck and biome.

## Trade-off worth reviewing

Infra evidence is now stderr plus the status field only. If a CLI version writes its error text *only* into `result` and never to stderr, that signal is gone and such a run burns an Attempt instead of voiding it. That is the direction the issue chose — no agent-authored text ever reaches the classifier — and it fails safe: escalating to a human beats retrying forever. Existing stderr-based classification is untouched.
