### PR TITLE
docs(adr): narrow the 0001 moat against orca

### DIFF
--- a/docs/adr/0001-build-stateless-orchestrator-not-adopt-sortie.md
+++ b/docs/adr/0001-build-stateless-orchestrator-not-adopt-sortie.md
@@ -21,3 +21,21 @@ Decided on [Does dependency-DAG gating stay core in v2?](https://github.com/lyey
 What v2 rests on instead: always-on autonomy governed entirely through the tracker — the issue tracker as sole state store, the operator reached only when a decision genuinely needs them. Dependency gating stays an unconditional invariant of the dispatch loop (no per-repo opt-out; the tracker port must expose an open-blocker count, and an adapter that cannot express blocking is not a valid adapter) — one rule of the loop, not the reason the loop exists.
 
 The decision to build rather than adopt survives regardless, and is no longer a live comparison: border-collie has diverged far enough — Attempts and the retry ladder, Refinement rounds, serialised conflict resolution (ADR 0007), Escalation, the working-hours gate — that adopting sortie today would be a rewrite, not an adoption.
+
+## Amendment (2026-08-22) — the moat narrows again, and Orca gets named
+
+Decided on [Orca as prior art: what does it already do that v2 plans to build?](https://github.com/lyeyixian/border-collie/issues/134), a research ticket of the same roadmap.
+
+[Orca](https://github.com/stablyai/orca) (MIT, ~49.6k stars, first commit 2026-03-17) did not exist when this ADR was written, and was not in view when the 2026-08-15 amendment moved the moat. Two of its facts land directly here.
+
+**"Neither gates dispatch on blocking dependencies" is now false of the field.** Orca gates dispatch mechanically: only `ready` tasks dispatch, readiness is derived by the runtime rather than by an agent, and the claim's precondition is part of the write. Had the previous amendment not already moved the moat off gating, this would have removed the ADR's rationale outright.
+
+**"Always-on autonomy" no longer distinguishes anything.** `orca serve` plus scheduled automations ship unattended execution — documented, with a VPS deployment guide and a systemd unit, and a `--precheck` shell gate that decides whether a run spends a session at all. Agents working while the operator sleeps is table stakes now.
+
+What survives, and now carries the claim alone: **the tracker is the control plane, not a side-channel.** Nothing Orca ships puts the tracker in the control path. It reads context from Linear and writes status back, but only after a human has started the session, and its own Runs, Tasks, gates and mail live in a local SQLite database with a `reset` command. Border-collie's constraint is the opposite: the issue tracker is the only state store, and every other surface is a stateless client.
+
+Orca is not a build-versus-adopt candidate either. It never dispatches from a tracker unattended — it had an autonomous coordinator and retired it (`orchestration_migration_required`) — and it has no notion of a repo declaring gate-readable named commands, which is exactly what `WORKFLOW.md`'s `verify:` tier is for.
+
+Consequence for the roadmap: the repo-wide-pickup rung keeps its content and loses its pitch. What distinguishes it after Orca is **selection** — a repo-wide pass that claims, gates on blockers, respects attempt budgets and escalates — not that it runs while you sleep.
+
+Evidence: `docs/research/orca-prior-art.md` on the `research/orca-prior-art` branch.


### PR DESCRIPTION
Narrows ADR 0001's moat sentence against [Orca](https://github.com/stablyai/orca), decided on #134.

Orca is MIT, ~49.6k stars, first commit 2026-03-17. It did not exist when ADR 0001 was written and was not in view when the 2026-08-15 amendment (#128, merged in #135) moved the moat off dependency gating.

## What changes

Two claims stop distinguishing anything:

- **"Neither gates dispatch on blocking dependencies."** Orca does, mechanically. Only `ready` tasks dispatch, readiness is derived by the runtime rather than by an agent, and the claim's precondition is part of the write. Had the previous amendment not already moved the moat off gating, this would have removed the ADR's rationale outright.
- **"Always-on autonomy."** `orca serve` plus scheduled automations ship unattended execution with a VPS guide and a systemd unit, and a `--precheck` shell gate that decides whether a run spends a session at all.

What survives, carrying the claim alone: the tracker is the control plane, not a side-channel. Orca's own Runs, Tasks, gates and mail live in a local SQLite database with a `reset` command, which is the opposite of the map's "issue tracker is the only state store" constraint.

The amendment also records why Orca is not a build-versus-adopt candidate. It never dispatches from a tracker unattended, having retired its autonomous coordinator behind `orchestration_migration_required`, and it has no notion of a repo declaring gate-readable named commands.

## Roadmap consequence

The repo-wide-pickup rung keeps its content and loses its pitch. What distinguishes it after Orca is selection, a pass that claims, gates on blockers, respects attempt budgets and escalates, rather than the fact that it runs unattended.

No rungs are removed. Full evidence in `docs/research/orca-prior-art.md` on `research/orca-prior-art`, 748 lines.

Refs #134, #128, #125
