### PR TITLE
test(scaffold): fold the scaffolded-template comparison into one helper

### DIFF
--- a/tests/app/init.test.ts
+++ b/tests/app/init.test.ts
@@ -14,7 +14,10 @@ import {
   type OrchestratorLabel,
   READY_FOR_AGENT,
 } from "../../src/core/types.js";
-import { pinnedCliVersion } from "../helpers/workflow-template.js";
+import {
+  pinnedCliVersion,
+  templateAsScaffolded,
+} from "../helpers/workflow-template.js";
 
 function fakeDeps(existing: string[] = [], version = "9.9.9") {
   const writes: { cwd: string; relPath: string; content: string }[] = [];
@@ -129,14 +132,8 @@ describe("initScaffoldOnce", () => {
 
     for (const relPath of SCAFFOLD_FILES) {
       const scaffolded = readFileSync(join(dir, relPath), "utf8");
-      const template = readFileSync(relPath, "utf8");
 
-      expect(scaffolded).toBe(
-        template.replace(
-          /(npm install -g border-collie@)\S+/g,
-          `$1${packageVersion}`,
-        ),
-      );
+      expect(scaffolded).toBe(templateAsScaffolded(relPath, packageVersion));
     }
   });
 });

--- a/tests/cli/context.test.ts
+++ b/tests/cli/context.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { buildRealContext } from "../../src/cli/context.js";
+import { templateAsScaffolded } from "../helpers/workflow-template.js";
 
 /**
  * The one integration test in the set: builds the real composition root
@@ -117,16 +118,10 @@ describe("buildRealContext's durable log file", () => {
  * target repo can actually run — rather than trusting the injected-deps
  * unit tests that stand in for it in tests/app/init.test.ts.
  *
- * "Matching this package's own" is modulo the CLI pin, which `pinCliVersion`
- * (src/core/scaffold.ts) rewrites to the scaffolding CLI's own version on the
- * way out. Comparing that line verbatim would assert the checked-in templates
- * always pin exactly package.json's version — the one thing a release
- * deliberately breaks, since `npm version` bumps package.json before the tag
- * push publishes anything and the pin only catches up afterwards (issue #93).
- * That made the tagged commit unreleasable by construction. The pin's real
- * invariant is one-sided and lives in `pinIsAhead` (tests/helpers/
- * workflow-template.ts); here the pin is normalised so the rest of the
- * template is what gets compared.
+ * "Matching this package's own" is modulo the CLI pin, which a scaffold
+ * rewrites on the way out — see `templateAsScaffolded` (tests/helpers/
+ * workflow-template.ts) for why comparing that line verbatim made the tagged
+ * commit unreleasable by construction (issues #93, #123).
  */
 describe("buildRealContext's initScaffold", () => {
   it("scaffolds both workflow files into a fresh target repo, matching this package's own", async () => {
@@ -149,10 +144,7 @@ describe("buildRealContext's initScaffold", () => {
       .version as string;
     for (const { relPath } of actions) {
       expect(readFileSync(join(dir, relPath), "utf8")).toBe(
-        readFileSync(relPath, "utf8").replace(
-          /(npm install -g border-collie@)\S+/g,
-          `$1${packageVersion}`,
-        ),
+        templateAsScaffolded(relPath, packageVersion),
       );
     }
   });

--- a/tests/helpers/workflow-template.ts
+++ b/tests/helpers/workflow-template.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 /**
  * Readers for the scaffolded workflow templates (.github/workflows/), used by
  * the guards that hold those files to the contracts the rest of the system
@@ -23,7 +25,12 @@
  * unattended, and a floating `@latest` would hand an unattended fleet a
  * breaking release.
  */
-const CLI_PIN_PATTERN = /npm install -g border-collie@(\S+)/;
+const CLI_PIN_PATTERN = /(npm install -g border-collie@)(\S+)/;
+
+/** The same pattern for rewriting rather than reading. Kept separate because
+ * a `g` regex carries `lastIndex` between calls, and the reader below must
+ * answer the same question every time it is asked. */
+const CLI_PIN_PATTERN_ALL = new RegExp(CLI_PIN_PATTERN.source, "g");
 
 /**
  * The version a scaffolded workflow pins the CLI to, or null if it names
@@ -32,7 +39,34 @@ const CLI_PIN_PATTERN = /npm install -g border-collie@(\S+)/;
  * as some default.
  */
 export function pinnedCliVersion(template: string): string | null {
-  return CLI_PIN_PATTERN.exec(template)?.[1] ?? null;
+  return CLI_PIN_PATTERN.exec(template)?.[2] ?? null;
+}
+
+/**
+ * A checked-in template as a scaffold writes it into a target repo: the same
+ * bytes, with the CLI pin rewritten to `version` the way `pinCliVersion`
+ * (src/core/scaffold.ts) rewrites it on the way out.
+ *
+ * That rewrite is why comparing scaffolded output against the raw checked-in
+ * file compares the wrong thing. Byte-equality quietly asserts the checked-in
+ * pin equals the scaffolding version — the one thing a release deliberately
+ * breaks, since `npm version` moves package.json before the tag push
+ * publishes anything and `sync:version` moves the pin only afterwards. The
+ * tagged run is the whole window between them, so a byte-equal assertion
+ * fails there and nowhere else (issue #123): both call sites normalised the
+ * pin by hand, only one was updated when the rewrite landed (issue #99), and
+ * every release after it was built to fail its first tagged run. They share
+ * this now so the next change to the rewrite cannot update one and miss the
+ * other.
+ *
+ * What the pin actually owes is one-sided and lives in `pinIsAhead`; here it
+ * is normalised away, so what a caller compares is the rest of the template.
+ */
+export function templateAsScaffolded(relPath: string, version: string): string {
+  return readFileSync(relPath, "utf8").replace(
+    CLI_PIN_PATTERN_ALL,
+    `$1${version}`,
+  );
 }
 
 const RUN_NAME_PATTERN = /^run-name:[ \t]*(.*?)[ \t]*$/m;


### PR DESCRIPTION
Fixes #123.

## Problem

Two tests compare scaffolded output against this repo's checked-in templates, and both have to account for the CLI pin that `pinCliVersion` rewrites on the way out. Both did it by hand, so when the rewrite landed (#99) only one was updated:

- `tests/app/init.test.ts` — normalised the pin. Correct.
- `tests/cli/context.test.ts` — byte-equality. Stale.

That byte-equality quietly asserted *checked-in pin == package.json version*. True at rest, which is why it stayed green, and false for exactly the window a release opens: `npm version` moves `package.json` before the tag push publishes anything, and `sync:version` moves the pin only afterwards. The tagged run is that window, so **every release after #99 was built to fail its first tagged run** — `v0.5.0` was simply the first to reach it. Preflight runs before the bump, when the two still agree, and cannot see it.

Already fixed in `34b1949`; this removes the duplication that let it happen.

## What changed

`templateAsScaffolded(relPath, version)` joins the existing readers in `tests/helpers/workflow-template.ts`, and both call sites use it. A future change to the rewrite can no longer update one and miss the other.

The reader and the rewrite now share one pattern, kept as two `RegExp` objects on purpose: a `g` regex carries `lastIndex` between calls, and `pinnedCliVersion` must answer the same question every time it is asked.

Both assertions stay, as the issue expected. `init.test.ts` reaches the scaffold through injected deps, `context.test.ts` through the real filesystem — different chains, same comparison.

`pinIsAhead` is untouched: the pin's real invariant is one-sided, it was correct throughout, and it is what actually guards the templates.

## Verification

`typecheck`, `biome`, 589 tests.

Beyond the suite, since the failure only appears in a state the suite never sits in:

- **The release window.** Bumped `package.json` to `0.6.0` against the checked-in `0.5.0` pin — the exact state that failed `v0.5.0`'s tagged run — and the three scaffold-related test files stay green. Reverted.
- **The helper itself.** Rewrites the pin, changes exactly one line, covers every pin occurrence, and the reader is not stateful across calls.

## Note on what these tests can't catch

Trying to prove the assertions still have teeth by drifting a template passes, because `initScaffold` reads the same checked-in file the tests compare against — a template edit moves both sides. That is inherent to what they assert ("the scaffold copies the file unchanged except the pin"), not something this PR introduces, but it is worth stating plainly: neither test can catch a bad template. That is `pinIsAhead`'s job, and the `run-name` guard's.
