### PR TITLE
docs(adr): record the 0001 amendment from the v2 roadmap

### DIFF
--- a/docs/adr/0001-build-stateless-orchestrator-not-adopt-sortie.md
+++ b/docs/adr/0001-build-stateless-orchestrator-not-adopt-sortie.md
@@ -11,3 +11,13 @@ The build is affordable because the Orchestrator is **stateless: GitHub is the o
 - **Contribute DAG dispatch upstream** — not pursued for v1: Go codebase, tracker-agnostic abstraction (blocking semantics differ across GitHub/Jira/Linear/Gitea), maintainer roadmap pointed elsewhere.
 
 Both references remain useful as design cribs: Symphony's repo-owned workflow contract, explicit `dispatchable` flag, stall-timeout + exponential-backoff retry semantics, and workspace-path containment are patterns worth borrowing.
+
+## Amendment (2026-08-15) — the rationale moves, the decision stands
+
+Decided on [Does dependency-DAG gating stay core in v2?](https://github.com/lyeyixian/border-collie/issues/128), a ticket of the v2 autonomy roadmap.
+
+"Dispatchability is border-collie's reason to exist" no longer holds. Symphony's spec leaves blocker gating to the adapter, but its announcement describes gating in practice — the moat was always thinner than this ADR claimed. And border-collie never computed a DAG anyway: `isDispatchable` reads one field from GitHub's own `issue_dependencies_summary`, so the gate is a tracker-expressed fact the Orchestrator honours, not a capability it owns. A differentiator that costs one field-read was never going to carry a whole tool.
+
+What v2 rests on instead: always-on autonomy governed entirely through the tracker — the issue tracker as sole state store, the operator reached only when a decision genuinely needs them. Dependency gating stays an unconditional invariant of the dispatch loop (no per-repo opt-out; the tracker port must expose an open-blocker count, and an adapter that cannot express blocking is not a valid adapter) — one rule of the loop, not the reason the loop exists.
+
+The decision to build rather than adopt survives regardless, and is no longer a live comparison: border-collie has diverged far enough — Attempts and the retry ladder, Refinement rounds, serialised conflict resolution (ADR 0007), Escalation, the working-hours gate — that adopting sortie today would be a rewrite, not an adoption.


### PR DESCRIPTION
Records the ADR 0001 amendment decided on #128, a ticket of the [v2 autonomy roadmap](https://github.com/lyeyixian/border-collie/issues/125).

The amendment was written during #128 but never committed. It sat as an uncommitted working-tree change on `main` for a week, so a decision the map cites as settled existed only locally and would not survive a `git checkout`. Ten added lines, no other file touched.

## What it says

"Dispatchability is border-collie's reason to exist" no longer holds. Dependency gating stays an unconditional invariant of the dispatch loop, with no per-repo opt-out and a tracker port that must expose an open-blocker count, but it is one rule of the loop rather than the reason the loop exists. What v2 rests on instead is always-on autonomy governed entirely through the tracker.

The build-not-adopt decision survives on divergence rather than on the original comparison. Attempts and the retry ladder, Refinement rounds, serialised conflict resolution (ADR 0007), Escalation and the working-hours gate put enough distance between border-collie and sortie that adopting today would be a rewrite.

## Known gap

The text is committed as written on 2026-08-15, before the Orca research on #134. It argues the moat was thinner than the original ADR claimed using Symphony evidence alone. Orca makes that case stronger than the amendment states, since Orca gates dispatch on dependencies mechanically and atomically, and `orca serve` plus scheduled automations ship always-on unattended execution. That means the amendment's replacement claim, always-on autonomy governed entirely through the tracker, now carries more weight than it was written to carry.

Revising it is #134's job, so this PR preserves the text unchanged rather than editing a decision out from under the ticket that owns it.

Refs #128, #125, #134
